### PR TITLE
added director producer writer

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -81939,49 +81939,32 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "150",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "sep_style",
+            "label": "Separator Style",
+            "type": "text_input",
+            "tooltip": "Override the separator artwork style used before this Defaults File.",
+            "section": "basics",
+            "placeholder": "orig"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "basics"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
+            "placeholder": "Custom sort title format",
+            "section": "basics"
           },
           {
             "key": "style",
@@ -82020,7 +82003,48 @@
                 "image_url": "/static/images/people-styles/actor_diiivoycolor.webp",
                 "fallback_url": "https://kometa.wiki/en/nightly/assets/images/defaults/styles/actor_diiivoycolor.png"
               }
-            ]
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the translation key used for generated collection names and summaries.",
+            "section": "naming",
+            "placeholder": "director"
           },
           {
             "key": "data_depth",
@@ -82030,7 +82054,8 @@
             "min": 1,
             "step": 1,
             "default": "5",
-            "tooltip": "Replaces the data dynamic collection value. Controls the depth within the casting credits to search for common actors."
+            "tooltip": "Replaces the data dynamic collection value. Controls the depth within the casting credits to search for common directors.",
+            "section": "people_data"
           },
           {
             "key": "data_limit",
@@ -82040,22 +82065,8 @@
             "min": 1,
             "step": 1,
             "default": "25",
-            "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
-          },
-          {
-            "key": "tmdb_birthday",
-            "label": "TMDb Birthday",
-            "type": "text_input",
-            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
-            "placeholder": "{\"this_month\": true}"
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
-            "mutually_exclusive_with": "exclude"
+            "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create.",
+            "section": "people_data"
           },
           {
             "key": "exclude",
@@ -82063,32 +82074,33 @@
             "type": "string_list",
             "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add person name (e.g. Jeremy Kleiner)",
-            "mutually_exclusive_with": "include"
+            "mutually_exclusive_with": "include",
+            "section": "people_data"
           },
           {
-            "key": "minimum_items",
-            "label": "Minimum Items",
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude",
+            "section": "people_data"
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
             "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}",
+            "section": "people_data"
           },
           {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "key": "tmdb_deathday",
+            "label": "TMDb Deathday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's deathday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>.",
+            "placeholder": "{\"this_month\": true}",
+            "section": "people_data"
           },
           {
             "key": "collection_mode",
@@ -82113,57 +82125,61 @@
                 "value": "show_items",
                 "label": "Show this Collection and its Items"
               }
-            ]
+            ],
+            "section": "scope"
           },
           {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
+            "key": "limit",
+            "label": "Limit",
             "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "tooltip": "Changes the Builder Limit for each generated director collection.",
+            "section": "scope",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the Kometa name_mapping value for generated collections in this Defaults File.",
+            "section": "scope",
+            "placeholder": "Custom name mapping"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Configure when collections in this Defaults File update by default.",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -82500,6 +82516,413 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "type": "toggle",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting.",
+            "default": true,
+            "section": "scope"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Limit Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for limit overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "25",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Minimum Items Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for minimum items overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "2",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Name Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for name overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "Custom collection name",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Sort Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for sort order overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "01, 02, etc.",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for schedule overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for sort by overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "title.asc, release.desc, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Summary Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for summary overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "Custom collection summary",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_tmdb_person_offset_overrides",
+            "label": "TMDb Person Offset Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for tmdb person offset overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "0, 1, 2, etc.",
+            "dynamic_child_prefix": "tmdb_person_offset_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Use Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for use overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Background File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for background file overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "C:\\Path\\To\\background.jpg",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Logo File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for logo file overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "C:\\Path\\To\\logo.png",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Poster File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for poster file overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "C:\\Path\\To\\poster.jpg",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Square Art File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for square art file overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "C:\\Path\\To\\square-art.png",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for background url overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for logo url overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for poster url overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for square art url overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "https://example.com/square-art.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\background.jpg"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\logo.png"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\poster.jpg"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\square-art.png"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Hub Priority Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for hub priority overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for item radarr tag overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for item sonarr tag overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Visible Home Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible home overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Visible Library Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible library overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Visible Shared Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible shared overrides.",
+            "key_placeholder": "Director name (e.g. Christopher Nolan)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility",
+            "media_types": [
+              "movie"
             ]
           },
           {
@@ -82510,7 +82933,83 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "people_data",
+            "label": "People Data"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Actor Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -82531,49 +83030,32 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "160",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "sep_style",
+            "label": "Separator Style",
+            "type": "text_input",
+            "tooltip": "Override the separator artwork style used before this Defaults File.",
+            "section": "basics",
+            "placeholder": "orig"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "basics"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
+            "placeholder": "Custom sort title format",
+            "section": "basics"
           },
           {
             "key": "style",
@@ -82612,7 +83094,48 @@
                 "image_url": "/static/images/people-styles/actor_diiivoycolor.webp",
                 "fallback_url": "https://kometa.wiki/en/nightly/assets/images/defaults/styles/actor_diiivoycolor.png"
               }
-            ]
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the translation key used for generated collection names and summaries.",
+            "section": "naming",
+            "placeholder": "producer"
           },
           {
             "key": "data_depth",
@@ -82622,7 +83145,8 @@
             "min": 1,
             "step": 1,
             "default": "5",
-            "tooltip": "Replaces the data dynamic collection value. Controls the depth within the casting credits to search for common actors."
+            "tooltip": "Replaces the data dynamic collection value. Controls the depth within the casting credits to search for common producers.",
+            "section": "people_data"
           },
           {
             "key": "data_limit",
@@ -82632,22 +83156,8 @@
             "min": 1,
             "step": 1,
             "default": "25",
-            "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
-          },
-          {
-            "key": "tmdb_birthday",
-            "label": "TMDb Birthday",
-            "type": "text_input",
-            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
-            "placeholder": "{\"this_month\": true}"
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
-            "mutually_exclusive_with": "exclude"
+            "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create.",
+            "section": "people_data"
           },
           {
             "key": "exclude",
@@ -82655,32 +83165,33 @@
             "type": "string_list",
             "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add person name (e.g. Jeremy Kleiner)",
-            "mutually_exclusive_with": "include"
+            "mutually_exclusive_with": "include",
+            "section": "people_data"
           },
           {
-            "key": "minimum_items",
-            "label": "Minimum Items",
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude",
+            "section": "people_data"
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
             "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}",
+            "section": "people_data"
           },
           {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "key": "tmdb_deathday",
+            "label": "TMDb Deathday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's deathday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>.",
+            "placeholder": "{\"this_month\": true}",
+            "section": "people_data"
           },
           {
             "key": "collection_mode",
@@ -82705,57 +83216,61 @@
                 "value": "show_items",
                 "label": "Show this Collection and its Items"
               }
-            ]
+            ],
+            "section": "scope"
           },
           {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
+            "key": "limit",
+            "label": "Limit",
             "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "tooltip": "Changes the Builder Limit for each generated producer collection.",
+            "section": "scope",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the Kometa name_mapping value for generated collections in this Defaults File.",
+            "section": "scope",
+            "placeholder": "Custom name mapping"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Configure when collections in this Defaults File update by default.",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -83092,6 +83607,413 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "type": "toggle",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting.",
+            "default": true,
+            "section": "scope"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Limit Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for limit overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "25",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Minimum Items Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for minimum items overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "2",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Name Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for name overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "Custom collection name",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Sort Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for sort order overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "01, 02, etc.",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for schedule overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for sort by overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "title.asc, release.desc, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Summary Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for summary overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "Custom collection summary",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_tmdb_person_offset_overrides",
+            "label": "TMDb Person Offset Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for tmdb person offset overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "0, 1, 2, etc.",
+            "dynamic_child_prefix": "tmdb_person_offset_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Use Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for use overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Background File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for background file overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "C:\\Path\\To\\background.jpg",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Logo File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for logo file overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "C:\\Path\\To\\logo.png",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Poster File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for poster file overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "C:\\Path\\To\\poster.jpg",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Square Art File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for square art file overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "C:\\Path\\To\\square-art.png",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for background url overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for logo url overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for poster url overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for square art url overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "https://example.com/square-art.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\background.jpg"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\logo.png"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\poster.jpg"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\square-art.png"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Hub Priority Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for hub priority overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for item radarr tag overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for item sonarr tag overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Visible Home Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible home overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Visible Library Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible library overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Visible Shared Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible shared overrides.",
+            "key_placeholder": "Producer name (e.g. Kathleen Kennedy)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility",
+            "media_types": [
+              "movie"
             ]
           },
           {
@@ -83102,7 +84024,83 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "people_data",
+            "label": "People Data"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Actor Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -83123,49 +84121,32 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "170",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "sep_style",
+            "label": "Separator Style",
+            "type": "text_input",
+            "tooltip": "Override the separator artwork style used before this Defaults File.",
+            "section": "basics",
+            "placeholder": "orig"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "basics"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
+            "placeholder": "Custom sort title format",
+            "section": "basics"
           },
           {
             "key": "style",
@@ -83204,7 +84185,48 @@
                 "image_url": "/static/images/people-styles/actor_diiivoycolor.webp",
                 "fallback_url": "https://kometa.wiki/en/nightly/assets/images/defaults/styles/actor_diiivoycolor.png"
               }
-            ]
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the translation key used for generated collection names and summaries.",
+            "section": "naming",
+            "placeholder": "writer"
           },
           {
             "key": "data_depth",
@@ -83214,7 +84236,8 @@
             "min": 1,
             "step": 1,
             "default": "5",
-            "tooltip": "Replaces the data dynamic collection value. Controls the depth within the casting credits to search for common actors."
+            "tooltip": "Replaces the data dynamic collection value. Controls the depth within the casting credits to search for common writers.",
+            "section": "people_data"
           },
           {
             "key": "data_limit",
@@ -83224,22 +84247,8 @@
             "min": 1,
             "step": 1,
             "default": "25",
-            "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
-          },
-          {
-            "key": "tmdb_birthday",
-            "label": "TMDb Birthday",
-            "type": "text_input",
-            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
-            "placeholder": "{\"this_month\": true}"
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
-            "mutually_exclusive_with": "exclude"
+            "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create.",
+            "section": "people_data"
           },
           {
             "key": "exclude",
@@ -83247,32 +84256,33 @@
             "type": "string_list",
             "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add person name (e.g. Jeremy Kleiner)",
-            "mutually_exclusive_with": "include"
+            "mutually_exclusive_with": "include",
+            "section": "people_data"
           },
           {
-            "key": "minimum_items",
-            "label": "Minimum Items",
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude",
+            "section": "people_data"
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
             "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}",
+            "section": "people_data"
           },
           {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "key": "tmdb_deathday",
+            "label": "TMDb Deathday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's deathday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>.",
+            "placeholder": "{\"this_month\": true}",
+            "section": "people_data"
           },
           {
             "key": "collection_mode",
@@ -83297,57 +84307,61 @@
                 "value": "show_items",
                 "label": "Show this Collection and its Items"
               }
-            ]
+            ],
+            "section": "scope"
           },
           {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
+            "key": "limit",
+            "label": "Limit",
             "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "tooltip": "Changes the Builder Limit for each generated writer collection.",
+            "section": "scope",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the Kometa name_mapping value for generated collections in this Defaults File.",
+            "section": "scope",
+            "placeholder": "Custom name mapping"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Configure when collections in this Defaults File update by default.",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -83684,6 +84698,413 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "type": "toggle",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting.",
+            "default": true,
+            "section": "scope"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Limit Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for limit overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "25",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Minimum Items Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for minimum items overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "2",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Name Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for name overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "Custom collection name",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Sort Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for sort order overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "01, 02, etc.",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for schedule overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for sort by overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "title.asc, release.desc, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Summary Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for summary overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "Custom collection summary",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_tmdb_person_offset_overrides",
+            "label": "TMDb Person Offset Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for tmdb person offset overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "0, 1, 2, etc.",
+            "dynamic_child_prefix": "tmdb_person_offset_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Use Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for use overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Background File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for background file overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "C:\\Path\\To\\background.jpg",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Logo File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for logo file overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "C:\\Path\\To\\logo.png",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Poster File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for poster file overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "C:\\Path\\To\\poster.jpg",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Square Art File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for square art file overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "C:\\Path\\To\\square-art.png",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for background url overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for logo url overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for poster url overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for square art url overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "https://example.com/square-art.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\background.jpg"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\logo.png"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\poster.jpg"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\square-art.png"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Hub Priority Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for hub priority overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for item radarr tag overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for item sonarr tag overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Visible Home Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible home overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Visible Library Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible library overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Visible Shared Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a child key to an override for visible shared overrides.",
+            "key_placeholder": "Writer name (e.g. Charlie Kaufman)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "name_like"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility",
+            "media_types": [
+              "movie"
             ]
           },
           {
@@ -83694,7 +85115,83 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "media_types": [
+              "movie"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "people_data",
+            "label": "People Data"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Actor Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       }

--- a/tests/test_collection_genre_other_chart_actor_contract.py
+++ b/tests/test_collection_genre_other_chart_actor_contract.py
@@ -118,3 +118,28 @@ def test_actor_collection_exposes_person_specific_defaults_and_dynamic_maps():
     }
     for key, (child_prefix, value_kind, section, validation_preset, media_types) in expected_mappings.items():
         _assert_mapping(fields[key], child_prefix, value_kind, section, "name_like", validation_preset=validation_preset, media_types=media_types)
+
+
+def test_movie_person_collections_match_actor_dynamic_person_contract():
+    for collection_id in ["collection_director", "collection_producer", "collection_writer"]:
+        collection = _load_collection(collection_id, ("movie",))
+        fields = _field_map(collection)
+
+        section_ids = [section.get("id") for section in collection.get("template_variable_sections") or [] if isinstance(section, dict)]
+        assert section_ids == ["basics", "naming", "people_data", "scope", "child_override_maps", "artwork", "visibility"]
+
+        for key in ["sep_style", "translation_key", "use_all", "limit", "schedule", "tmdb_deathday", "file_poster", "url_poster"]:
+            assert key in fields
+
+        expected_mappings = {
+            "child_use_overrides": ("use_", "boolean", "child_override_maps", None, None),
+            "child_name_overrides": ("name_", "string", "child_override_maps", None, None),
+            "child_tmdb_person_offset_overrides": ("tmdb_person_offset_", "integer", "child_override_maps", None, None),
+            "child_limit_overrides": ("limit_", "integer", "child_override_maps", None, None),
+            "child_file_poster_overrides": ("file_poster_", "string", "artwork", None, None),
+            "child_url_poster_overrides": ("url_poster_", "string", "artwork", "url", None),
+            "child_visible_library_overrides": ("visible_library_", "boolean", "visibility", None, None),
+            "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "visibility", None, ["movie"]),
+        }
+        for key, (child_prefix, value_kind, section, validation_preset, media_types) in expected_mappings.items():
+            _assert_mapping(fields[key], child_prefix, value_kind, section, "name_like", validation_preset=validation_preset, media_types=media_types)

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -809,6 +809,74 @@ def test_prepare_import_payload_collapses_actor_dynamic_child_template_variables
     assert any("libraries.Movies.collection_files[0].template_variables.tmdb_person_offset_Tom Hanks" in line for line in report.lines)
 
 
+def test_prepare_import_payload_collapses_movie_person_dynamic_child_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "collection_files": [
+                        {
+                            "default": "director",
+                            "template_variables": {
+                                "tmdb_person_offset_Christopher Nolan": 1,
+                                "name_Christopher Nolan": "Nolan Favorites",
+                                "limit_Christopher Nolan": 50,
+                                "file_poster_Christopher Nolan": r"C:\Posters\nolan.jpg",
+                                "visible_library_Christopher Nolan": False,
+                            },
+                        },
+                        {
+                            "default": "producer",
+                            "template_variables": {
+                                "tmdb_person_offset_Kathleen Kennedy": 2,
+                                "name_Kathleen Kennedy": "Kennedy Produced",
+                                "limit_Kathleen Kennedy": 40,
+                                "file_poster_Kathleen Kennedy": r"C:\Posters\kennedy.jpg",
+                                "visible_library_Kathleen Kennedy": True,
+                            },
+                        },
+                        {
+                            "default": "writer",
+                            "template_variables": {
+                                "tmdb_person_offset_Charlie Kaufman": 3,
+                                "name_Charlie Kaufman": "Kaufman Written",
+                                "limit_Charlie Kaufman": 30,
+                                "file_poster_Charlie Kaufman": r"C:\Posters\kaufman.jpg",
+                                "visible_library_Charlie Kaufman": False,
+                            },
+                        },
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-collection_director"] is True
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_director_child_name_overrides"]) == {"Christopher Nolan": "Nolan Favorites"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_director_child_tmdb_person_offset_overrides"]) == {"Christopher Nolan": "1"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_director_child_limit_overrides"]) == {"Christopher Nolan": "50"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_director_child_file_poster_overrides"]) == {"Christopher Nolan": r"C:\Posters\nolan.jpg"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_director_child_visible_library_overrides"]) == {"Christopher Nolan": "false"}
+    assert libraries_payload["mov-library_movies-collection_producer"] is True
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_producer_child_name_overrides"]) == {"Kathleen Kennedy": "Kennedy Produced"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_producer_child_tmdb_person_offset_overrides"]) == {"Kathleen Kennedy": "2"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_producer_child_limit_overrides"]) == {"Kathleen Kennedy": "40"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_producer_child_file_poster_overrides"]) == {"Kathleen Kennedy": r"C:\Posters\kennedy.jpg"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_producer_child_visible_library_overrides"]) == {"Kathleen Kennedy": "true"}
+    assert libraries_payload["mov-library_movies-collection_writer"] is True
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_writer_child_name_overrides"]) == {"Charlie Kaufman": "Kaufman Written"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_writer_child_tmdb_person_offset_overrides"]) == {"Charlie Kaufman": "3"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_writer_child_limit_overrides"]) == {"Charlie Kaufman": "30"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_writer_child_file_poster_overrides"]) == {"Charlie Kaufman": r"C:\Posters\kaufman.jpg"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_writer_child_visible_library_overrides"]) == {"Charlie Kaufman": "false"}
+    assert any("libraries.Movies.collection_files[0].template_variables.tmdb_person_offset_Christopher Nolan" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[1].template_variables.tmdb_person_offset_Kathleen Kennedy" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[2].template_variables.tmdb_person_offset_Charlie Kaufman" in line for line in report.lines)
+
+
 def test_prepare_import_payload_collapses_year_dynamic_child_template_variables():
     payload, report = importer.prepare_import_payload(
         {

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -1,3 +1,5 @@
+import json
+
 from modules import output_collections
 
 
@@ -263,6 +265,30 @@ def test_apply_template_var_normalizers_expands_actor_dynamic_child_override_map
     assert template_vars["limit_Tom Hanks"] == 50
     assert template_vars["file_poster_Tom Hanks"] == r"C:\Posters\tom-hanks.jpg"
     assert template_vars["visible_library_Tom Hanks"] is False
+
+
+def test_apply_template_var_normalizers_expands_movie_person_dynamic_child_override_maps():
+    examples = [
+        ("director", "Christopher Nolan", "Nolan Favorites", "1", r"C:\Posters\nolan.jpg"),
+        ("producer", "Kathleen Kennedy", "Kennedy Produced", "2", r"C:\Posters\kennedy.jpg"),
+        ("writer", "Charlie Kaufman", "Kaufman Written", "3", r"C:\Posters\kaufman.jpg"),
+    ]
+    for default_name, person_name, name_override, offset, poster_path in examples:
+        template_vars = {
+            "child_name_overrides": json.dumps({person_name: name_override}),
+            "child_tmdb_person_offset_overrides": json.dumps({person_name: offset}),
+            "child_limit_overrides": json.dumps({person_name: "50"}),
+            "child_file_poster_overrides": json.dumps({person_name: poster_path}),
+            "child_visible_library_overrides": json.dumps({person_name: "false"}),
+        }
+
+        output_collections._apply_template_var_normalizers(template_vars, default_name)
+
+        assert template_vars[f"name_{person_name}"] == name_override
+        assert template_vars[f"tmdb_person_offset_{person_name}"] == int(offset)
+        assert template_vars[f"limit_{person_name}"] == 50
+        assert template_vars[f"file_poster_{person_name}"] == poster_path
+        assert template_vars[f"visible_library_{person_name}"] is False
 
 
 def test_apply_template_var_normalizers_expands_year_dynamic_child_override_maps():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Adds dynamic person collection coverage for `director`, `producer`, and `writer`.

- Expands Quickstart collection JSON so all three movie person defaults match the existing `actor` contract.
- Adds sectioned UI metadata for basics, naming, people data, scope, child override maps, artwork, and visibility.
- Adds shared/default controls and dynamic child override maps, including `tmdb_person_offset_`, child names, limits, posters, visibility, and item Radarr tags.
- Adds importer coverage for collapsing keyed template variables like `tmdb_person_offset_Christopher Nolan`.
- Adds exporter/normalizer coverage so dynamic child override maps expand back to Kometa template variables.

## Testing

```powershell
venv\Scripts\python.exe -m pytest tests/test_collection_genre_other_chart_actor_contract.py tests/test_importer_collection_files.py::test_prepare_import_payload_collapses_actor_dynamic_child_template_variables tests/test_importer_collection_files.py::test_prepare_import_payload_collapses_movie_person_dynamic_child_template_variables tests/test_output_collection_child_override_contract.py
```

Result: `19 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
