### PR TITLE
added anioist myanimelist letterboxd

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -40732,251 +40732,35 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "020",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
-          },
-          {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "type": "text_input",
-            "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
             "key": "use_all",
             "label": "Use All Child Collections",
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "children"
           },
           {
-            "key": "use_popular",
-            "label": "AniList Popular",
-            "tooltip": "Collection of the most Popular Anime on AniList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_popular",
-            "label": "AniList Popular Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the AniList Popular collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_popular",
-            "label": "AniList Popular Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the AniList Popular collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_popular",
-            "label": "AniList Popular Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_popular",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_popular",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_season",
-            "label": "AniList Season",
-            "tooltip": "Collection of the Current Season's Anime on AniList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_season",
-            "label": "AniList Season Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the AniList Season collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_season",
-            "label": "AniList Season Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the AniList Season collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_season",
-            "label": "AniList Season Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_season",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_season",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_top",
-            "label": "AniList Top Rated",
-            "tooltip": "Collection of the Top Rated Anime on AniList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_top",
-            "label": "AniList Top Rated Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the AniList Top Rated collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_top",
-            "label": "AniList Top Rated Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the AniList Top Rated collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_top",
-            "label": "AniList Top Rated Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_top",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_top",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_trending",
-            "label": "AniList Trending",
-            "tooltip": "Collection of the Trending Anime on AniList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_trending",
-            "label": "AniList Trending Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the AniList Trending collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_trending",
-            "label": "AniList Trending Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the AniList Trending collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_trending",
-            "label": "AniList Trending Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_trending",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_trending",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
+            "key": "allowed_libraries",
+            "label": "Allowed Libraries",
+            "type": "select",
+            "section": "basics",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "movie",
+                "label": "Movie"
+              },
+              {
+                "value": "show",
+                "label": "Show"
+              }
             ]
           },
           {
@@ -40988,7 +40772,8 @@
             "options": [
               "color",
               "white"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "minimum_items",
@@ -40997,209 +40782,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "radarr_add_missing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_search",
-            "label": "Search media when added to Sonarr",
-            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_monitor",
-            "label": "Monitor media when added to Radarr",
-            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Radarr",
-            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Sonarr",
-            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_tag",
-            "label": "Radarr Tag",
-            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_tag",
-            "label": "Sonarr Tag",
-            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "item_sonarr_tag",
-            "label": "Item Sonarr Tag",
-            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_folder",
-            "label": "Sonarr Root Folder",
-            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Sonarr root folder path",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "sonarr_monitor",
-            "label": "Sonarr Monitor",
-            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
-            "type": "select",
-            "options": [
-              {
-                "value": "all",
-                "label": "All"
-              },
-              {
-                "value": "none",
-                "label": "None"
-              },
-              {
-                "value": "future",
-                "label": "Future"
-              },
-              {
-                "value": "missing",
-                "label": "Missing"
-              },
-              {
-                "value": "existing",
-                "label": "Existing"
-              },
-              {
-                "value": "pilot",
-                "label": "Pilot"
-              },
-              {
-                "value": "first",
-                "label": "First Season"
-              },
-              {
-                "value": "latest",
-                "label": "Latest Season"
-              }
-            ],
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_upgrade_existing",
-            "label": "Upgrade existing media in Sonarr",
-            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "sync_mode",
@@ -41216,7 +40800,8 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "cache_builders",
@@ -41226,222 +40811,8 @@
             "default": 1,
             "input_type": "number",
             "min": 0,
-            "step": 1
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_popular",
-            "label": "AniList Popular Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Popular collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_popular",
-            "label": "AniList Popular Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_popular",
-            "label": "AniList Popular Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_popular",
-            "label": "AniList Popular Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_popular",
-              "visible_library_popular",
-              "visible_shared_popular"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_season",
-            "label": "AniList Season Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Season collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_season",
-            "label": "AniList Season Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Season collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_season",
-            "label": "AniList Season Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_season",
-            "label": "AniList Season Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_season",
-              "visible_library_season",
-              "visible_shared_season"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_top",
-            "label": "AniList Top Rated Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Top Rated collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_top",
-            "label": "AniList Top Rated Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_top",
-            "label": "AniList Top Rated Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_top",
-            "label": "AniList Top Rated Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_top",
-              "visible_library_top",
-              "visible_shared_top"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_trending",
-            "label": "AniList Trending Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Trending collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_trending",
-            "label": "AniList Trending Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_trending",
-            "label": "AniList Trending Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the AniList Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_trending",
-            "label": "AniList Trending Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_trending",
-              "visible_library_trending",
-              "visible_shared_trending"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "collection_order",
@@ -41796,7 +41167,2599 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "text",
+            "section": "basics",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text",
+            "section": "naming",
+            "placeholder": "Custom collection mapping name"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "section": "naming",
+            "placeholder": "Title 1, Title 2"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "default": "100",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "use_popular",
+            "label": "AniList Popular",
+            "tooltip": "Collection of the most Popular Anime on AniList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_popular",
+            "label": "AniList Popular Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the AniList Popular collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_popular",
+            "label": "AniList Popular Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the AniList Popular collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_popular",
+            "label": "AniList Popular Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the AniList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_popular",
+            "label": "AniList Popular Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
+          },
+          {
+            "key": "cache_builders_popular",
+            "label": "AniList Popular Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_popular",
+            "label": "AniList Popular Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_popular",
+            "label": "AniList Popular Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_top",
+            "label": "AniList Top Rated",
+            "tooltip": "Collection of the Top Rated Anime on AniList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_top",
+            "label": "AniList Top Rated Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the AniList Top Rated collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_top",
+            "label": "AniList Top Rated Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the AniList Top Rated collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_top",
+            "label": "AniList Top Rated Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the AniList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_top",
+            "label": "AniList Top Rated Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_top",
+            "label": "AniList Top Rated Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_top",
+            "label": "AniList Top Rated Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_top",
+            "label": "AniList Top Rated Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_trending",
+            "label": "AniList Trending",
+            "tooltip": "Collection of the Trending Anime on AniList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_trending",
+            "label": "AniList Trending Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the AniList Trending collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_trending",
+            "label": "AniList Trending Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the AniList Trending collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_trending",
+            "label": "AniList Trending Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the AniList Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_trending",
+            "label": "AniList Trending Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_trending",
+            "label": "AniList Trending Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_trending",
+            "label": "AniList Trending Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_trending",
+            "label": "AniList Trending Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_season",
+            "label": "AniList Season",
+            "tooltip": "Collection of the Current Season's Anime on AniList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_season",
+            "label": "AniList Season Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the AniList Season collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_season",
+            "label": "AniList Season Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the AniList Season collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_season",
+            "label": "AniList Season Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the AniList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_season",
+            "label": "AniList Season Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_season",
+            "label": "AniList Season Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_season",
+            "label": "AniList Season Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_season",
+            "label": "AniList Season Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "chart/<<style>>/<<mapping_name_encoded>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_background_popular",
+            "label": "AniList Popular Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_season",
+            "label": "AniList Season Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_top",
+            "label": "AniList Top Rated Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_trending",
+            "label": "AniList Trending Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_logo_popular",
+            "label": "AniList Popular Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_season",
+            "label": "AniList Season Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_top",
+            "label": "AniList Top Rated Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_trending",
+            "label": "AniList Trending Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_poster_popular",
+            "label": "AniList Popular Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_season",
+            "label": "AniList Season Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_top",
+            "label": "AniList Top Rated Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_trending",
+            "label": "AniList Trending Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_square_art_popular",
+            "label": "AniList Popular Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_season",
+            "label": "AniList Season Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_top",
+            "label": "AniList Top Rated Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_trending",
+            "label": "AniList Trending Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_popular",
+            "label": "AniList Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_season",
+            "label": "AniList Season Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_season",
+              "visible_library_season",
+              "visible_shared_season"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_top",
+            "label": "AniList Top Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_trending",
+            "label": "AniList Trending Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending",
+              "visible_library_trending",
+              "visible_shared_trending"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "basics"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "basics"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_radarr_tag_popular",
+            "label": "AniList Popular Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_season",
+            "label": "AniList Season Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_top",
+            "label": "AniList Top Rated Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_trending",
+            "label": "AniList Trending Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_sonarr_tag_popular",
+            "label": "AniList Popular Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_season",
+            "label": "AniList Season Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_top",
+            "label": "AniList Top Rated Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_trending",
+            "label": "AniList Trending Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_popular",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_season",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_top",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_trending",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder_popular",
+            "label": "AniList Popular Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_season",
+            "label": "AniList Season Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_top",
+            "label": "AniList Top Rated Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_trending",
+            "label": "AniList Trending Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing_popular",
+            "label": "AniList Popular Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_season",
+            "label": "AniList Season Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_top",
+            "label": "AniList Top Rated Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_trending",
+            "label": "AniList Trending Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_popular",
+            "label": "AniList Popular Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_season",
+            "label": "AniList Season Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_top",
+            "label": "AniList Top Rated Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_trending",
+            "label": "AniList Trending Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_search_popular",
+            "label": "AniList Popular Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_season",
+            "label": "AniList Season Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_top",
+            "label": "AniList Top Rated Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_trending",
+            "label": "AniList Trending Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_tag_popular",
+            "label": "AniList Popular Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_season",
+            "label": "AniList Season Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_top",
+            "label": "AniList Top Rated Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_trending",
+            "label": "AniList Trending Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_upgrade_existing_popular",
+            "label": "AniList Popular Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_season",
+            "label": "AniList Season Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_top",
+            "label": "AniList Top Rated Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_trending",
+            "label": "AniList Trending Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_popular",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_season",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_top",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_trending",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder_popular",
+            "label": "AniList Popular Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_season",
+            "label": "AniList Season Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_top",
+            "label": "AniList Top Rated Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_trending",
+            "label": "AniList Trending Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_existing_popular",
+            "label": "AniList Popular Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_season",
+            "label": "AniList Season Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_top",
+            "label": "AniList Top Rated Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_trending",
+            "label": "AniList Trending Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_popular",
+            "label": "AniList Popular Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_season",
+            "label": "AniList Season Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_top",
+            "label": "AniList Top Rated Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_trending",
+            "label": "AniList Trending Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_search_popular",
+            "label": "AniList Popular Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_season",
+            "label": "AniList Season Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_top",
+            "label": "AniList Top Rated Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_trending",
+            "label": "AniList Trending Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_tag_popular",
+            "label": "AniList Popular Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_season",
+            "label": "AniList Season Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_top",
+            "label": "AniList Top Rated Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_trending",
+            "label": "AniList Trending Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_upgrade_existing_popular",
+            "label": "AniList Popular Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_season",
+            "label": "AniList Season Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_top",
+            "label": "AniList Top Rated Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_trending",
+            "label": "AniList Trending Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "url_background_popular",
+            "label": "AniList Popular Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_season",
+            "label": "AniList Season Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_top",
+            "label": "AniList Top Rated Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_trending",
+            "label": "AniList Trending Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_logo_popular",
+            "label": "AniList Popular Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_season",
+            "label": "AniList Season Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_top",
+            "label": "AniList Top Rated Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_trending",
+            "label": "AniList Trending Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_poster_popular",
+            "label": "AniList Popular Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_season",
+            "label": "AniList Season Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_top",
+            "label": "AniList Top Rated Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_trending",
+            "label": "AniList Trending Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_square_art_popular",
+            "label": "AniList Popular Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_season",
+            "label": "AniList Season Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_top",
+            "label": "AniList Top Rated Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_trending",
+            "label": "AniList Trending Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "AniList Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_season",
+            "label": "AniList Season Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Season collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_top",
+            "label": "AniList Top Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Top Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_trending",
+            "label": "AniList Trending Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Trending collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "AniList Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_season",
+            "label": "AniList Season Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Season collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_top",
+            "label": "AniList Top Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_trending",
+            "label": "AniList Trending Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "AniList Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_season",
+            "label": "AniList Season Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "AniList Top Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_trending",
+            "label": "AniList Trending Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          }
+        ],
+        "sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "builder",
+            "label": "Builder Controls"
+          },
+          {
+            "id": "children",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "automation",
+            "label": "Automation"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       },
@@ -41816,45 +43779,36 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "020",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
           },
           {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "type": "text_input",
-            "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "key": "allowed_libraries",
+            "label": "Allowed Libraries",
+            "type": "select",
+            "section": "basics",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "movie",
+                "label": "Movie"
+              },
+              {
+                "value": "show",
+                "label": "Show"
+              }
+            ]
           },
           {
             "key": "style",
@@ -41865,264 +43819,8 @@
             "options": [
               "color",
               "white"
-            ]
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_favorited",
-            "label": "MyAnimeList Favorited",
-            "tooltip": "Collection of most Favorited Anime on MyAnimeList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_favorited",
-            "label": "MyAnimeList Favorited Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the MyAnimeList Favorited collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_favorited",
-            "label": "MyAnimeList Favorited Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the MyAnimeList Favorited collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_favorited",
-            "label": "MyAnimeList Favorited Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Favorited collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_favorited",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_favorited",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_popular",
-            "label": "MyAnimeList Popular",
-            "tooltip": "Collection of the most Popular Anime on MyAnimeList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_popular",
-            "label": "MyAnimeList Popular Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the MyAnimeList Popular collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_popular",
-            "label": "MyAnimeList Popular Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the MyAnimeList Popular collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_popular",
-            "label": "MyAnimeList Popular Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_popular",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_popular",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_season",
-            "label": "MyAnimeList Season",
-            "tooltip": "Collection of the Current Seasons Anime on MyAnimeList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_season",
-            "label": "MyAnimeList Season Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the MyAnimeList Season collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_season",
-            "label": "MyAnimeList Season Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the MyAnimeList Season collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_season",
-            "label": "MyAnimeList Season Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_season",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_season",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_airing",
-            "label": "MyAnimeList Top Airing",
-            "tooltip": "Collection of the Top Rated Airing on MyAnimeList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_airing",
-            "label": "MyAnimeList Top Airing Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the MyAnimeList Top Airing collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_airing",
-            "label": "MyAnimeList Top Airing Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the MyAnimeList Top Airing collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_airing",
-            "label": "MyAnimeList Top Airing Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Airing collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_airing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_airing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_top",
-            "label": "MyAnimeList Top Rated",
-            "tooltip": "Collection of the Top Rated Anime on MyAnimeList.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_top",
-            "label": "MyAnimeList Top Rated Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the MyAnimeList Top Rated collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_top",
-            "label": "MyAnimeList Top Rated Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the MyAnimeList Top Rated collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_top",
-            "label": "MyAnimeList Top Rated Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_top",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_top",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "minimum_items",
@@ -42131,7 +43829,1314 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "basics"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1,
+            "section": "basics"
+          },
+          {
+            "key": "collection_order",
+            "label": "Collection Order",
+            "type": "select",
+            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
+            "default": "custom",
+            "options": [
+              {
+                "value": "custom",
+                "label": "Custom Order",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "alpha",
+                "label": "Alphabetical Order",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "title.asc",
+                "label": "Title Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "title.desc",
+                "label": "Title Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "season.asc",
+                "label": "Season Ascending",
+                "media_types": [
+                  "season"
+                ]
+              },
+              {
+                "value": "season.desc",
+                "label": "Season Descending",
+                "media_types": [
+                  "season"
+                ]
+              },
+              {
+                "value": "show.asc",
+                "label": "Show Ascending",
+                "media_types": [
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "show.desc",
+                "label": "Show Descending",
+                "media_types": [
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "year.asc",
+                "label": "Year Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "year.desc",
+                "label": "Year Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "release.asc",
+                "label": "Release Date (Originally Available) Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "release.desc",
+                "label": "Release Date (Originally Available) Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "episode_release.asc",
+                "label": "Episode Release Date Ascending",
+                "media_types": [
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "episode_release.desc",
+                "label": "Episode Release Date Descending",
+                "media_types": [
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "critic_rating.asc",
+                "label": "Critic Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "critic_rating.desc",
+                "label": "Critic Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "audience_rating.asc",
+                "label": "Audience Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "audience_rating.desc",
+                "label": "Audience Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "user_rating.asc",
+                "label": "User Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "user_rating.desc",
+                "label": "User Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "content_rating.asc",
+                "label": "Content Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show"
+                ]
+              },
+              {
+                "value": "content_rating.desc",
+                "label": "Content Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show"
+                ]
+              },
+              {
+                "value": "duration.asc",
+                "label": "Duration Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "duration.desc",
+                "label": "Duration Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "progress.asc",
+                "label": "Progress Ascending",
+                "media_types": [
+                  "episode"
+                ]
+              },
+              {
+                "value": "progress.desc",
+                "label": "Progress Descending",
+                "media_types": [
+                  "episode"
+                ]
+              },
+              {
+                "value": "plays.asc",
+                "label": "Number of Plays Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "plays.desc",
+                "label": "Number of Plays Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "unplayed.asc",
+                "label": "Unplayed Ascending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "unplayed.desc",
+                "label": "Unplayed Descending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "episode_added.asc",
+                "label": "Last Episode Date Added Ascending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "episode_added.desc",
+                "label": "Last Episode Date Added Descending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "added.asc",
+                "label": "Date Added Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "added.desc",
+                "label": "Date Added Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "viewed.asc",
+                "label": "Date Last Viewed Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "viewed.desc",
+                "label": "Date Last Viewed Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "resolution.asc",
+                "label": "Resolution Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "resolution.desc",
+                "label": "Resolution Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "bitrate.asc",
+                "label": "Bitrate Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "bitrate.desc",
+                "label": "Bitrate Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "random",
+                "label": "Random",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "text",
+            "section": "basics",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text",
+            "section": "naming",
+            "placeholder": "Custom collection mapping name"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "section": "naming",
+            "placeholder": "Title 1, Title 2"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "default": "100",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "starting_only",
+            "label": "Starting Only",
+            "type": "select",
+            "section": "builder",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "starting_only_season",
+            "label": "Season Starting Only",
+            "type": "select",
+            "section": "builder",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "use_popular",
+            "label": "MyAnimeList Popular",
+            "tooltip": "Collection of the most Popular Anime on MyAnimeList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_popular",
+            "label": "MyAnimeList Popular Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the MyAnimeList Popular collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_popular",
+            "label": "MyAnimeList Popular Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the MyAnimeList Popular collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_popular",
+            "label": "MyAnimeList Popular Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_popular",
+            "label": "MyAnimeList Popular Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_popular",
+            "label": "MyAnimeList Popular Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_popular",
+            "label": "MyAnimeList Popular Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_popular",
+            "label": "MyAnimeList Popular Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_favorited",
+            "label": "MyAnimeList Favorited",
+            "tooltip": "Collection of most Favorited Anime on MyAnimeList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_favorited",
+            "label": "MyAnimeList Favorited Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the MyAnimeList Favorited collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_favorited",
+            "label": "MyAnimeList Favorited Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the MyAnimeList Favorited collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_favorited",
+            "label": "MyAnimeList Favorited Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Favorited collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_favorited",
+            "label": "MyAnimeList Favorited Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_favorited",
+            "label": "MyAnimeList Favorited Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_favorited",
+            "label": "MyAnimeList Favorited Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_favorited",
+            "label": "MyAnimeList Favorited Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_top",
+            "label": "MyAnimeList Top Rated",
+            "tooltip": "Collection of the Top Rated Anime on MyAnimeList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_top",
+            "label": "MyAnimeList Top Rated Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the MyAnimeList Top Rated collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_top",
+            "label": "MyAnimeList Top Rated Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the MyAnimeList Top Rated collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_top",
+            "label": "MyAnimeList Top Rated Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_top",
+            "label": "MyAnimeList Top Rated Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_top",
+            "label": "MyAnimeList Top Rated Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_top",
+            "label": "MyAnimeList Top Rated Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_top",
+            "label": "MyAnimeList Top Rated Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_airing",
+            "label": "MyAnimeList Top Airing",
+            "tooltip": "Collection of the Top Rated Airing on MyAnimeList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_airing",
+            "label": "MyAnimeList Top Airing Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the MyAnimeList Top Airing collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_airing",
+            "label": "MyAnimeList Top Airing Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the MyAnimeList Top Airing collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_airing",
+            "label": "MyAnimeList Top Airing Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Airing collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_airing",
+            "label": "MyAnimeList Top Airing Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_airing",
+            "label": "MyAnimeList Top Airing Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_airing",
+            "label": "MyAnimeList Top Airing Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_airing",
+            "label": "MyAnimeList Top Airing Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_season",
+            "label": "MyAnimeList Season",
+            "tooltip": "Collection of the Current Seasons Anime on MyAnimeList.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_season",
+            "label": "MyAnimeList Season Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the MyAnimeList Season collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_season",
+            "label": "MyAnimeList Season Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the MyAnimeList Season collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_season",
+            "label": "MyAnimeList Season Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_season",
+            "label": "MyAnimeList Season Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_season",
+            "label": "MyAnimeList Season Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_season",
+            "label": "MyAnimeList Season Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_season",
+            "label": "MyAnimeList Season Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "chart/<<style>>/<<mapping_name_encoded>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_background_airing",
+            "label": "MyAnimeList Top Airing Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_favorited",
+            "label": "MyAnimeList Favorited Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_popular",
+            "label": "MyAnimeList Popular Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_season",
+            "label": "MyAnimeList Season Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_top",
+            "label": "MyAnimeList Top Rated Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_logo_airing",
+            "label": "MyAnimeList Top Airing Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_favorited",
+            "label": "MyAnimeList Favorited Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_popular",
+            "label": "MyAnimeList Popular Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_season",
+            "label": "MyAnimeList Season Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_top",
+            "label": "MyAnimeList Top Rated Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_poster_airing",
+            "label": "MyAnimeList Top Airing Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_favorited",
+            "label": "MyAnimeList Favorited Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_popular",
+            "label": "MyAnimeList Popular Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_season",
+            "label": "MyAnimeList Season Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_top",
+            "label": "MyAnimeList Top Rated Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_square_art_airing",
+            "label": "MyAnimeList Top Airing Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_favorited",
+            "label": "MyAnimeList Favorited Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_popular",
+            "label": "MyAnimeList Popular Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_season",
+            "label": "MyAnimeList Season Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_top",
+            "label": "MyAnimeList Top Rated Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_airing",
+            "label": "MyAnimeList Top Airing Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_airing",
+              "visible_library_airing",
+              "visible_shared_airing"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_favorited",
+            "label": "MyAnimeList Favorited Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_favorited",
+              "visible_library_favorited",
+              "visible_shared_favorited"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_popular",
+            "label": "MyAnimeList Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_season",
+            "label": "MyAnimeList Season Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_season",
+              "visible_library_season",
+              "visible_shared_season"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_top",
+            "label": "MyAnimeList Top Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "ignore_ids",
@@ -42139,7 +45144,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "basics"
           },
           {
             "key": "ignore_imdb_ids",
@@ -42147,7 +45153,130 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "validation_preset": "imdb_id_plex",
+            "section": "basics"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_radarr_tag_airing",
+            "label": "MyAnimeList Top Airing Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_favorited",
+            "label": "MyAnimeList Favorited Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_popular",
+            "label": "MyAnimeList Popular Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_season",
+            "label": "MyAnimeList Season Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_top",
+            "label": "MyAnimeList Top Rated Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_sonarr_tag_airing",
+            "label": "MyAnimeList Top Airing Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_favorited",
+            "label": "MyAnimeList Favorited Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_popular",
+            "label": "MyAnimeList Popular Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_season",
+            "label": "MyAnimeList Season Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_top",
+            "label": "MyAnimeList Top Rated Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
           },
           {
             "key": "radarr_add_missing",
@@ -42157,35 +45286,124 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation"
           },
           {
-            "key": "sonarr_add_missing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "key": "radarr_add_missing_airing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
             "tooltip_variant": "danger",
             "type": "toggle",
             "media_types": [
-              "show"
-            ]
+              "movie"
+            ],
+            "section": "automation"
           },
           {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "key": "radarr_add_missing_favorited",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation"
           },
           {
-            "key": "sonarr_search",
-            "label": "Search media when added to Sonarr",
-            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "key": "radarr_add_missing_popular",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
             "type": "toggle",
             "media_types": [
-              "show"
-            ]
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_season",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_top",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder_airing",
+            "label": "MyAnimeList Top Airing Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_favorited",
+            "label": "MyAnimeList Favorited Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_popular",
+            "label": "MyAnimeList Popular Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_season",
+            "label": "MyAnimeList Season Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_top",
+            "label": "MyAnimeList Top Rated Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
           },
           {
             "key": "radarr_monitor",
@@ -42194,6 +45412,30 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_airing",
+            "label": "MyAnimeList Top Airing Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
@@ -42203,15 +45445,339 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing_airing",
+            "label": "MyAnimeList Top Airing Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
-            "key": "sonarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Sonarr",
-            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "key": "radarr_monitor_existing_favorited",
+            "label": "MyAnimeList Favorited Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_popular",
+            "label": "MyAnimeList Popular Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_season",
+            "label": "MyAnimeList Season Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_top",
+            "label": "MyAnimeList Top Rated Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_favorited",
+            "label": "MyAnimeList Favorited Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_popular",
+            "label": "MyAnimeList Popular Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_season",
+            "label": "MyAnimeList Season Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_top",
+            "label": "MyAnimeList Top Rated Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
             "type": "toggle",
             "media_types": [
-              "show"
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_search_airing",
+            "label": "MyAnimeList Top Airing Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_favorited",
+            "label": "MyAnimeList Favorited Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_popular",
+            "label": "MyAnimeList Popular Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_season",
+            "label": "MyAnimeList Season Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_top",
+            "label": "MyAnimeList Top Rated Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
@@ -42222,47 +45788,249 @@
             "placeholder": "Add Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation"
           },
           {
-            "key": "sonarr_tag",
-            "label": "Sonarr Tag",
-            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "key": "radarr_tag_airing",
+            "label": "MyAnimeList Top Airing Radarr Tags",
             "type": "string_list",
-            "placeholder": "Add Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
+            "section": "automation",
             "media_types": [
               "movie"
-            ]
+            ],
+            "placeholder": "4k,chart"
           },
           {
-            "key": "item_sonarr_tag",
-            "label": "Item Sonarr Tag",
-            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "key": "radarr_tag_favorited",
+            "label": "MyAnimeList Favorited Radarr Tags",
             "type": "string_list",
-            "placeholder": "Add item Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
+            "section": "automation",
             "media_types": [
               "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_popular",
+            "label": "MyAnimeList Popular Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_season",
+            "label": "MyAnimeList Season Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_top",
+            "label": "MyAnimeList Top Rated Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_upgrade_existing_airing",
+            "label": "MyAnimeList Top Airing Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
+          },
+          {
+            "key": "radarr_upgrade_existing_favorited",
+            "label": "MyAnimeList Favorited Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_popular",
+            "label": "MyAnimeList Popular Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_season",
+            "label": "MyAnimeList Season Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_top",
+            "label": "MyAnimeList Top Rated Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_airing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_favorited",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_popular",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_season",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_top",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
           },
           {
             "key": "sonarr_folder",
@@ -42272,7 +46040,58 @@
             "placeholder": "Enter Sonarr root folder path",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder_airing",
+            "label": "MyAnimeList Top Airing Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_favorited",
+            "label": "MyAnimeList Favorited Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_popular",
+            "label": "MyAnimeList Popular Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_season",
+            "label": "MyAnimeList Season Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_top",
+            "label": "MyAnimeList Top Rated Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
           },
           {
             "key": "sonarr_monitor",
@@ -42315,16 +46134,554 @@
             ],
             "media_types": [
               "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_airing",
+            "label": "MyAnimeList Top Airing Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
             ]
           },
           {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
             "type": "toggle",
             "media_types": [
-              "movie"
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_existing_airing",
+            "label": "MyAnimeList Top Airing Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
+          },
+          {
+            "key": "sonarr_monitor_existing_favorited",
+            "label": "MyAnimeList Favorited Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_popular",
+            "label": "MyAnimeList Popular Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_season",
+            "label": "MyAnimeList Season Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_top",
+            "label": "MyAnimeList Top Rated Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_favorited",
+            "label": "MyAnimeList Favorited Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_popular",
+            "label": "MyAnimeList Popular Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_season",
+            "label": "MyAnimeList Season Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_top",
+            "label": "MyAnimeList Top Rated Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_search_airing",
+            "label": "MyAnimeList Top Airing Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_favorited",
+            "label": "MyAnimeList Favorited Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_popular",
+            "label": "MyAnimeList Popular Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_season",
+            "label": "MyAnimeList Season Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_top",
+            "label": "MyAnimeList Top Rated Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_tag_airing",
+            "label": "MyAnimeList Top Airing Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_favorited",
+            "label": "MyAnimeList Favorited Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_popular",
+            "label": "MyAnimeList Popular Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_season",
+            "label": "MyAnimeList Season Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_top",
+            "label": "MyAnimeList Top Rated Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
           },
           {
             "key": "sonarr_upgrade_existing",
@@ -42333,7 +46690,759 @@
             "type": "toggle",
             "media_types": [
               "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_upgrade_existing_airing",
+            "label": "MyAnimeList Top Airing Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_favorited",
+            "label": "MyAnimeList Favorited Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_popular",
+            "label": "MyAnimeList Popular Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_season",
+            "label": "MyAnimeList Season Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_top",
+            "label": "MyAnimeList Top Rated Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "url_background_airing",
+            "label": "MyAnimeList Top Airing Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_favorited",
+            "label": "MyAnimeList Favorited Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_popular",
+            "label": "MyAnimeList Popular Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_season",
+            "label": "MyAnimeList Season Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_top",
+            "label": "MyAnimeList Top Rated Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_logo_airing",
+            "label": "MyAnimeList Top Airing Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_favorited",
+            "label": "MyAnimeList Favorited Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_popular",
+            "label": "MyAnimeList Popular Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_season",
+            "label": "MyAnimeList Season Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_top",
+            "label": "MyAnimeList Top Rated Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_poster_airing",
+            "label": "MyAnimeList Top Airing Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_favorited",
+            "label": "MyAnimeList Favorited Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_popular",
+            "label": "MyAnimeList Popular Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_season",
+            "label": "MyAnimeList Season Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_top",
+            "label": "MyAnimeList Top Rated Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_square_art_airing",
+            "label": "MyAnimeList Top Airing Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_favorited",
+            "label": "MyAnimeList Favorited Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_popular",
+            "label": "MyAnimeList Popular Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_season",
+            "label": "MyAnimeList Season Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_top",
+            "label": "MyAnimeList Top Rated Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_airing",
+            "label": "MyAnimeList Top Airing Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_favorited",
+            "label": "MyAnimeList Favorited Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Favorited collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "MyAnimeList Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_season",
+            "label": "MyAnimeList Season Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Season collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_top",
+            "label": "MyAnimeList Top Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_airing",
+            "label": "MyAnimeList Top Airing Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_favorited",
+            "label": "MyAnimeList Favorited Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Favorited collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "MyAnimeList Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_season",
+            "label": "MyAnimeList Season Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Season collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_top",
+            "label": "MyAnimeList Top Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_airing",
+            "label": "MyAnimeList Top Airing Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_favorited",
+            "label": "MyAnimeList Favorited Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Favorited collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "MyAnimeList Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_season",
+            "label": "MyAnimeList Season Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "MyAnimeList Top Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          }
+        ],
+        "sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "builder",
+            "label": "Builder Controls"
+          },
+          {
+            "id": "children",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "automation",
+            "label": "Automation"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          }
+        ]
+      },
+      {
+        "id": "collection_letterboxd",
+        "label": "Letterboxd Charts",
+        "url": "https://kometa.wiki/en/nightly/defaults/chart/letterboxd",
+        "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/letterboxd.png",
+        "media_types": [
+          "movie"
+        ],
+        "template_variables": [
+          {
+            "key": "collection_section",
+            "label": "Collection Section",
+            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
+            "type": "text_input",
+            "default": "020",
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "allowed_libraries",
+            "label": "Allowed Libraries",
+            "type": "select",
+            "section": "basics",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "movie",
+                "label": "Movie"
+              },
+              {
+                "value": "show",
+                "label": "Show"
+              }
+            ]
+          },
+          {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "sync_mode",
@@ -42350,7 +47459,8 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "cache_builders",
@@ -42360,260 +47470,8 @@
             "default": 1,
             "input_type": "number",
             "min": 0,
-            "step": 1
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_favorited",
-            "label": "MyAnimeList Favorited Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Favorited collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_favorited",
-            "label": "MyAnimeList Favorited Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Favorited collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_favorited",
-            "label": "MyAnimeList Favorited Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Favorited collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_favorited",
-            "label": "MyAnimeList Favorited Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_favorited",
-              "visible_library_favorited",
-              "visible_shared_favorited"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_popular",
-            "label": "MyAnimeList Popular Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Popular collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_popular",
-            "label": "MyAnimeList Popular Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_popular",
-            "label": "MyAnimeList Popular Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_popular",
-            "label": "MyAnimeList Popular Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_popular",
-              "visible_library_popular",
-              "visible_shared_popular"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_season",
-            "label": "MyAnimeList Season Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Season collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_season",
-            "label": "MyAnimeList Season Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Season collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_season",
-            "label": "MyAnimeList Season Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_season",
-            "label": "MyAnimeList Season Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_season",
-              "visible_library_season",
-              "visible_shared_season"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_airing",
-            "label": "MyAnimeList Top Airing Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_airing",
-            "label": "MyAnimeList Top Airing Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_airing",
-            "label": "MyAnimeList Top Airing Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_airing",
-            "label": "MyAnimeList Top Airing Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_airing",
-              "visible_library_airing",
-              "visible_shared_airing"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_top",
-            "label": "MyAnimeList Top Rated Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_top",
-            "label": "MyAnimeList Top Rated Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_top",
-            "label": "MyAnimeList Top Rated Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_top",
-            "label": "MyAnimeList Top Rated Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_top",
-              "visible_library_top",
-              "visible_shared_top"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "collection_order",
@@ -42968,1071 +47826,8 @@
                   "episode"
                 ]
               }
-            ]
-          }
-        ]
-      },
-      {
-        "id": "collection_letterboxd",
-        "label": "Letterboxd Charts",
-        "url": "https://kometa.wiki/en/nightly/defaults/chart/letterboxd",
-        "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/letterboxd.png",
-        "media_types": [
-          "movie"
-        ],
-        "template_variables": [
-          {
-            "key": "collection_section",
-            "label": "Collection Section",
-            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
-            "type": "text_input",
-            "default": "020",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
-          },
-          {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File.",
-            "type": "text_input",
-            "default": 100,
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_1001_movies",
-            "label": "1,001 To See Before You Die",
-            "tooltip": "Collection of 1,001 Movies You Must See Before You Die.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_1001_movies",
-            "label": "1,001 To See Before You Die Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 1,001 To See Before You Die collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_1001_movies",
-            "label": "1,001 To See Before You Die Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 1,001 To See Before You Die collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_1001_movies",
-            "label": "1,001 To See Before You Die Limit",
-            "tooltip": "Changes the Builder Limit of the 1,001 To See Before You Die collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_1001_movies",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_afi_100",
-            "label": "AFI 100 Years 100 Movies",
-            "tooltip": "Collection of AFI's 100 Years...100 Movies.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_afi_100",
-            "label": "AFI 100 Years 100 Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the AFI 100 Years 100 Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_afi_100",
-            "label": "AFI 100 Years 100 Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the AFI 100 Years 100 Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_afi_100",
-            "label": "AFI 100 Years 100 Movies Limit",
-            "tooltip": "Changes the Builder Limit of the AFI 100 Years 100 Movies collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_afi_100",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100",
-            "tooltip": "Collection of Box Office Mojo's all-time top 100 films.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Box Office Mojo All Time 100 collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Box Office Mojo All Time 100 collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Limit",
-            "tooltip": "Changes the Builder Limit of the Box Office Mojo All Time 100 collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_boxofficemojo_100",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_cannes",
-            "label": "Cannes Palme d'Or Winners",
-            "tooltip": "Collection of films that have won the Palme d'Or at the Cannes Film Festival.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_cannes",
-            "label": "Cannes Palme d'Or Winners Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Cannes Palme d'Or Winners collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_cannes",
-            "label": "Cannes Palme d'Or Winners Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Cannes Palme d'Or Winners collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_cannes",
-            "label": "Cannes Palme d'Or Winners Limit",
-            "tooltip": "Changes the Builder Limit of the Cannes Palme d'Or Winners collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_cannes",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites",
-            "tooltip": "Collection of Edgar Wright's 1,000 Favorite Movies.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Edgar Wright's 1,000 Favorites collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Edgar Wright's 1,000 Favorites collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Limit",
-            "tooltip": "Changes the Builder Limit of the Edgar Wright's 1,000 Favorites collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_edgarwright",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd)",
-            "tooltip": "Collection of the Top 250 Movies on IMDb, from Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the IMDb Top 250 (Letterboxd) collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the IMDb Top 250 (Letterboxd) collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Limit",
-            "tooltip": "Changes the Builder Limit of the IMDb Top 250 (Letterboxd) collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_imdb_top_250",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_top_500",
-            "label": "Letterboxd Top 500",
-            "tooltip": "Collection of the Top 500 films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_top_500",
-            "label": "Letterboxd Top 500 Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Letterboxd Top 500 collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_top_500",
-            "label": "Letterboxd Top 500 Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Letterboxd Top 500 collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_top_500",
-            "label": "Letterboxd Top 500 Limit",
-            "tooltip": "Changes the Builder Limit of the Letterboxd Top 500 collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_top_500",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_international",
-            "label": "Top 250 International",
-            "tooltip": "Collection of the Top 250 international films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_international",
-            "label": "Top 250 International Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 International collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_international",
-            "label": "Top 250 International Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 International collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_international",
-            "label": "Top 250 International Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 International collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_international",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_science",
-            "label": "Top 250 Sci-Fi Films",
-            "tooltip": "Collection of the Top 250 science-fiction films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_science",
-            "label": "Top 250 Sci-Fi Films Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 Sci-Fi Films collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_science",
-            "label": "Top 250 Sci-Fi Films Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 Sci-Fi Films collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_science",
-            "label": "Top 250 Sci-Fi Films Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 Sci-Fi Films collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_science",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_western",
-            "label": "Top 100 Western Films",
-            "tooltip": "Collection of the Top 100 western films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_western",
-            "label": "Top 100 Western Films Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 100 Western Films collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_western",
-            "label": "Top 100 Western Films Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 100 Western Films collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_western",
-            "label": "Top 100 Western Films Limit",
-            "tooltip": "Changes the Builder Limit of the Top 100 Western Films collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_western",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_silent",
-            "label": "Top 100 Silent Films",
-            "tooltip": "Collection of the Top 100 silent films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_silent",
-            "label": "Top 100 Silent Films Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 100 Silent Films collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_silent",
-            "label": "Top 100 Silent Films Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 100 Silent Films collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_silent",
-            "label": "Top 100 Silent Films Limit",
-            "tooltip": "Changes the Builder Limit of the Top 100 Silent Films collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_silent",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_million",
-            "label": "One Million Watched Club",
-            "tooltip": "Collection of films in the One Million Watched Club on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_million",
-            "label": "One Million Watched Club Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the One Million Watched Club collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_million",
-            "label": "One Million Watched Club Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the One Million Watched Club collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_million",
-            "label": "One Million Watched Club Limit",
-            "tooltip": "Changes the Builder Limit of the One Million Watched Club collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_million",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_oscars",
-            "label": "Oscar Best Picture Winners",
-            "tooltip": "Collection of films that have won the Academy Award for Best Picture.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_oscars",
-            "label": "Oscar Best Picture Winners Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Oscar Best Picture Winners collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_oscars",
-            "label": "Oscar Best Picture Winners Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Oscar Best Picture Winners collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_oscars",
-            "label": "Oscar Best Picture Winners Limit",
-            "tooltip": "Changes the Builder Limit of the Oscar Best Picture Winners collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_oscars",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_rogerebert",
-            "label": "Roger Ebert's Great Movies",
-            "tooltip": "Collection of films from Roger Ebert's \"Great Movies\" essays.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_rogerebert",
-            "label": "Roger Ebert's Great Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Roger Ebert's Great Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_rogerebert",
-            "label": "Roger Ebert's Great Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Roger Ebert's Great Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_rogerebert",
-            "label": "Roger Ebert's Great Movies Limit",
-            "tooltip": "Changes the Builder Limit of the Roger Ebert's Great Movies collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_rogerebert",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_sight_sound",
-            "label": "Sight & Sound Greatest Films",
-            "tooltip": "Collection of Sight and Sound's Greatest Films of All Time.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_sight_sound",
-            "label": "Sight & Sound Greatest Films Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Sight & Sound Greatest Films collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_sight_sound",
-            "label": "Sight & Sound Greatest Films Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Sight & Sound Greatest Films collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_sight_sound",
-            "label": "Sight & Sound Greatest Films Limit",
-            "tooltip": "Changes the Builder Limit of the Sight & Sound Greatest Films collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_sight_sound",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_animation",
-            "label": "Top 100 Animation",
-            "tooltip": "Collection of the Top 100 animated films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_animation",
-            "label": "Top 100 Animation Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 100 Animation collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_animation",
-            "label": "Top 100 Animation Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 100 Animation collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_animation",
-            "label": "Top 100 Animation Limit",
-            "tooltip": "Changes the Builder Limit of the Top 100 Animation collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_animation",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_black_directors",
-            "label": "Top 250 Black-Directed",
-            "tooltip": "Collection of the Top 250 Black-Directed films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_black_directors",
-            "label": "Top 250 Black-Directed Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 Black-Directed collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_black_directors",
-            "label": "Top 250 Black-Directed Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 Black-Directed collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_black_directors",
-            "label": "Top 250 Black-Directed Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 Black-Directed collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_black_directors",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_documentaries",
-            "label": "Top 250 Documentaries",
-            "tooltip": "Collection of the Top 250 documentary films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_documentaries",
-            "label": "Top 250 Documentaries Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 Documentaries collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_documentaries",
-            "label": "Top 250 Documentaries Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 Documentaries collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_documentaries",
-            "label": "Top 250 Documentaries Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 Documentaries collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_documentaries",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_horror",
-            "label": "Top 250 Horror",
-            "tooltip": "Collection of the Top 250 horror films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_horror",
-            "label": "Top 250 Horror Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 Horror collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_horror",
-            "label": "Top 250 Horror Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 Horror collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_horror",
-            "label": "Top 250 Horror Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 Horror collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_horror",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_most_fans",
-            "label": "Top 250 Most Fans",
-            "tooltip": "Collection of the Top 250 films with the most fans on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_most_fans",
-            "label": "Top 250 Most Fans Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 Most Fans collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_most_fans",
-            "label": "Top 250 Most Fans Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 Most Fans collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_most_fans",
-            "label": "Top 250 Most Fans Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 Most Fans collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_most_fans",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "use_women_directors",
-            "label": "Top 250 Women-Directed",
-            "tooltip": "Collection of the Top 250 Women-Directed films on Letterboxd.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_women_directors",
-            "label": "Top 250 Women-Directed Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Top 250 Women-Directed collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_women_directors",
-            "label": "Top 250 Women-Directed Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Top 250 Women-Directed collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_women_directors",
-            "label": "Top 250 Women-Directed Limit",
-            "tooltip": "Changes the Builder Limit of the Top 250 Women-Directed collection.",
-            "type": "text_input",
-            "default": "limit",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_women_directors",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "style",
-            "label": "Style",
-            "type": "select",
-            "tooltip": "Controls the visual theme of the collections created.",
-            "default": "color",
-            "options": [
-              "color",
-              "white"
-            ]
-          },
-          {
-            "key": "minimum_items",
-            "label": "Minimum Items",
-            "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "radarr_add_missing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor",
-            "label": "Monitor media when added to Radarr",
-            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Radarr",
-            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_tag",
-            "label": "Radarr Tag",
-            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sync_mode",
-            "label": "Sync Mode",
-            "type": "select",
-            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
-            "default": "sync",
-            "options": [
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ]
-          },
-          {
-            "key": "cache_builders",
-            "label": "Cache Builders",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
-            "default": 1,
-            "input_type": "number",
-            "min": 0,
-            "step": 1
+            ],
+            "section": "basics"
           },
           {
             "key": "collection_mode",
@@ -44057,37 +47852,2760 @@
                 "value": "show_items",
                 "label": "Show this Collection and its Items"
               }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "text",
+            "section": "basics",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text",
+            "section": "naming",
+            "placeholder": "Custom collection mapping name"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "section": "naming",
+            "placeholder": "Title 1, Title 2"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File.",
+            "type": "text_input",
+            "default": 100,
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "use_top_500",
+            "label": "Letterboxd Top 500",
+            "tooltip": "Collection of the Top 500 films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_top_500",
+            "label": "Letterboxd Top 500 Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Letterboxd Top 500 collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_top_500",
+            "label": "Letterboxd Top 500 Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Letterboxd Top 500 collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_top_500",
+            "label": "Letterboxd Top 500 Limit",
+            "tooltip": "Changes the Builder Limit of the Letterboxd Top 500 collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_top_500",
+            "label": "Letterboxd Top 500 Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
+            "key": "cache_builders_top_500",
+            "label": "Letterboxd Top 500 Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_top_500",
+            "label": "Letterboxd Top 500 Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
             ]
           },
           {
-            "key": "visible_library",
-            "label": "Visible Library",
+            "key": "schedule_top_500",
+            "label": "Letterboxd Top 500 Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100",
+            "tooltip": "Collection of Box Office Mojo's all-time top 100 films.",
             "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Box Office Mojo All Time 100 collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Box Office Mojo All Time 100 collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Limit",
+            "tooltip": "Changes the Builder Limit of the Box Office Mojo All Time 100 collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
+            "key": "cache_builders_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
             ]
+          },
+          {
+            "key": "schedule_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_afi_100",
+            "label": "AFI 100 Years 100 Movies",
+            "tooltip": "Collection of AFI's 100 Years...100 Movies.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_afi_100",
+            "label": "AFI 100 Years 100 Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the AFI 100 Years 100 Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_afi_100",
+            "label": "AFI 100 Years 100 Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the AFI 100 Years 100 Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_afi_100",
+            "label": "AFI 100 Years 100 Movies Limit",
+            "tooltip": "Changes the Builder Limit of the AFI 100 Years 100 Movies collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_afi_100",
+            "label": "AFI 100 Years 100 Movies Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_afi_100",
+            "label": "AFI 100 Years 100 Movies Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_afi_100",
+            "label": "AFI 100 Years 100 Movies Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_afi_100",
+            "label": "AFI 100 Years 100 Movies Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_sight_sound",
+            "label": "Sight & Sound Greatest Films",
+            "tooltip": "Collection of Sight and Sound's Greatest Films of All Time.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_sight_sound",
+            "label": "Sight & Sound Greatest Films Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Sight & Sound Greatest Films collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_sight_sound",
+            "label": "Sight & Sound Greatest Films Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Sight & Sound Greatest Films collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_sight_sound",
+            "label": "Sight & Sound Greatest Films Limit",
+            "tooltip": "Changes the Builder Limit of the Sight & Sound Greatest Films collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_sight_sound",
+            "label": "Sight & Sound Greatest Films Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_sight_sound",
+            "label": "Sight & Sound Greatest Films Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_sight_sound",
+            "label": "Sight & Sound Greatest Films Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_sight_sound",
+            "label": "Sight & Sound Greatest Films Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_1001_movies",
+            "label": "1,001 To See Before You Die",
+            "tooltip": "Collection of 1,001 Movies You Must See Before You Die.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_1001_movies",
+            "label": "1,001 To See Before You Die Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 1,001 To See Before You Die collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_1001_movies",
+            "label": "1,001 To See Before You Die Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 1,001 To See Before You Die collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_1001_movies",
+            "label": "1,001 To See Before You Die Limit",
+            "tooltip": "Changes the Builder Limit of the 1,001 To See Before You Die collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_1001_movies",
+            "label": "1,001 To See Before You Die Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_1001_movies",
+            "label": "1,001 To See Before You Die Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_1001_movies",
+            "label": "1,001 To See Before You Die Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_1001_movies",
+            "label": "1,001 To See Before You Die Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites",
+            "tooltip": "Collection of Edgar Wright's 1,000 Favorite Movies.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Edgar Wright's 1,000 Favorites collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Edgar Wright's 1,000 Favorites collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Limit",
+            "tooltip": "Changes the Builder Limit of the Edgar Wright's 1,000 Favorites collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_rogerebert",
+            "label": "Roger Ebert's Great Movies",
+            "tooltip": "Collection of films from Roger Ebert's \"Great Movies\" essays.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_rogerebert",
+            "label": "Roger Ebert's Great Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Roger Ebert's Great Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_rogerebert",
+            "label": "Roger Ebert's Great Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Roger Ebert's Great Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_rogerebert",
+            "label": "Roger Ebert's Great Movies Limit",
+            "tooltip": "Changes the Builder Limit of the Roger Ebert's Great Movies collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_rogerebert",
+            "label": "Roger Ebert's Great Movies Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_rogerebert",
+            "label": "Roger Ebert's Great Movies Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_rogerebert",
+            "label": "Roger Ebert's Great Movies Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_rogerebert",
+            "label": "Roger Ebert's Great Movies Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_women_directors",
+            "label": "Top 250 Women-Directed",
+            "tooltip": "Collection of the Top 250 Women-Directed films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_women_directors",
+            "label": "Top 250 Women-Directed Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 Women-Directed collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_women_directors",
+            "label": "Top 250 Women-Directed Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 Women-Directed collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_women_directors",
+            "label": "Top 250 Women-Directed Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 Women-Directed collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_women_directors",
+            "label": "Top 250 Women-Directed Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_women_directors",
+            "label": "Top 250 Women-Directed Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_women_directors",
+            "label": "Top 250 Women-Directed Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_women_directors",
+            "label": "Top 250 Women-Directed Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_black_directors",
+            "label": "Top 250 Black-Directed",
+            "tooltip": "Collection of the Top 250 Black-Directed films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_black_directors",
+            "label": "Top 250 Black-Directed Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 Black-Directed collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_black_directors",
+            "label": "Top 250 Black-Directed Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 Black-Directed collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_black_directors",
+            "label": "Top 250 Black-Directed Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 Black-Directed collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_black_directors",
+            "label": "Top 250 Black-Directed Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_black_directors",
+            "label": "Top 250 Black-Directed Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_black_directors",
+            "label": "Top 250 Black-Directed Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_black_directors",
+            "label": "Top 250 Black-Directed Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_most_fans",
+            "label": "Top 250 Most Fans",
+            "tooltip": "Collection of the Top 250 films with the most fans on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_most_fans",
+            "label": "Top 250 Most Fans Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 Most Fans collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_most_fans",
+            "label": "Top 250 Most Fans Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 Most Fans collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_most_fans",
+            "label": "Top 250 Most Fans Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 Most Fans collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_most_fans",
+            "label": "Top 250 Most Fans Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_most_fans",
+            "label": "Top 250 Most Fans Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_most_fans",
+            "label": "Top 250 Most Fans Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_most_fans",
+            "label": "Top 250 Most Fans Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_documentaries",
+            "label": "Top 250 Documentaries",
+            "tooltip": "Collection of the Top 250 documentary films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_documentaries",
+            "label": "Top 250 Documentaries Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 Documentaries collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_documentaries",
+            "label": "Top 250 Documentaries Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 Documentaries collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_documentaries",
+            "label": "Top 250 Documentaries Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 Documentaries collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_documentaries",
+            "label": "Top 250 Documentaries Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_documentaries",
+            "label": "Top 250 Documentaries Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_documentaries",
+            "label": "Top 250 Documentaries Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_documentaries",
+            "label": "Top 250 Documentaries Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_animation",
+            "label": "Top 100 Animation",
+            "tooltip": "Collection of the Top 100 animated films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_animation",
+            "label": "Top 100 Animation Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 100 Animation collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_animation",
+            "label": "Top 100 Animation Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 100 Animation collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_animation",
+            "label": "Top 100 Animation Limit",
+            "tooltip": "Changes the Builder Limit of the Top 100 Animation collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_animation",
+            "label": "Top 100 Animation Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_animation",
+            "label": "Top 100 Animation Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_animation",
+            "label": "Top 100 Animation Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_animation",
+            "label": "Top 100 Animation Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_horror",
+            "label": "Top 250 Horror",
+            "tooltip": "Collection of the Top 250 horror films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_horror",
+            "label": "Top 250 Horror Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 Horror collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_horror",
+            "label": "Top 250 Horror Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 Horror collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_horror",
+            "label": "Top 250 Horror Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 Horror collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_horror",
+            "label": "Top 250 Horror Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_horror",
+            "label": "Top 250 Horror Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_horror",
+            "label": "Top 250 Horror Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_horror",
+            "label": "Top 250 Horror Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_international",
+            "label": "Top 250 International",
+            "tooltip": "Collection of the Top 250 international films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_international",
+            "label": "Top 250 International Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 International collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_international",
+            "label": "Top 250 International Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 International collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_international",
+            "label": "Top 250 International Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 International collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_international",
+            "label": "Top 250 International Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_international",
+            "label": "Top 250 International Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_international",
+            "label": "Top 250 International Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_international",
+            "label": "Top 250 International Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_science",
+            "label": "Top 250 Sci-Fi Films",
+            "tooltip": "Collection of the Top 250 science-fiction films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_science",
+            "label": "Top 250 Sci-Fi Films Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 250 Sci-Fi Films collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_science",
+            "label": "Top 250 Sci-Fi Films Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 250 Sci-Fi Films collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_science",
+            "label": "Top 250 Sci-Fi Films Limit",
+            "tooltip": "Changes the Builder Limit of the Top 250 Sci-Fi Films collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_science",
+            "label": "Top 250 Sci-Fi Films Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_science",
+            "label": "Top 250 Sci-Fi Films Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_science",
+            "label": "Top 250 Sci-Fi Films Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_science",
+            "label": "Top 250 Sci-Fi Films Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_million",
+            "label": "One Million Watched Club",
+            "tooltip": "Collection of films in the One Million Watched Club on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_million",
+            "label": "One Million Watched Club Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the One Million Watched Club collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_million",
+            "label": "One Million Watched Club Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the One Million Watched Club collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_million",
+            "label": "One Million Watched Club Limit",
+            "tooltip": "Changes the Builder Limit of the One Million Watched Club collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_million",
+            "label": "One Million Watched Club Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_million",
+            "label": "One Million Watched Club Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_million",
+            "label": "One Million Watched Club Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_million",
+            "label": "One Million Watched Club Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_western",
+            "label": "Top 100 Western Films",
+            "tooltip": "Collection of the Top 100 western films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_western",
+            "label": "Top 100 Western Films Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 100 Western Films collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_western",
+            "label": "Top 100 Western Films Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 100 Western Films collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_western",
+            "label": "Top 100 Western Films Limit",
+            "tooltip": "Changes the Builder Limit of the Top 100 Western Films collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_western",
+            "label": "Top 100 Western Films Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_western",
+            "label": "Top 100 Western Films Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_western",
+            "label": "Top 100 Western Films Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_western",
+            "label": "Top 100 Western Films Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_silent",
+            "label": "Top 100 Silent Films",
+            "tooltip": "Collection of the Top 100 silent films on Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_silent",
+            "label": "Top 100 Silent Films Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Top 100 Silent Films collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_silent",
+            "label": "Top 100 Silent Films Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Top 100 Silent Films collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_silent",
+            "label": "Top 100 Silent Films Limit",
+            "tooltip": "Changes the Builder Limit of the Top 100 Silent Films collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_silent",
+            "label": "Top 100 Silent Films Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_silent",
+            "label": "Top 100 Silent Films Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_silent",
+            "label": "Top 100 Silent Films Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_silent",
+            "label": "Top 100 Silent Films Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd)",
+            "tooltip": "Collection of the Top 250 Movies on IMDb, from Letterboxd.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the IMDb Top 250 (Letterboxd) collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the IMDb Top 250 (Letterboxd) collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Limit",
+            "tooltip": "Changes the Builder Limit of the IMDb Top 250 (Letterboxd) collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_oscars",
+            "label": "Oscar Best Picture Winners",
+            "tooltip": "Collection of films that have won the Academy Award for Best Picture.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_oscars",
+            "label": "Oscar Best Picture Winners Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Oscar Best Picture Winners collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_oscars",
+            "label": "Oscar Best Picture Winners Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Oscar Best Picture Winners collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_oscars",
+            "label": "Oscar Best Picture Winners Limit",
+            "tooltip": "Changes the Builder Limit of the Oscar Best Picture Winners collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_oscars",
+            "label": "Oscar Best Picture Winners Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_oscars",
+            "label": "Oscar Best Picture Winners Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_oscars",
+            "label": "Oscar Best Picture Winners Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_oscars",
+            "label": "Oscar Best Picture Winners Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_cannes",
+            "label": "Cannes Palme d'Or Winners",
+            "tooltip": "Collection of films that have won the Palme d'Or at the Cannes Film Festival.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_cannes",
+            "label": "Cannes Palme d'Or Winners Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Cannes Palme d'Or Winners collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_cannes",
+            "label": "Cannes Palme d'Or Winners Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Cannes Palme d'Or Winners collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_cannes",
+            "label": "Cannes Palme d'Or Winners Limit",
+            "tooltip": "Changes the Builder Limit of the Cannes Palme d'Or Winners collection.",
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_cannes",
+            "label": "Cannes Palme d'Or Winners Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_cannes",
+            "label": "Cannes Palme d'Or Winners Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_cannes",
+            "label": "Cannes Palme d'Or Winners Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_cannes",
+            "label": "Cannes Palme d'Or Winners Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "chart/<<style>>/<<mapping_name_encoded>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_background_1001_movies",
+            "label": "1,001 To See Before You Die Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_afi_100",
+            "label": "AFI 100 Years 100 Movies Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_animation",
+            "label": "Top 100 Animation Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_black_directors",
+            "label": "Top 250 Black-Directed Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_cannes",
+            "label": "Cannes Palme d'Or Winners Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_documentaries",
+            "label": "Top 250 Documentaries Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_horror",
+            "label": "Top 250 Horror Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_international",
+            "label": "Top 250 International Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_million",
+            "label": "One Million Watched Club Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_most_fans",
+            "label": "Top 250 Most Fans Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_oscars",
+            "label": "Oscar Best Picture Winners Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_rogerebert",
+            "label": "Roger Ebert's Great Movies Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_science",
+            "label": "Top 250 Sci-Fi Films Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_sight_sound",
+            "label": "Sight & Sound Greatest Films Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_silent",
+            "label": "Top 100 Silent Films Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_top_500",
+            "label": "Letterboxd Top 500 Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_western",
+            "label": "Top 100 Western Films Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_women_directors",
+            "label": "Top 250 Women-Directed Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_logo_1001_movies",
+            "label": "1,001 To See Before You Die Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_afi_100",
+            "label": "AFI 100 Years 100 Movies Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_animation",
+            "label": "Top 100 Animation Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_black_directors",
+            "label": "Top 250 Black-Directed Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_cannes",
+            "label": "Cannes Palme d'Or Winners Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_documentaries",
+            "label": "Top 250 Documentaries Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_horror",
+            "label": "Top 250 Horror Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_international",
+            "label": "Top 250 International Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_million",
+            "label": "One Million Watched Club Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_most_fans",
+            "label": "Top 250 Most Fans Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_oscars",
+            "label": "Oscar Best Picture Winners Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_rogerebert",
+            "label": "Roger Ebert's Great Movies Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_science",
+            "label": "Top 250 Sci-Fi Films Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_sight_sound",
+            "label": "Sight & Sound Greatest Films Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_silent",
+            "label": "Top 100 Silent Films Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_top_500",
+            "label": "Letterboxd Top 500 Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_western",
+            "label": "Top 100 Western Films Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_women_directors",
+            "label": "Top 250 Women-Directed Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_poster_1001_movies",
+            "label": "1,001 To See Before You Die Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_afi_100",
+            "label": "AFI 100 Years 100 Movies Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_animation",
+            "label": "Top 100 Animation Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_black_directors",
+            "label": "Top 250 Black-Directed Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_cannes",
+            "label": "Cannes Palme d'Or Winners Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_documentaries",
+            "label": "Top 250 Documentaries Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_horror",
+            "label": "Top 250 Horror Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_international",
+            "label": "Top 250 International Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_million",
+            "label": "One Million Watched Club Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_most_fans",
+            "label": "Top 250 Most Fans Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_oscars",
+            "label": "Oscar Best Picture Winners Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_rogerebert",
+            "label": "Roger Ebert's Great Movies Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_science",
+            "label": "Top 250 Sci-Fi Films Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_sight_sound",
+            "label": "Sight & Sound Greatest Films Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_silent",
+            "label": "Top 100 Silent Films Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_top_500",
+            "label": "Letterboxd Top 500 Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_western",
+            "label": "Top 100 Western Films Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_women_directors",
+            "label": "Top 250 Women-Directed Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_square_art_1001_movies",
+            "label": "1,001 To See Before You Die Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_afi_100",
+            "label": "AFI 100 Years 100 Movies Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_animation",
+            "label": "Top 100 Animation Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_black_directors",
+            "label": "Top 250 Black-Directed Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_cannes",
+            "label": "Cannes Palme d'Or Winners Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_documentaries",
+            "label": "Top 250 Documentaries Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_horror",
+            "label": "Top 250 Horror Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_international",
+            "label": "Top 250 International Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_million",
+            "label": "One Million Watched Club Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_most_fans",
+            "label": "Top 250 Most Fans Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_oscars",
+            "label": "Oscar Best Picture Winners Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_rogerebert",
+            "label": "Roger Ebert's Great Movies Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_science",
+            "label": "Top 250 Sci-Fi Films Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_sight_sound",
+            "label": "Sight & Sound Greatest Films Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_silent",
+            "label": "Top 100 Silent Films Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_top_500",
+            "label": "Letterboxd Top 500 Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_western",
+            "label": "Top 100 Western Films Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_women_directors",
+            "label": "Top 250 Women-Directed Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
           },
           {
             "key": "hub_priority",
@@ -44107,37 +50625,8 @@
             "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "visible_home_1001_movies",
-            "label": "1,001 To See Before You Die Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_1001_movies",
-            "label": "1,001 To See Before You Die Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_1001_movies",
-            "label": "1,001 To See Before You Die Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_1001_movies",
@@ -44157,37 +50646,8 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "visible_home_afi_100",
-            "label": "AFI 100 Years 100 Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_afi_100",
-            "label": "AFI 100 Years 100 Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_afi_100",
-            "label": "AFI 100 Years 100 Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_afi_100",
@@ -44207,687 +50667,8 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "visible_home_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_boxofficemojo_100",
-            "label": "Box Office Mojo All Time 100 Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_boxofficemojo_100",
-              "visible_library_boxofficemojo_100",
-              "visible_shared_boxofficemojo_100"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_cannes",
-            "label": "Cannes Palme d'Or Winners Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_cannes",
-            "label": "Cannes Palme d'Or Winners Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_cannes",
-            "label": "Cannes Palme d'Or Winners Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_cannes",
-            "label": "Cannes Palme d'Or Winners Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_cannes",
-              "visible_library_cannes",
-              "visible_shared_cannes"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_edgarwright",
-            "label": "Edgar Wright's 1,000 Favorites Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_edgarwright",
-              "visible_library_edgarwright",
-              "visible_shared_edgarwright"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_imdb_top_250",
-            "label": "IMDb Top 250 (Letterboxd) Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_imdb_top_250",
-              "visible_library_imdb_top_250",
-              "visible_shared_imdb_top_250"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_top_500",
-            "label": "Letterboxd Top 500 Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Letterboxd Top 500 collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_top_500",
-            "label": "Letterboxd Top 500 Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Letterboxd Top 500 collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_top_500",
-            "label": "Letterboxd Top 500 Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Letterboxd Top 500 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_top_500",
-            "label": "Letterboxd Top 500 Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_top_500",
-              "visible_library_top_500",
-              "visible_shared_top_500"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_international",
-            "label": "Top 250 International Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 International collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_international",
-            "label": "Top 250 International Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 International collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_international",
-            "label": "Top 250 International Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 International collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_international",
-            "label": "Top 250 International Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_international",
-              "visible_library_international",
-              "visible_shared_international"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_science",
-            "label": "Top 250 Sci-Fi Films Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_science",
-            "label": "Top 250 Sci-Fi Films Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_science",
-            "label": "Top 250 Sci-Fi Films Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_science",
-            "label": "Top 250 Sci-Fi Films Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_science",
-              "visible_library_science",
-              "visible_shared_science"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_western",
-            "label": "Top 100 Western Films Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Western Films collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_western",
-            "label": "Top 100 Western Films Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Western Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_western",
-            "label": "Top 100 Western Films Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Western Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_western",
-            "label": "Top 100 Western Films Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_western",
-              "visible_library_western",
-              "visible_shared_western"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_silent",
-            "label": "Top 100 Silent Films Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Silent Films collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_silent",
-            "label": "Top 100 Silent Films Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Silent Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_silent",
-            "label": "Top 100 Silent Films Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Silent Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_silent",
-            "label": "Top 100 Silent Films Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_silent",
-              "visible_library_silent",
-              "visible_shared_silent"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_million",
-            "label": "One Million Watched Club Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the One Million Watched Club collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_million",
-            "label": "One Million Watched Club Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the One Million Watched Club collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_million",
-            "label": "One Million Watched Club Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the One Million Watched Club collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_million",
-            "label": "One Million Watched Club Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_million",
-              "visible_library_million",
-              "visible_shared_million"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_oscars",
-            "label": "Oscar Best Picture Winners Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_oscars",
-            "label": "Oscar Best Picture Winners Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_oscars",
-            "label": "Oscar Best Picture Winners Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_oscars",
-            "label": "Oscar Best Picture Winners Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_oscars",
-              "visible_library_oscars",
-              "visible_shared_oscars"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_rogerebert",
-            "label": "Roger Ebert's Great Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_rogerebert",
-            "label": "Roger Ebert's Great Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_rogerebert",
-            "label": "Roger Ebert's Great Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_rogerebert",
-            "label": "Roger Ebert's Great Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_rogerebert",
-              "visible_library_rogerebert",
-              "visible_shared_rogerebert"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_sight_sound",
-            "label": "Sight & Sound Greatest Films Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_sight_sound",
-            "label": "Sight & Sound Greatest Films Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_sight_sound",
-            "label": "Sight & Sound Greatest Films Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_sight_sound",
-            "label": "Sight & Sound Greatest Films Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_sight_sound",
-              "visible_library_sight_sound",
-              "visible_shared_sight_sound"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_animation",
-            "label": "Top 100 Animation Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Animation collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_animation",
-            "label": "Top 100 Animation Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Animation collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_animation",
-            "label": "Top 100 Animation Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 100 Animation collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "section": "visibility"
           },
           {
             "key": "hub_priority_animation",
@@ -44907,37 +50688,8 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "visible_home_black_directors",
-            "label": "Top 250 Black-Directed Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Black-Directed collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_black_directors",
-            "label": "Top 250 Black-Directed Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Black-Directed collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_black_directors",
-            "label": "Top 250 Black-Directed Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Black-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_black_directors",
@@ -44957,37 +50709,50 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_home_documentaries",
-            "label": "Top 250 Documentaries Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Documentaries collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_boxofficemojo_100",
+              "visible_library_boxofficemojo_100",
+              "visible_shared_boxofficemojo_100"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_library_documentaries",
-            "label": "Top 250 Documentaries Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Documentaries collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_cannes",
+            "label": "Cannes Palme d'Or Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_cannes",
+              "visible_library_cannes",
+              "visible_shared_cannes"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_documentaries",
-            "label": "Top 250 Documentaries Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Documentaries collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_documentaries",
@@ -45007,37 +50772,29 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_home_horror",
-            "label": "Top 250 Horror Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Horror collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_edgarwright",
+              "visible_library_edgarwright",
+              "visible_shared_edgarwright"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "visible_library_horror",
-            "label": "Top 250 Horror Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Horror collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_horror",
-            "label": "Top 250 Horror Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Horror collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_horror",
@@ -45057,37 +50814,71 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_home_most_fans",
-            "label": "Top 250 Most Fans Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Most Fans collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_imdb_top_250",
+              "visible_library_imdb_top_250",
+              "visible_shared_imdb_top_250"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_library_most_fans",
-            "label": "Top 250 Most Fans Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Most Fans collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_international",
+            "label": "Top 250 International Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_international",
+              "visible_library_international",
+              "visible_shared_international"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_shared_most_fans",
-            "label": "Top 250 Most Fans Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Most Fans collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_million",
+            "label": "One Million Watched Club Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_million",
+              "visible_library_million",
+              "visible_shared_million"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_most_fans",
@@ -45107,37 +50898,155 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_home_women_directors",
-            "label": "Top 250 Women-Directed Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Women-Directed collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_oscars",
+            "label": "Oscar Best Picture Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_oscars",
+              "visible_library_oscars",
+              "visible_shared_oscars"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_library_women_directors",
-            "label": "Top 250 Women-Directed Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Women-Directed collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_rogerebert",
+            "label": "Roger Ebert's Great Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_rogerebert",
+              "visible_library_rogerebert",
+              "visible_shared_rogerebert"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
-            "key": "visible_shared_women_directors",
-            "label": "Top 250 Women-Directed Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Top 250 Women-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
+            "key": "hub_priority_science",
+            "label": "Top 250 Sci-Fi Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_science",
+              "visible_library_science",
+              "visible_shared_science"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_sight_sound",
+            "label": "Sight & Sound Greatest Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_sight_sound",
+              "visible_library_sight_sound",
+              "visible_shared_sight_sound"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_silent",
+            "label": "Top 100 Silent Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_silent",
+              "visible_library_silent",
+              "visible_shared_silent"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_top_500",
+            "label": "Letterboxd Top 500 Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top_500",
+              "visible_library_top_500",
+              "visible_shared_top_500"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_western",
+            "label": "Top 100 Western Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_western",
+              "visible_library_western",
+              "visible_shared_western"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility"
           },
           {
             "key": "hub_priority_women_directors",
@@ -45157,362 +51066,8237 @@
             "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "basics"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "basics"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_radarr_tag_1001_movies",
+            "label": "1,001 To See Before You Die Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_afi_100",
+            "label": "AFI 100 Years 100 Movies Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_animation",
+            "label": "Top 100 Animation Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_black_directors",
+            "label": "Top 250 Black-Directed Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_cannes",
+            "label": "Cannes Palme d'Or Winners Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_documentaries",
+            "label": "Top 250 Documentaries Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_horror",
+            "label": "Top 250 Horror Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_international",
+            "label": "Top 250 International Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_million",
+            "label": "One Million Watched Club Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_most_fans",
+            "label": "Top 250 Most Fans Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_oscars",
+            "label": "Oscar Best Picture Winners Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_rogerebert",
+            "label": "Roger Ebert's Great Movies Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_science",
+            "label": "Top 250 Sci-Fi Films Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_sight_sound",
+            "label": "Sight & Sound Greatest Films Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_silent",
+            "label": "Top 100 Silent Films Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_top_500",
+            "label": "Letterboxd Top 500 Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_western",
+            "label": "Top 100 Western Films Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_women_directors",
+            "label": "Top 250 Women-Directed Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_1001_movies",
+            "label": "1,001 To See Before You Die Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_afi_100",
+            "label": "AFI 100 Years 100 Movies Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_animation",
+            "label": "Top 100 Animation Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_black_directors",
+            "label": "Top 250 Black-Directed Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_cannes",
+            "label": "Cannes Palme d'Or Winners Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_documentaries",
+            "label": "Top 250 Documentaries Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_horror",
+            "label": "Top 250 Horror Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_international",
+            "label": "Top 250 International Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_million",
+            "label": "One Million Watched Club Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_most_fans",
+            "label": "Top 250 Most Fans Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_oscars",
+            "label": "Oscar Best Picture Winners Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_rogerebert",
+            "label": "Roger Ebert's Great Movies Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_science",
+            "label": "Top 250 Sci-Fi Films Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_sight_sound",
+            "label": "Sight & Sound Greatest Films Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_silent",
+            "label": "Top 100 Silent Films Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_top_500",
+            "label": "Letterboxd Top 500 Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_western",
+            "label": "Top 100 Western Films Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_women_directors",
+            "label": "Top 250 Women-Directed Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_1001_movies",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_afi_100",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_animation",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_black_directors",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_boxofficemojo_100",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_cannes",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_documentaries",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_edgarwright",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_horror",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_imdb_top_250",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_international",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_million",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_most_fans",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_oscars",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_rogerebert",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_science",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_sight_sound",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_silent",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_top_500",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_western",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_women_directors",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder_1001_movies",
+            "label": "1,001 To See Before You Die Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_afi_100",
+            "label": "AFI 100 Years 100 Movies Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_animation",
+            "label": "Top 100 Animation Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_black_directors",
+            "label": "Top 250 Black-Directed Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_cannes",
+            "label": "Cannes Palme d'Or Winners Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_documentaries",
+            "label": "Top 250 Documentaries Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_horror",
+            "label": "Top 250 Horror Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_international",
+            "label": "Top 250 International Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_million",
+            "label": "One Million Watched Club Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_most_fans",
+            "label": "Top 250 Most Fans Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_oscars",
+            "label": "Oscar Best Picture Winners Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_rogerebert",
+            "label": "Roger Ebert's Great Movies Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_science",
+            "label": "Top 250 Sci-Fi Films Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_sight_sound",
+            "label": "Sight & Sound Greatest Films Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_silent",
+            "label": "Top 100 Silent Films Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_top_500",
+            "label": "Letterboxd Top 500 Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_western",
+            "label": "Top 100 Western Films Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_women_directors",
+            "label": "Top 250 Women-Directed Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_1001_movies",
+            "label": "1,001 To See Before You Die Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
-            "key": "collection_order",
-            "label": "Collection Order",
+            "key": "radarr_monitor_afi_100",
+            "label": "AFI 100 Years 100 Movies Radarr Monitor",
             "type": "select",
-            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
-            "default": "custom",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
             "options": [
               {
-                "value": "custom",
-                "label": "Custom Order",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
+                "value": "",
+                "label": "Default"
               },
               {
-                "value": "alpha",
-                "label": "Alphabetical Order",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
+                "value": "true",
+                "label": "True"
               },
               {
-                "value": "title.asc",
-                "label": "Title Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "title.desc",
-                "label": "Title Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "season.asc",
-                "label": "Season Ascending",
-                "media_types": [
-                  "season"
-                ]
-              },
-              {
-                "value": "season.desc",
-                "label": "Season Descending",
-                "media_types": [
-                  "season"
-                ]
-              },
-              {
-                "value": "show.asc",
-                "label": "Show Ascending",
-                "media_types": [
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "show.desc",
-                "label": "Show Descending",
-                "media_types": [
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "year.asc",
-                "label": "Year Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "year.desc",
-                "label": "Year Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "release.asc",
-                "label": "Release Date (Originally Available) Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "release.desc",
-                "label": "Release Date (Originally Available) Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "episode_release.asc",
-                "label": "Episode Release Date Ascending",
-                "media_types": [
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "episode_release.desc",
-                "label": "Episode Release Date Descending",
-                "media_types": [
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "critic_rating.asc",
-                "label": "Critic Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "critic_rating.desc",
-                "label": "Critic Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "audience_rating.asc",
-                "label": "Audience Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "audience_rating.desc",
-                "label": "Audience Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "user_rating.asc",
-                "label": "User Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "user_rating.desc",
-                "label": "User Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "content_rating.asc",
-                "label": "Content Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show"
-                ]
-              },
-              {
-                "value": "content_rating.desc",
-                "label": "Content Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show"
-                ]
-              },
-              {
-                "value": "duration.asc",
-                "label": "Duration Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "duration.desc",
-                "label": "Duration Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "progress.asc",
-                "label": "Progress Ascending",
-                "media_types": [
-                  "episode"
-                ]
-              },
-              {
-                "value": "progress.desc",
-                "label": "Progress Descending",
-                "media_types": [
-                  "episode"
-                ]
-              },
-              {
-                "value": "plays.asc",
-                "label": "Number of Plays Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "plays.desc",
-                "label": "Number of Plays Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "unplayed.asc",
-                "label": "Unplayed Ascending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "unplayed.desc",
-                "label": "Unplayed Descending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "episode_added.asc",
-                "label": "Last Episode Date Added Ascending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "episode_added.desc",
-                "label": "Last Episode Date Added Descending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "added.asc",
-                "label": "Date Added Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "added.desc",
-                "label": "Date Added Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "viewed.asc",
-                "label": "Date Last Viewed Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "viewed.desc",
-                "label": "Date Last Viewed Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "resolution.asc",
-                "label": "Resolution Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "resolution.desc",
-                "label": "Resolution Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "bitrate.asc",
-                "label": "Bitrate Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "bitrate.desc",
-                "label": "Bitrate Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "random",
-                "label": "Random",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
+                "value": "false",
+                "label": "False"
               }
             ]
+          },
+          {
+            "key": "radarr_monitor_animation",
+            "label": "Top 100 Animation Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_black_directors",
+            "label": "Top 250 Black-Directed Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_cannes",
+            "label": "Cannes Palme d'Or Winners Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_documentaries",
+            "label": "Top 250 Documentaries Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing_1001_movies",
+            "label": "1,001 To See Before You Die Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_afi_100",
+            "label": "AFI 100 Years 100 Movies Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_animation",
+            "label": "Top 100 Animation Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_black_directors",
+            "label": "Top 250 Black-Directed Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_cannes",
+            "label": "Cannes Palme d'Or Winners Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_documentaries",
+            "label": "Top 250 Documentaries Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_horror",
+            "label": "Top 250 Horror Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_international",
+            "label": "Top 250 International Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_million",
+            "label": "One Million Watched Club Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_most_fans",
+            "label": "Top 250 Most Fans Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_oscars",
+            "label": "Oscar Best Picture Winners Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_rogerebert",
+            "label": "Roger Ebert's Great Movies Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_science",
+            "label": "Top 250 Sci-Fi Films Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_sight_sound",
+            "label": "Sight & Sound Greatest Films Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_silent",
+            "label": "Top 100 Silent Films Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_top_500",
+            "label": "Letterboxd Top 500 Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_western",
+            "label": "Top 100 Western Films Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_women_directors",
+            "label": "Top 250 Women-Directed Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_horror",
+            "label": "Top 250 Horror Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_international",
+            "label": "Top 250 International Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_million",
+            "label": "One Million Watched Club Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_most_fans",
+            "label": "Top 250 Most Fans Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_oscars",
+            "label": "Oscar Best Picture Winners Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_rogerebert",
+            "label": "Roger Ebert's Great Movies Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_science",
+            "label": "Top 250 Sci-Fi Films Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_sight_sound",
+            "label": "Sight & Sound Greatest Films Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_silent",
+            "label": "Top 100 Silent Films Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_top_500",
+            "label": "Letterboxd Top 500 Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_western",
+            "label": "Top 100 Western Films Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_women_directors",
+            "label": "Top 250 Women-Directed Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_search_1001_movies",
+            "label": "1,001 To See Before You Die Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_afi_100",
+            "label": "AFI 100 Years 100 Movies Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_animation",
+            "label": "Top 100 Animation Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_black_directors",
+            "label": "Top 250 Black-Directed Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_cannes",
+            "label": "Cannes Palme d'Or Winners Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_documentaries",
+            "label": "Top 250 Documentaries Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_horror",
+            "label": "Top 250 Horror Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_international",
+            "label": "Top 250 International Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_million",
+            "label": "One Million Watched Club Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_most_fans",
+            "label": "Top 250 Most Fans Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_oscars",
+            "label": "Oscar Best Picture Winners Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_rogerebert",
+            "label": "Roger Ebert's Great Movies Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_science",
+            "label": "Top 250 Sci-Fi Films Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_sight_sound",
+            "label": "Sight & Sound Greatest Films Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_silent",
+            "label": "Top 100 Silent Films Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_top_500",
+            "label": "Letterboxd Top 500 Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_western",
+            "label": "Top 100 Western Films Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_women_directors",
+            "label": "Top 250 Women-Directed Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_tag_1001_movies",
+            "label": "1,001 To See Before You Die Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_afi_100",
+            "label": "AFI 100 Years 100 Movies Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_animation",
+            "label": "Top 100 Animation Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_black_directors",
+            "label": "Top 250 Black-Directed Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_cannes",
+            "label": "Cannes Palme d'Or Winners Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_documentaries",
+            "label": "Top 250 Documentaries Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_horror",
+            "label": "Top 250 Horror Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_international",
+            "label": "Top 250 International Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_million",
+            "label": "One Million Watched Club Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_most_fans",
+            "label": "Top 250 Most Fans Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_oscars",
+            "label": "Oscar Best Picture Winners Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_rogerebert",
+            "label": "Roger Ebert's Great Movies Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_science",
+            "label": "Top 250 Sci-Fi Films Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_sight_sound",
+            "label": "Sight & Sound Greatest Films Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_silent",
+            "label": "Top 100 Silent Films Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_top_500",
+            "label": "Letterboxd Top 500 Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_western",
+            "label": "Top 100 Western Films Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_women_directors",
+            "label": "Top 250 Women-Directed Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_upgrade_existing_1001_movies",
+            "label": "1,001 To See Before You Die Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_afi_100",
+            "label": "AFI 100 Years 100 Movies Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_animation",
+            "label": "Top 100 Animation Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_black_directors",
+            "label": "Top 250 Black-Directed Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_cannes",
+            "label": "Cannes Palme d'Or Winners Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_documentaries",
+            "label": "Top 250 Documentaries Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_horror",
+            "label": "Top 250 Horror Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_international",
+            "label": "Top 250 International Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_million",
+            "label": "One Million Watched Club Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_most_fans",
+            "label": "Top 250 Most Fans Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_oscars",
+            "label": "Oscar Best Picture Winners Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_rogerebert",
+            "label": "Roger Ebert's Great Movies Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_science",
+            "label": "Top 250 Sci-Fi Films Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_sight_sound",
+            "label": "Sight & Sound Greatest Films Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_silent",
+            "label": "Top 100 Silent Films Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_top_500",
+            "label": "Letterboxd Top 500 Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_western",
+            "label": "Top 100 Western Films Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_women_directors",
+            "label": "Top 250 Women-Directed Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_folder_1001_movies",
+            "label": "1,001 To See Before You Die Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_afi_100",
+            "label": "AFI 100 Years 100 Movies Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_animation",
+            "label": "Top 100 Animation Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_black_directors",
+            "label": "Top 250 Black-Directed Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_cannes",
+            "label": "Cannes Palme d'Or Winners Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_documentaries",
+            "label": "Top 250 Documentaries Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_horror",
+            "label": "Top 250 Horror Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_international",
+            "label": "Top 250 International Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_million",
+            "label": "One Million Watched Club Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_most_fans",
+            "label": "Top 250 Most Fans Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_oscars",
+            "label": "Oscar Best Picture Winners Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_rogerebert",
+            "label": "Roger Ebert's Great Movies Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_science",
+            "label": "Top 250 Sci-Fi Films Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_sight_sound",
+            "label": "Sight & Sound Greatest Films Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_silent",
+            "label": "Top 100 Silent Films Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_top_500",
+            "label": "Letterboxd Top 500 Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_western",
+            "label": "Top 100 Western Films Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_women_directors",
+            "label": "Top 250 Women-Directed Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_monitor_1001_movies",
+            "label": "1,001 To See Before You Die Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_afi_100",
+            "label": "AFI 100 Years 100 Movies Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_animation",
+            "label": "Top 100 Animation Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_black_directors",
+            "label": "Top 250 Black-Directed Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_cannes",
+            "label": "Cannes Palme d'Or Winners Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_documentaries",
+            "label": "Top 250 Documentaries Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_1001_movies",
+            "label": "1,001 To See Before You Die Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_afi_100",
+            "label": "AFI 100 Years 100 Movies Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_animation",
+            "label": "Top 100 Animation Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_black_directors",
+            "label": "Top 250 Black-Directed Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_cannes",
+            "label": "Cannes Palme d'Or Winners Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_documentaries",
+            "label": "Top 250 Documentaries Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_horror",
+            "label": "Top 250 Horror Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_international",
+            "label": "Top 250 International Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_million",
+            "label": "One Million Watched Club Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_most_fans",
+            "label": "Top 250 Most Fans Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_oscars",
+            "label": "Oscar Best Picture Winners Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_rogerebert",
+            "label": "Roger Ebert's Great Movies Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_science",
+            "label": "Top 250 Sci-Fi Films Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_sight_sound",
+            "label": "Sight & Sound Greatest Films Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_silent",
+            "label": "Top 100 Silent Films Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_top_500",
+            "label": "Letterboxd Top 500 Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_western",
+            "label": "Top 100 Western Films Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_women_directors",
+            "label": "Top 250 Women-Directed Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_horror",
+            "label": "Top 250 Horror Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_international",
+            "label": "Top 250 International Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_million",
+            "label": "One Million Watched Club Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_most_fans",
+            "label": "Top 250 Most Fans Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_oscars",
+            "label": "Oscar Best Picture Winners Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_rogerebert",
+            "label": "Roger Ebert's Great Movies Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_science",
+            "label": "Top 250 Sci-Fi Films Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_sight_sound",
+            "label": "Sight & Sound Greatest Films Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_silent",
+            "label": "Top 100 Silent Films Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_top_500",
+            "label": "Letterboxd Top 500 Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_western",
+            "label": "Top 100 Western Films Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_women_directors",
+            "label": "Top 250 Women-Directed Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_1001_movies",
+            "label": "1,001 To See Before You Die Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_afi_100",
+            "label": "AFI 100 Years 100 Movies Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_animation",
+            "label": "Top 100 Animation Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_black_directors",
+            "label": "Top 250 Black-Directed Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_cannes",
+            "label": "Cannes Palme d'Or Winners Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_documentaries",
+            "label": "Top 250 Documentaries Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_horror",
+            "label": "Top 250 Horror Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_international",
+            "label": "Top 250 International Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_million",
+            "label": "One Million Watched Club Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_most_fans",
+            "label": "Top 250 Most Fans Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_oscars",
+            "label": "Oscar Best Picture Winners Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_rogerebert",
+            "label": "Roger Ebert's Great Movies Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_science",
+            "label": "Top 250 Sci-Fi Films Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_sight_sound",
+            "label": "Sight & Sound Greatest Films Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_silent",
+            "label": "Top 100 Silent Films Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_top_500",
+            "label": "Letterboxd Top 500 Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_western",
+            "label": "Top 100 Western Films Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_women_directors",
+            "label": "Top 250 Women-Directed Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_tag_1001_movies",
+            "label": "1,001 To See Before You Die Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_afi_100",
+            "label": "AFI 100 Years 100 Movies Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_animation",
+            "label": "Top 100 Animation Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_black_directors",
+            "label": "Top 250 Black-Directed Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_cannes",
+            "label": "Cannes Palme d'Or Winners Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_documentaries",
+            "label": "Top 250 Documentaries Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_horror",
+            "label": "Top 250 Horror Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_international",
+            "label": "Top 250 International Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_million",
+            "label": "One Million Watched Club Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_most_fans",
+            "label": "Top 250 Most Fans Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_oscars",
+            "label": "Oscar Best Picture Winners Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_rogerebert",
+            "label": "Roger Ebert's Great Movies Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_science",
+            "label": "Top 250 Sci-Fi Films Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_sight_sound",
+            "label": "Sight & Sound Greatest Films Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_silent",
+            "label": "Top 100 Silent Films Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_top_500",
+            "label": "Letterboxd Top 500 Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_western",
+            "label": "Top 100 Western Films Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_women_directors",
+            "label": "Top 250 Women-Directed Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_upgrade_existing_1001_movies",
+            "label": "1,001 To See Before You Die Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_afi_100",
+            "label": "AFI 100 Years 100 Movies Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_animation",
+            "label": "Top 100 Animation Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_black_directors",
+            "label": "Top 250 Black-Directed Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_cannes",
+            "label": "Cannes Palme d'Or Winners Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_documentaries",
+            "label": "Top 250 Documentaries Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_horror",
+            "label": "Top 250 Horror Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_international",
+            "label": "Top 250 International Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_million",
+            "label": "One Million Watched Club Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_most_fans",
+            "label": "Top 250 Most Fans Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_oscars",
+            "label": "Oscar Best Picture Winners Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_rogerebert",
+            "label": "Roger Ebert's Great Movies Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_science",
+            "label": "Top 250 Sci-Fi Films Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_sight_sound",
+            "label": "Sight & Sound Greatest Films Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_silent",
+            "label": "Top 100 Silent Films Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_top_500",
+            "label": "Letterboxd Top 500 Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_western",
+            "label": "Top 100 Western Films Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_women_directors",
+            "label": "Top 250 Women-Directed Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "url_background_1001_movies",
+            "label": "1,001 To See Before You Die Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_afi_100",
+            "label": "AFI 100 Years 100 Movies Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_animation",
+            "label": "Top 100 Animation Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_black_directors",
+            "label": "Top 250 Black-Directed Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_cannes",
+            "label": "Cannes Palme d'Or Winners Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_documentaries",
+            "label": "Top 250 Documentaries Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_horror",
+            "label": "Top 250 Horror Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_international",
+            "label": "Top 250 International Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_million",
+            "label": "One Million Watched Club Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_most_fans",
+            "label": "Top 250 Most Fans Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_oscars",
+            "label": "Oscar Best Picture Winners Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_rogerebert",
+            "label": "Roger Ebert's Great Movies Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_science",
+            "label": "Top 250 Sci-Fi Films Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_sight_sound",
+            "label": "Sight & Sound Greatest Films Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_silent",
+            "label": "Top 100 Silent Films Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_top_500",
+            "label": "Letterboxd Top 500 Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_western",
+            "label": "Top 100 Western Films Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_women_directors",
+            "label": "Top 250 Women-Directed Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_logo_1001_movies",
+            "label": "1,001 To See Before You Die Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_afi_100",
+            "label": "AFI 100 Years 100 Movies Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_animation",
+            "label": "Top 100 Animation Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_black_directors",
+            "label": "Top 250 Black-Directed Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_cannes",
+            "label": "Cannes Palme d'Or Winners Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_documentaries",
+            "label": "Top 250 Documentaries Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_horror",
+            "label": "Top 250 Horror Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_international",
+            "label": "Top 250 International Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_million",
+            "label": "One Million Watched Club Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_most_fans",
+            "label": "Top 250 Most Fans Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_oscars",
+            "label": "Oscar Best Picture Winners Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_rogerebert",
+            "label": "Roger Ebert's Great Movies Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_science",
+            "label": "Top 250 Sci-Fi Films Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_sight_sound",
+            "label": "Sight & Sound Greatest Films Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_silent",
+            "label": "Top 100 Silent Films Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_top_500",
+            "label": "Letterboxd Top 500 Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_western",
+            "label": "Top 100 Western Films Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_women_directors",
+            "label": "Top 250 Women-Directed Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_poster_1001_movies",
+            "label": "1,001 To See Before You Die Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_afi_100",
+            "label": "AFI 100 Years 100 Movies Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_animation",
+            "label": "Top 100 Animation Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_black_directors",
+            "label": "Top 250 Black-Directed Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_cannes",
+            "label": "Cannes Palme d'Or Winners Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_documentaries",
+            "label": "Top 250 Documentaries Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_horror",
+            "label": "Top 250 Horror Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_international",
+            "label": "Top 250 International Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_million",
+            "label": "One Million Watched Club Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_most_fans",
+            "label": "Top 250 Most Fans Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_oscars",
+            "label": "Oscar Best Picture Winners Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_rogerebert",
+            "label": "Roger Ebert's Great Movies Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_science",
+            "label": "Top 250 Sci-Fi Films Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_sight_sound",
+            "label": "Sight & Sound Greatest Films Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_silent",
+            "label": "Top 100 Silent Films Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_top_500",
+            "label": "Letterboxd Top 500 Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_western",
+            "label": "Top 100 Western Films Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_women_directors",
+            "label": "Top 250 Women-Directed Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_square_art_1001_movies",
+            "label": "1,001 To See Before You Die Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_afi_100",
+            "label": "AFI 100 Years 100 Movies Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_animation",
+            "label": "Top 100 Animation Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_black_directors",
+            "label": "Top 250 Black-Directed Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_cannes",
+            "label": "Cannes Palme d'Or Winners Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_documentaries",
+            "label": "Top 250 Documentaries Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_horror",
+            "label": "Top 250 Horror Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_international",
+            "label": "Top 250 International Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_million",
+            "label": "One Million Watched Club Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_most_fans",
+            "label": "Top 250 Most Fans Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_oscars",
+            "label": "Oscar Best Picture Winners Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_rogerebert",
+            "label": "Roger Ebert's Great Movies Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_science",
+            "label": "Top 250 Sci-Fi Films Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_sight_sound",
+            "label": "Sight & Sound Greatest Films Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_silent",
+            "label": "Top 100 Silent Films Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_top_500",
+            "label": "Letterboxd Top 500 Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_western",
+            "label": "Top 100 Western Films Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_women_directors",
+            "label": "Top 250 Women-Directed Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_1001_movies",
+            "label": "1,001 To See Before You Die Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_afi_100",
+            "label": "AFI 100 Years 100 Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_animation",
+            "label": "Top 100 Animation Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Animation collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_black_directors",
+            "label": "Top 250 Black-Directed Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Black-Directed collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_cannes",
+            "label": "Cannes Palme d'Or Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_documentaries",
+            "label": "Top 250 Documentaries Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Documentaries collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_horror",
+            "label": "Top 250 Horror Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Horror collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_international",
+            "label": "Top 250 International Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 International collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_million",
+            "label": "One Million Watched Club Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the One Million Watched Club collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_most_fans",
+            "label": "Top 250 Most Fans Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Most Fans collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_oscars",
+            "label": "Oscar Best Picture Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_rogerebert",
+            "label": "Roger Ebert's Great Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_science",
+            "label": "Top 250 Sci-Fi Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_sight_sound",
+            "label": "Sight & Sound Greatest Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_silent",
+            "label": "Top 100 Silent Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Silent Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_top_500",
+            "label": "Letterboxd Top 500 Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Letterboxd Top 500 collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_western",
+            "label": "Top 100 Western Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Western Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_women_directors",
+            "label": "Top 250 Women-Directed Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Women-Directed collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_1001_movies",
+            "label": "1,001 To See Before You Die Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_afi_100",
+            "label": "AFI 100 Years 100 Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_animation",
+            "label": "Top 100 Animation Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Animation collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_black_directors",
+            "label": "Top 250 Black-Directed Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Black-Directed collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_cannes",
+            "label": "Cannes Palme d'Or Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_documentaries",
+            "label": "Top 250 Documentaries Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Documentaries collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_horror",
+            "label": "Top 250 Horror Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Horror collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_international",
+            "label": "Top 250 International Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 International collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_million",
+            "label": "One Million Watched Club Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the One Million Watched Club collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_most_fans",
+            "label": "Top 250 Most Fans Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Most Fans collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_oscars",
+            "label": "Oscar Best Picture Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_rogerebert",
+            "label": "Roger Ebert's Great Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_science",
+            "label": "Top 250 Sci-Fi Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_sight_sound",
+            "label": "Sight & Sound Greatest Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_silent",
+            "label": "Top 100 Silent Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Silent Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_top_500",
+            "label": "Letterboxd Top 500 Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Letterboxd Top 500 collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_western",
+            "label": "Top 100 Western Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Western Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_women_directors",
+            "label": "Top 250 Women-Directed Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Women-Directed collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_1001_movies",
+            "label": "1,001 To See Before You Die Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_afi_100",
+            "label": "AFI 100 Years 100 Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_animation",
+            "label": "Top 100 Animation Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Animation collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_black_directors",
+            "label": "Top 250 Black-Directed Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Black-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_cannes",
+            "label": "Cannes Palme d'Or Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_documentaries",
+            "label": "Top 250 Documentaries Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Documentaries collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_horror",
+            "label": "Top 250 Horror Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Horror collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_international",
+            "label": "Top 250 International Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 International collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_million",
+            "label": "One Million Watched Club Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the One Million Watched Club collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_most_fans",
+            "label": "Top 250 Most Fans Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Most Fans collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_oscars",
+            "label": "Oscar Best Picture Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_rogerebert",
+            "label": "Roger Ebert's Great Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_science",
+            "label": "Top 250 Sci-Fi Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_sight_sound",
+            "label": "Sight & Sound Greatest Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_silent",
+            "label": "Top 100 Silent Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Silent Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_top_500",
+            "label": "Letterboxd Top 500 Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Letterboxd Top 500 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_western",
+            "label": "Top 100 Western Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Western Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_women_directors",
+            "label": "Top 250 Women-Directed Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Women-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          }
+        ],
+        "sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "builder",
+            "label": "Builder Controls"
+          },
+          {
+            "id": "children",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "automation",
+            "label": "Automation"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       },

--- a/tests/test_collection_chart_anilist_mal_letterboxd_contract.py
+++ b/tests/test_collection_chart_anilist_mal_letterboxd_contract.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+
+
+def _walk(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _walk(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _walk(value)
+
+
+def _collection(collection_id):
+    data = json.loads(Path("static/json/quickstart_collections.json").read_text(encoding="utf-8"))
+    return next(node for node in _walk(data) if node.get("id") == collection_id)
+
+
+def _field_keys(collection_id):
+    return {field["key"] for field in _collection(collection_id)["template_variables"]}
+
+
+def test_anilist_chart_exposes_shared_child_custom_and_arr_template_variables():
+    collection = _collection("collection_anilist")
+    keys = _field_keys("collection_anilist")
+
+    assert [section["id"] for section in collection["sections"]] == [
+        "basics",
+        "naming",
+        "builder",
+        "children",
+        "artwork",
+        "automation",
+        "visibility",
+    ]
+    assert {
+        "image",
+        "allowed_libraries",
+        "schedule",
+        "url_logo",
+        "url_logo_popular",
+        "url_logo_top",
+        "url_logo_trending",
+        "url_logo_season",
+        "sync_mode_trending",
+        "cache_builders_season",
+        "collection_order_top",
+        "radarr_folder_popular",
+        "radarr_tag_trending",
+        "sonarr_folder_season",
+        "sonarr_search_season",
+    }.issubset(keys)
+
+
+def test_myanimelist_chart_exposes_starting_only_shared_child_custom_and_arr_template_variables():
+    keys = _field_keys("collection_myanimelist")
+
+    assert {
+        "starting_only",
+        "starting_only_season",
+        "image",
+        "allowed_libraries",
+        "schedule",
+        "url_logo",
+        "url_logo_popular",
+        "url_logo_favorited",
+        "url_logo_top",
+        "url_logo_airing",
+        "url_logo_season",
+        "sync_mode_season",
+        "cache_builders_airing",
+        "collection_order_top",
+        "radarr_folder_favorited",
+        "radarr_tag_popular",
+        "sonarr_folder_season",
+        "sonarr_search_season",
+    }.issubset(keys)
+
+
+def test_letterboxd_chart_exposes_shared_child_custom_and_arr_template_variables():
+    keys = _field_keys("collection_letterboxd")
+
+    assert {
+        "image",
+        "allowed_libraries",
+        "schedule",
+        "sort_title",
+        "url_logo",
+        "url_logo_top_500",
+        "url_logo_1001_movies",
+        "url_logo_black_directors",
+        "url_logo_imdb_top_250",
+        "url_logo_oscars",
+        "url_logo_cannes",
+        "sync_mode_oscars",
+        "cache_builders_black_directors",
+        "collection_order_cannes",
+        "radarr_folder_women_directors",
+        "radarr_tag_top_500",
+        "sonarr_folder_imdb_top_250",
+        "sonarr_search_imdb_top_250",
+    }.issubset(keys)

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2098,10 +2098,26 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
                     "mov-library_movies-template_collection_anilist_limit": "80",
                     "mov-library_movies-template_collection_anilist_limit_popular": "40",
                     "mov-library_movies-template_collection_anilist_limit_season": "25",
+                    "mov-library_movies-template_collection_anilist_image": "chart/color/anilist",
+                    "mov-library_movies-template_collection_anilist_url_logo_season": "https://example.com/anilist-season.png",
+                    "mov-library_movies-template_collection_anilist_sync_mode_trending": "append",
+                    "mov-library_movies-template_collection_anilist_cache_builders_season": "0",
+                    "mov-library_movies-template_collection_anilist_collection_order_top": "custom",
+                    "mov-library_movies-template_collection_anilist_radarr_folder_popular": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_anilist_sonarr_search_season": "false",
                     "mov-library_movies-collection_myanimelist": True,
                     "mov-library_movies-template_collection_myanimelist_limit": "90",
                     "mov-library_movies-template_collection_myanimelist_limit_favorited": "45",
                     "mov-library_movies-template_collection_myanimelist_limit_airing": "12",
+                    "mov-library_movies-template_collection_myanimelist_starting_only": "true",
+                    "mov-library_movies-template_collection_myanimelist_starting_only_season": "false",
+                    "mov-library_movies-template_collection_myanimelist_image": "chart/color/mal",
+                    "mov-library_movies-template_collection_myanimelist_url_logo_favorited": "https://example.com/mal-favorited.png",
+                    "mov-library_movies-template_collection_myanimelist_sync_mode_season": "append",
+                    "mov-library_movies-template_collection_myanimelist_cache_builders_airing": "0",
+                    "mov-library_movies-template_collection_myanimelist_collection_order_top": "custom",
+                    "mov-library_movies-template_collection_myanimelist_radarr_folder_favorited": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_myanimelist_sonarr_search_season": "false",
                     "mov-library_movies-collection_basic": True,
                     "mov-library_movies-template_collection_basic_limit": "20",
                     "mov-library_movies-template_collection_basic_limit_released": "10",
@@ -2115,6 +2131,15 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
                     "mov-library_movies-template_collection_letterboxd_limit_1001_movies": "80",
                     "mov-library_movies-template_collection_letterboxd_limit_top_500": "60",
                     "mov-library_movies-template_collection_letterboxd_limit_women_directors": "40",
+                    "mov-library_movies-template_collection_letterboxd_allowed_libraries": "movie",
+                    "mov-library_movies-template_collection_letterboxd_image": "chart/color/letterboxd",
+                    "mov-library_movies-template_collection_letterboxd_url_logo_top_500": "https://example.com/letterboxd-top-500.png",
+                    "mov-library_movies-template_collection_letterboxd_url_logo_cannes": "https://example.com/letterboxd-cannes.png",
+                    "mov-library_movies-template_collection_letterboxd_sync_mode_oscars": "append",
+                    "mov-library_movies-template_collection_letterboxd_cache_builders_black_directors": "0",
+                    "mov-library_movies-template_collection_letterboxd_collection_order_cannes": "custom",
+                    "mov-library_movies-template_collection_letterboxd_radarr_folder_women_directors": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_letterboxd_sonarr_search_imdb_top_250": "false",
                     "mov-library_movies-collection_imdb": True,
                     "mov-library_movies-template_collection_imdb_limit": "250",
                     "mov-library_movies-template_collection_imdb_allowed_libraries": "movie",
@@ -2195,9 +2220,25 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
     assert anilist_entry["template_variables"]["limit"] == "80"
     assert anilist_entry["template_variables"]["limit_popular"] == "40"
     assert anilist_entry["template_variables"]["limit_season"] == "25"
+    assert anilist_entry["template_variables"]["image"] == "chart/color/anilist"
+    assert anilist_entry["template_variables"]["url_logo_season"] == "https://example.com/anilist-season.png"
+    assert anilist_entry["template_variables"]["sync_mode_trending"] == "append"
+    assert anilist_entry["template_variables"]["cache_builders_season"] == "0"
+    assert anilist_entry["template_variables"]["collection_order_top"] == "custom"
+    assert anilist_entry["template_variables"]["radarr_folder_popular"] == r"C:\Media\Movies"
+    assert anilist_entry["template_variables"]["sonarr_search_season"] is False
     assert myanimelist_entry["template_variables"]["limit"] == "90"
     assert myanimelist_entry["template_variables"]["limit_favorited"] == "45"
     assert myanimelist_entry["template_variables"]["limit_airing"] == "12"
+    assert myanimelist_entry["template_variables"]["starting_only"] is True
+    assert myanimelist_entry["template_variables"]["starting_only_season"] is False
+    assert myanimelist_entry["template_variables"]["image"] == "chart/color/mal"
+    assert myanimelist_entry["template_variables"]["url_logo_favorited"] == "https://example.com/mal-favorited.png"
+    assert myanimelist_entry["template_variables"]["sync_mode_season"] == "append"
+    assert myanimelist_entry["template_variables"]["cache_builders_airing"] == "0"
+    assert myanimelist_entry["template_variables"]["collection_order_top"] == "custom"
+    assert myanimelist_entry["template_variables"]["radarr_folder_favorited"] == r"C:\Media\Movies"
+    assert myanimelist_entry["template_variables"]["sonarr_search_season"] is False
     assert basic_entry["template_variables"]["limit"] == "20"
     assert basic_entry["template_variables"]["limit_released"] == "10"
     assert basic_entry["template_variables"]["limit_episodes"] == "5"
@@ -2209,6 +2250,15 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
     assert letterboxd_entry["template_variables"]["limit_1001_movies"] == "80"
     assert letterboxd_entry["template_variables"]["limit_top_500"] == "60"
     assert letterboxd_entry["template_variables"]["limit_women_directors"] == "40"
+    assert letterboxd_entry["template_variables"]["allowed_libraries"] == "movie"
+    assert letterboxd_entry["template_variables"]["image"] == "chart/color/letterboxd"
+    assert letterboxd_entry["template_variables"]["url_logo_top_500"] == "https://example.com/letterboxd-top-500.png"
+    assert letterboxd_entry["template_variables"]["url_logo_cannes"] == "https://example.com/letterboxd-cannes.png"
+    assert letterboxd_entry["template_variables"]["sync_mode_oscars"] == "append"
+    assert letterboxd_entry["template_variables"]["cache_builders_black_directors"] == "0"
+    assert letterboxd_entry["template_variables"]["collection_order_cannes"] == "custom"
+    assert letterboxd_entry["template_variables"]["radarr_folder_women_directors"] == r"C:\Media\Movies"
+    assert letterboxd_entry["template_variables"]["sonarr_search_imdb_top_250"] is False
     assert imdb_entry["template_variables"]["limit"] == "250"
     assert imdb_entry["template_variables"]["allowed_libraries"] == "movie"
     assert imdb_entry["template_variables"]["url_logo_lowest"] == "https://example.com/lowest.png"

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -103,6 +103,13 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
                                 "limit": 80,
                                 "limit_popular": 40,
                                 "limit_season": 25,
+                                "image": "chart/color/anilist",
+                                "url_logo_season": "https://example.com/anilist-season.png",
+                                "sync_mode_trending": "append",
+                                "cache_builders_season": 0,
+                                "collection_order_top": "custom",
+                                "radarr_folder_popular": r"C:\Media\Movies",
+                                "sonarr_search_season": "false",
                             },
                         },
                         {
@@ -111,6 +118,15 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
                                 "limit": 90,
                                 "limit_favorited": 45,
                                 "limit_airing": 12,
+                                "starting_only": True,
+                                "starting_only_season": False,
+                                "image": "chart/color/mal",
+                                "url_logo_favorited": "https://example.com/mal-favorited.png",
+                                "sync_mode_season": "append",
+                                "cache_builders_airing": 0,
+                                "collection_order_top": "custom",
+                                "radarr_folder_favorited": r"C:\Media\Movies",
+                                "sonarr_search_season": "false",
                             },
                         },
                         {
@@ -132,6 +148,15 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
                                 "limit_1001_movies": 80,
                                 "limit_top_500": 60,
                                 "limit_women_directors": 40,
+                                "allowed_libraries": "movie",
+                                "image": "chart/color/letterboxd",
+                                "url_logo_top_500": "https://example.com/letterboxd-top-500.png",
+                                "url_logo_cannes": "https://example.com/letterboxd-cannes.png",
+                                "sync_mode_oscars": "append",
+                                "cache_builders_black_directors": 0,
+                                "collection_order_cannes": "custom",
+                                "radarr_folder_women_directors": r"C:\Media\Movies",
+                                "sonarr_search_imdb_top_250": "false",
                             },
                         },
                         {
@@ -227,9 +252,25 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
     assert libraries_payload["mov-library_movies-template_collection_anilist_limit"] == 80
     assert libraries_payload["mov-library_movies-template_collection_anilist_limit_popular"] == 40
     assert libraries_payload["mov-library_movies-template_collection_anilist_limit_season"] == 25
+    assert libraries_payload["mov-library_movies-template_collection_anilist_image"] == "chart/color/anilist"
+    assert libraries_payload["mov-library_movies-template_collection_anilist_url_logo_season"] == "https://example.com/anilist-season.png"
+    assert libraries_payload["mov-library_movies-template_collection_anilist_sync_mode_trending"] == "append"
+    assert libraries_payload["mov-library_movies-template_collection_anilist_cache_builders_season"] == 0
+    assert libraries_payload["mov-library_movies-template_collection_anilist_collection_order_top"] == "custom"
+    assert libraries_payload["mov-library_movies-template_collection_anilist_radarr_folder_popular"] == r"C:\Media\Movies"
+    assert libraries_payload["mov-library_movies-template_collection_anilist_sonarr_search_season"] == "false"
     assert libraries_payload["mov-library_movies-template_collection_myanimelist_limit"] == 90
     assert libraries_payload["mov-library_movies-template_collection_myanimelist_limit_favorited"] == 45
     assert libraries_payload["mov-library_movies-template_collection_myanimelist_limit_airing"] == 12
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_starting_only"] is True
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_starting_only_season"] is False
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_image"] == "chart/color/mal"
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_url_logo_favorited"] == "https://example.com/mal-favorited.png"
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_sync_mode_season"] == "append"
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_cache_builders_airing"] == 0
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_collection_order_top"] == "custom"
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_radarr_folder_favorited"] == r"C:\Media\Movies"
+    assert libraries_payload["mov-library_movies-template_collection_myanimelist_sonarr_search_season"] == "false"
     assert libraries_payload["mov-library_movies-template_collection_basic_limit"] == 20
     assert libraries_payload["mov-library_movies-template_collection_basic_limit_released"] == 10
     assert libraries_payload["mov-library_movies-template_collection_basic_limit_episodes"] == 5
@@ -241,6 +282,15 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
     assert libraries_payload["mov-library_movies-template_collection_letterboxd_limit_1001_movies"] == 80
     assert libraries_payload["mov-library_movies-template_collection_letterboxd_limit_top_500"] == 60
     assert libraries_payload["mov-library_movies-template_collection_letterboxd_limit_women_directors"] == 40
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_allowed_libraries"] == "movie"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_image"] == "chart/color/letterboxd"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_url_logo_top_500"] == "https://example.com/letterboxd-top-500.png"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_url_logo_cannes"] == "https://example.com/letterboxd-cannes.png"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_sync_mode_oscars"] == "append"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_cache_builders_black_directors"] == 0
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_collection_order_cannes"] == "custom"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_radarr_folder_women_directors"] == r"C:\Media\Movies"
+    assert libraries_payload["mov-library_movies-template_collection_letterboxd_sonarr_search_imdb_top_250"] == "false"
     assert libraries_payload["mov-library_movies-template_collection_imdb_limit"] == 250
     assert libraries_payload["mov-library_movies-template_collection_imdb_allowed_libraries"] == "movie"
     assert libraries_payload["mov-library_movies-template_collection_imdb_url_logo_lowest"] == "https://example.com/lowest.png"


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Adds the next chart collection coverage pass for `anilist`, `myanimelist`, and `letterboxd`.

- Expands Quickstart collection JSON with missing supported template variables.
- Adds shared/artwork fields, fixed child fields, custom child overrides, and ARR child overrides.
- Adds MyAnimeList `starting_only` / `starting_only_season` support.
- Preserves Letterboxd movie-only/default controls while exposing its fixed child override fields.
- Adds JSON contract coverage plus import/export assertions for the new fields.

## Testing

```powershell
venv\Scripts\python.exe -m pytest tests/test_collection_chart_anilist_mal_letterboxd_contract.py tests/test_collection_order_contract.py tests/test_collection_cache_builders_contract.py tests/test_importer_collection_files.py::test_prepare_import_payload_accepts_chart_builder_size_template_variables tests/test_core_backend.py::test_build_libraries_section_preserves_chart_builder_size_template_variables
```

Result: `11 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
