### PR TITLE
aspect and resolution added

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -81312,357 +81312,24 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "125",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
-          },
-          {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
             "key": "use_all",
             "label": "Use All Child Collections",
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
             "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_1.33",
-            "label": "1.33 - Academy Aperture",
-            "tooltip": "Collection of Movies/Shows with a 1.33 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_1.33",
-            "label": "1.33 - Academy Aperture Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 1.33 - Academy Aperture collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_1.33",
-            "label": "1.33 - Academy Aperture Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 1.33 - Academy Aperture collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_1.33",
-            "label": "1.33 - Academy Aperture Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.33 - Academy Aperture collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_1.65",
-            "label": "1.65 - Early Widescreen",
-            "tooltip": "Collection of Movies/Shows with a 1.65 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_1.65",
-            "label": "1.65 - Early Widescreen Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 1.65 - Early Widescreen collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_1.65",
-            "label": "1.65 - Early Widescreen Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 1.65 - Early Widescreen collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_1.65",
-            "label": "1.65 - Early Widescreen Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.65 - Early Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_1.66",
-            "label": "1.66 - European Widescreen",
-            "tooltip": "Collection of Movies/Shows with a 1.66 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_1.66",
-            "label": "1.66 - European Widescreen Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 1.66 - European Widescreen collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_1.66",
-            "label": "1.66 - European Widescreen Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 1.66 - European Widescreen collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_1.66",
-            "label": "1.66 - European Widescreen Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.66 - European Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_1.78",
-            "label": "1.78 - Widescreen TV",
-            "tooltip": "Collection of Movies/Shows with a 1.78 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_1.78",
-            "label": "1.78 - Widescreen TV Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 1.78 - Widescreen TV collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_1.78",
-            "label": "1.78 - Widescreen TV Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 1.78 - Widescreen TV collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_1.78",
-            "label": "1.78 - Widescreen TV Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.78 - Widescreen TV collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_1.85",
-            "label": "1.85 - American Widescreen",
-            "tooltip": "Collection of Movies/Shows with a 1.85 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_1.85",
-            "label": "1.85 - American Widescreen Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 1.85 - American Widescreen collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_1.85",
-            "label": "1.85 - American Widescreen Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 1.85 - American Widescreen collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_1.85",
-            "label": "1.85 - American Widescreen Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.85 - American Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_2.2",
-            "label": "2.2 - 70mm Frame",
-            "tooltip": "Collection of Movies/Shows with a 2.2 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_2.2",
-            "label": "2.2 - 70mm Frame Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 2.2 - 70mm Frame collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_2.2",
-            "label": "2.2 - 70mm Frame Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 2.2 - 70mm Frame collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_2.2",
-            "label": "2.2 - 70mm Frame Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 2.2 - 70mm Frame collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_2.35",
-            "label": "2.35 - Anamorphic Projection",
-            "tooltip": "Collection of Movies/Shows with a 2.35 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_2.35",
-            "label": "2.35 - Anamorphic Projection Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 2.35 - Anamorphic Projection collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_2.35",
-            "label": "2.35 - Anamorphic Projection Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 2.35 - Anamorphic Projection collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_2.35",
-            "label": "2.35 - Anamorphic Projection Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 2.35 - Anamorphic Projection collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_2.77",
-            "label": "2.77 - Cinerama",
-            "tooltip": "Collection of Movies/Shows with a 2.77 aspect ratio.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_2.77",
-            "label": "2.77 - Cinerama Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the 2.77 - Cinerama collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_2.77",
-            "label": "2.77 - Cinerama Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the 2.77 - Cinerama collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_2.77",
-            "label": "2.77 - Cinerama Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 2.77 - Cinerama collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific aspect ratios from these collections.",
-            "placeholder": "Add aspect ratio key (e.g. 1.65)"
-          },
-          {
-            "key": "minimum_items",
-            "label": "Minimum Items",
-            "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "item_sonarr_tag",
-            "label": "Item Sonarr Tag",
-            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Sonarr tag",
-            "media_types": [
-              "show"
-            ]
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sync_mode",
@@ -81679,374 +81346,125 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "basics"
           },
           {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
             "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "aspect"
+          },
+          {
+            "key": "filter_term",
+            "label": "Filter Term",
+            "type": "text_input",
+            "tooltip": "Filter term used by aspect ratio collections.",
+            "section": "scope",
+            "default": "aspect"
+          },
+          {
+            "key": "filter_term2",
+            "label": "Secondary Filter Term",
+            "type": "text_input",
+            "tooltip": "Optional secondary filter term.",
+            "section": "scope"
+          },
+          {
+            "key": "filter_value2",
+            "label": "Secondary Filter Value",
+            "type": "text_input",
+            "tooltip": "Optional secondary filter value.",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific aspect ratios from these collections.",
+            "placeholder": "Add aspect ratio key (e.g. 1.65)",
+            "section": "scope",
+            "validation_preset": "aspect_key"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "scope"
           },
           {
-            "key": "visible_home_1.33",
-            "label": "1.33 - Academy Aperture Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_1.33",
-            "label": "1.33 - Academy Aperture Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_1.33",
-            "label": "1.33 - Academy Aperture Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_1.33",
-            "label": "1.33 - Academy Aperture Hub Priority",
+            "key": "minimum_items",
+            "label": "Minimum Items",
             "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_1.33",
-              "visible_library_1.33",
-              "visible_shared_1.33"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "scope"
           },
           {
-            "key": "visible_home_1.65",
-            "label": "1.65 - Early Widescreen Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
-            "key": "visible_library_1.65",
-            "label": "1.65 - Early Widescreen Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_1.65",
-            "label": "1.65 - Early Widescreen Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_1.65",
-            "label": "1.65 - Early Widescreen Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_1.65",
-              "visible_library_1.65",
-              "visible_shared_1.65"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_1.66",
-            "label": "1.66 - European Widescreen Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_1.66",
-            "label": "1.66 - European Widescreen Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_1.66",
-            "label": "1.66 - European Widescreen Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_1.66",
-            "label": "1.66 - European Widescreen Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_1.66",
-              "visible_library_1.66",
-              "visible_shared_1.66"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_1.78",
-            "label": "1.78 - Widescreen TV Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_1.78",
-            "label": "1.78 - Widescreen TV Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_1.78",
-            "label": "1.78 - Widescreen TV Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_1.78",
-            "label": "1.78 - Widescreen TV Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_1.78",
-              "visible_library_1.78",
-              "visible_shared_1.78"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_1.85",
-            "label": "1.85 - American Widescreen Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_1.85",
-            "label": "1.85 - American Widescreen Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_1.85",
-            "label": "1.85 - American Widescreen Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_1.85",
-            "label": "1.85 - American Widescreen Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_1.85",
-              "visible_library_1.85",
-              "visible_shared_1.85"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_2.2",
-            "label": "2.2 - 70mm Frame Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_2.2",
-            "label": "2.2 - 70mm Frame Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_2.2",
-            "label": "2.2 - 70mm Frame Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_2.2",
-            "label": "2.2 - 70mm Frame Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_2.2",
-              "visible_library_2.2",
-              "visible_shared_2.2"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_2.35",
-            "label": "2.35 - Anamorphic Projection Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_2.35",
-            "label": "2.35 - Anamorphic Projection Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_2.35",
-            "label": "2.35 - Anamorphic Projection Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_2.35",
-            "label": "2.35 - Anamorphic Projection Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_2.35",
-              "visible_library_2.35",
-              "visible_shared_2.35"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_2.77",
-            "label": "2.77 - Cinerama Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the 2.77 - Cinerama collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_2.77",
-            "label": "2.77 - Cinerama Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the 2.77 - Cinerama collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_2.77",
-            "label": "2.77 - Cinerama Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the 2.77 - Cinerama collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_2.77",
-            "label": "2.77 - Cinerama Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_2.77",
-              "visible_library_2.77",
-              "visible_shared_2.77"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -82383,7 +81801,1040 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "schedule",
+            "tooltip": "Schedule all collections in this Defaults File.",
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text_input",
+            "tooltip": "Override the Plex collection name mapping for this Defaults File.",
+            "section": "scope"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "tooltip": "Delete existing collections with these exact names before creating this Defaults File.",
+            "placeholder": "Add collection title to delete",
+            "section": "scope"
+          },
+          {
+            "key": "use_1.33",
+            "label": "1.33 - Academy Aperture",
+            "tooltip": "Collection of Movies/Shows with a 1.33 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_1.33",
+            "label": "1.33 - Academy Aperture Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 1.33 - Academy Aperture collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_1.33",
+            "label": "1.33 - Academy Aperture Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 1.33 - Academy Aperture collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_1.33",
+            "label": "1.33 - Academy Aperture Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 1.33 - Academy Aperture collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_1.65",
+            "label": "1.65 - Early Widescreen",
+            "tooltip": "Collection of Movies/Shows with a 1.65 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_1.65",
+            "label": "1.65 - Early Widescreen Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 1.65 - Early Widescreen collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_1.65",
+            "label": "1.65 - Early Widescreen Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 1.65 - Early Widescreen collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_1.65",
+            "label": "1.65 - Early Widescreen Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 1.65 - Early Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_1.66",
+            "label": "1.66 - European Widescreen",
+            "tooltip": "Collection of Movies/Shows with a 1.66 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_1.66",
+            "label": "1.66 - European Widescreen Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 1.66 - European Widescreen collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_1.66",
+            "label": "1.66 - European Widescreen Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 1.66 - European Widescreen collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_1.66",
+            "label": "1.66 - European Widescreen Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 1.66 - European Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_1.78",
+            "label": "1.78 - Widescreen TV",
+            "tooltip": "Collection of Movies/Shows with a 1.78 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_1.78",
+            "label": "1.78 - Widescreen TV Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 1.78 - Widescreen TV collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_1.78",
+            "label": "1.78 - Widescreen TV Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 1.78 - Widescreen TV collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_1.78",
+            "label": "1.78 - Widescreen TV Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 1.78 - Widescreen TV collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_1.85",
+            "label": "1.85 - American Widescreen",
+            "tooltip": "Collection of Movies/Shows with a 1.85 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_1.85",
+            "label": "1.85 - American Widescreen Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 1.85 - American Widescreen collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_1.85",
+            "label": "1.85 - American Widescreen Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 1.85 - American Widescreen collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_1.85",
+            "label": "1.85 - American Widescreen Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 1.85 - American Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_2.2",
+            "label": "2.2 - 70mm Frame",
+            "tooltip": "Collection of Movies/Shows with a 2.2 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_2.2",
+            "label": "2.2 - 70mm Frame Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 2.2 - 70mm Frame collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_2.2",
+            "label": "2.2 - 70mm Frame Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 2.2 - 70mm Frame collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_2.2",
+            "label": "2.2 - 70mm Frame Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 2.2 - 70mm Frame collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_2.35",
+            "label": "2.35 - Anamorphic Projection",
+            "tooltip": "Collection of Movies/Shows with a 2.35 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_2.35",
+            "label": "2.35 - Anamorphic Projection Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 2.35 - Anamorphic Projection collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_2.35",
+            "label": "2.35 - Anamorphic Projection Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 2.35 - Anamorphic Projection collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_2.35",
+            "label": "2.35 - Anamorphic Projection Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 2.35 - Anamorphic Projection collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "use_2.77",
+            "label": "2.77 - Cinerama",
+            "tooltip": "Collection of Movies/Shows with a 2.77 aspect ratio.",
+            "type": "toggle",
+            "default": true,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "name_2.77",
+            "label": "2.77 - Cinerama Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the 2.77 - Cinerama collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "summary_2.77",
+            "label": "2.77 - Cinerama Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the 2.77 - Cinerama collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "limit_2.77",
+            "label": "2.77 - Cinerama Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the 2.77 - Cinerama collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "aspect_ratios"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Aspect Ratio Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Aspect Ratio Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Aspect Ratio Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Aspect Ratio Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sync_mode_overrides",
+            "label": "Aspect Ratio Sync Mode Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sync_mode_",
+            "dynamic_child_value_kind": "select",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "append or sync",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "aspect/<<key>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Default poster URL used when a child-specific poster override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Default local poster file used when a child-specific poster override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Default background URL used when a child-specific background override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Default local background file used when a child-specific background override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Default logo URL used when a child-specific logo override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Default local logo file used when a child-specific logo override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Default square art URL used when a child-specific square-art override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Default local square art file used when a child-specific square-art override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\square.png"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Aspect Ratio Poster URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Aspect Ratio Poster File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "C:\\Posters\\poster.jpg",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Aspect Ratio Background URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Aspect Ratio Background File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "C:\\Posters\\background.jpg",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Aspect Ratio Logo URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "https://example.com/logo.png",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Aspect Ratio Logo File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "C:\\Posters\\logo.png",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Aspect Ratio Square Art URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "https://example.com/square.png",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Aspect Ratio Square Art File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "C:\\Posters\\square.png",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_1.33",
+            "label": "1.33 - Academy Aperture Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_1.33",
+            "label": "1.33 - Academy Aperture Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_1.33",
+            "label": "1.33 - Academy Aperture Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_1.33",
+            "label": "1.33 - Academy Aperture Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.33",
+              "visible_library_1.33",
+              "visible_shared_1.33"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_1.65",
+            "label": "1.65 - Early Widescreen Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_1.65",
+            "label": "1.65 - Early Widescreen Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_1.65",
+            "label": "1.65 - Early Widescreen Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_1.65",
+            "label": "1.65 - Early Widescreen Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.65",
+              "visible_library_1.65",
+              "visible_shared_1.65"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_1.66",
+            "label": "1.66 - European Widescreen Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_1.66",
+            "label": "1.66 - European Widescreen Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_1.66",
+            "label": "1.66 - European Widescreen Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_1.66",
+            "label": "1.66 - European Widescreen Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.66",
+              "visible_library_1.66",
+              "visible_shared_1.66"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_1.78",
+            "label": "1.78 - Widescreen TV Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_1.78",
+            "label": "1.78 - Widescreen TV Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_1.78",
+            "label": "1.78 - Widescreen TV Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_1.78",
+            "label": "1.78 - Widescreen TV Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.78",
+              "visible_library_1.78",
+              "visible_shared_1.78"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_1.85",
+            "label": "1.85 - American Widescreen Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_1.85",
+            "label": "1.85 - American Widescreen Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_1.85",
+            "label": "1.85 - American Widescreen Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_1.85",
+            "label": "1.85 - American Widescreen Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.85",
+              "visible_library_1.85",
+              "visible_shared_1.85"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_2.2",
+            "label": "2.2 - 70mm Frame Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_2.2",
+            "label": "2.2 - 70mm Frame Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_2.2",
+            "label": "2.2 - 70mm Frame Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_2.2",
+            "label": "2.2 - 70mm Frame Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_2.2",
+              "visible_library_2.2",
+              "visible_shared_2.2"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_2.35",
+            "label": "2.35 - Anamorphic Projection Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_2.35",
+            "label": "2.35 - Anamorphic Projection Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_2.35",
+            "label": "2.35 - Anamorphic Projection Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_2.35",
+            "label": "2.35 - Anamorphic Projection Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_2.35",
+              "visible_library_2.35",
+              "visible_shared_2.35"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_2.77",
+            "label": "2.77 - Cinerama Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 2.77 - Cinerama collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_2.77",
+            "label": "2.77 - Cinerama Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 2.77 - Cinerama collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_2.77",
+            "label": "2.77 - Cinerama Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 2.77 - Cinerama collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_2.77",
+            "label": "2.77 - Cinerama Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_2.77",
+              "visible_library_2.77",
+              "visible_shared_2.77"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Aspect Ratio Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "technical,collection",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Aspect Ratio Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_validation_preset": "aspect_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Aspect ratio key (e.g. 1.78)",
+            "value_placeholder": "technical,collection",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "aspect_ratios",
+            "label": "Aspect Ratios"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Aspect Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -82403,58 +82854,24 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "120",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "style",
@@ -82472,7 +82889,85 @@
                 "value": "standards",
                 "label": "Standards"
               }
-            ]
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "resolution"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by resolution collections.",
+            "section": "scope",
+            "default": "resolution"
+          },
+          {
+            "key": "search_term2",
+            "label": "Secondary Search Term",
+            "type": "text_input",
+            "tooltip": "Optional secondary smart-filter search term.",
+            "section": "scope"
+          },
+          {
+            "key": "search_value2",
+            "label": "Secondary Search Value",
+            "type": "text_input",
+            "tooltip": "Optional secondary smart-filter search value.",
+            "section": "scope"
+          },
+          {
+            "key": "type",
+            "label": "Smart Filter Type",
+            "type": "text_input",
+            "tooltip": "Optional smart-filter type override.",
+            "section": "scope"
           },
           {
             "key": "include",
@@ -82480,14 +82975,18 @@
             "type": "string_list",
             "tooltip": "Only create collections for these resolutions. Kometa code allows this with Exclude, but the wiki says not to combine them.",
             "placeholder": "Add resolution key (e.g. 4k)",
-            "mutually_exclusive_with": "exclude"
+            "mutually_exclusive_with": "exclude",
+            "section": "scope",
+            "validation_preset": "resolution_key"
           },
           {
             "key": "append_include",
             "label": "Append Include",
             "type": "string_list",
             "tooltip": "Append additional resolutions to the default include list for this Defaults File.",
-            "placeholder": "Add resolution key (e.g. 4k)"
+            "placeholder": "Add resolution key (e.g. 4k)",
+            "section": "scope",
+            "validation_preset": "resolution_key"
           },
           {
             "key": "exclude",
@@ -82495,7 +82994,9 @@
             "type": "string_list",
             "tooltip": "Exclude specific resolutions from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add resolution key (e.g. 4k)",
-            "mutually_exclusive_with": "include"
+            "mutually_exclusive_with": "include",
+            "section": "scope",
+            "validation_preset": "resolution_key"
           },
           {
             "key": "addons",
@@ -82503,7 +83004,8 @@
             "type": "mapping_list",
             "tooltip": "Map a base value to additional resolutions that should be grouped into that collection.",
             "key_placeholder": "Base resolution (e.g. 4k)",
-            "value_placeholder": "Add comma-separated resolutions (e.g. 2160p, uhd)"
+            "value_placeholder": "Add comma-separated resolutions (e.g. 2160p, uhd)",
+            "section": "scope"
           },
           {
             "key": "append_addons",
@@ -82511,7 +83013,18 @@
             "type": "mapping_list",
             "tooltip": "Append additional resolutions mappings to the default addons dictionary for this Defaults File.",
             "key_placeholder": "Base resolution (e.g. 4k)",
-            "value_placeholder": "Add comma-separated resolutions (e.g. 2160p, uhd)"
+            "value_placeholder": "Add comma-separated resolutions (e.g. 2160p, uhd)",
+            "section": "scope"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -82520,7 +83033,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -82528,7 +83042,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -82536,70 +83051,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -82936,7 +83389,452 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "schedule",
+            "tooltip": "Schedule all collections in this Defaults File.",
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text_input",
+            "tooltip": "Override the Plex collection name mapping for this Defaults File.",
+            "section": "scope"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "tooltip": "Delete existing collections with these exact names before creating this Defaults File.",
+            "placeholder": "Add collection title to delete",
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an Other collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection.",
+            "section": "other_collection",
+            "placeholder": "Custom collection name format"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection.",
+            "section": "other_collection",
+            "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection.",
+            "section": "other_collection",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Resolution Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Resolution Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Resolution Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Resolution Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Resolution Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Resolution Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Resolution Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Resolution Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "resolution/<<key>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Default poster URL used when a child-specific poster override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Default local poster file used when a child-specific poster override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Default background URL used when a child-specific background override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Default local background file used when a child-specific background override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Default logo URL used when a child-specific logo override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Default local logo file used when a child-specific logo override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Default square art URL used when a child-specific square-art override is not set.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Default local square art file used when a child-specific square-art override is not set.",
+            "section": "artwork",
+            "placeholder": "C:\\Posters\\square.png"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Resolution Poster URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Resolution Poster File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "C:\\Posters\\poster.jpg",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Resolution Background URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Resolution Background File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "C:\\Posters\\background.jpg",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Resolution Logo URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "https://example.com/logo.png",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Resolution Logo File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "C:\\Posters\\logo.png",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Resolution Square Art URL Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "https://example.com/square.png",
+            "lookup_display_mode": "inline",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Resolution Square Art File Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "C:\\Posters\\square.png",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab.",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab.",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab.",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "tooltip": "Sets the priority for the Other collection recommendation hub row.",
+            "section": "visibility",
+            "placeholder": "1"
           },
           {
             "key": "item_radarr_tag",
@@ -82946,7 +83844,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -82956,7 +83855,123 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Resolution Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Resolution Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Resolution Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Resolution Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Resolution Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "technical,collection",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Resolution Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_validation_preset": "resolution_key",
+            "key_input_mode": "select",
+            "key_placeholder": "Resolution key (e.g. 4k)",
+            "value_placeholder": "technical,collection",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Resolution Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },

--- a/tests/test_collection_aspect_resolution_contract.py
+++ b/tests/test_collection_aspect_resolution_contract.py
@@ -1,0 +1,155 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+LIBRARIES_JS_PATH = ROOT / "static" / "local-js" / "025-libraries.js"
+
+
+def _load_collection(collection_id):
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    for group in data:
+        for collection in group.get("collections", []):
+            if collection.get("id") == collection_id:
+                return collection
+    raise AssertionError(f"Missing {collection_id}")
+
+
+def _field_map(collection):
+    return {item["key"]: item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+
+
+def _assert_mapping(field, child_prefix, value_kind, key_validation_preset, section, validation_preset=None, media_types=None):
+    assert field["type"] == "mapping_list"
+    assert field["dynamic_child_prefix"] == child_prefix
+    assert field["dynamic_child_value_kind"] == value_kind
+    assert field["key_validation_preset"] == key_validation_preset
+    assert field["key_input_mode"] == "select"
+    assert field["section"] == section
+    if validation_preset is None:
+        assert "validation_preset" not in field
+    else:
+        assert field["validation_preset"] == validation_preset
+    if media_types is None:
+        assert "media_types" not in field
+    else:
+        assert field["media_types"] == media_types
+
+
+def test_aspect_and_resolution_key_presets_are_select_backed():
+    source = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "aspect_key: {" in source
+    for key in ["'1.33'", "'1.78'", "'2.35'", "'2.77'"]:
+        assert key in source
+
+    assert "resolution_key: {" in source
+    for key in ["'4k'", "'1080'", "'480'", "'8k'"]:
+        assert key in source
+
+
+def test_aspect_collection_exposes_filter_defaults_static_ratios_and_dynamic_maps():
+    collection = _load_collection("collection_aspect")
+    fields = _field_map(collection)
+
+    section_ids = [section.get("id") for section in collection.get("template_variable_sections") or [] if isinstance(section, dict)]
+    assert section_ids == ["basics", "naming", "scope", "aspect_ratios", "child_override_maps", "artwork", "visibility"]
+
+    assert fields["filter_term"]["default"] == "aspect"
+    assert fields["translation_key"]["default"] == "aspect"
+    assert fields["image"]["default"] == "aspect/<<key>>"
+    assert fields["exclude"]["validation_preset"] == "aspect_key"
+
+    for ratio in ["1.33", "1.78", "2.35", "2.77"]:
+        assert fields[f"use_{ratio}"]["section"] == "aspect_ratios"
+        assert fields[f"name_{ratio}"]["section"] == "aspect_ratios"
+        assert fields[f"summary_{ratio}"]["section"] == "aspect_ratios"
+        assert fields[f"limit_{ratio}"]["section"] == "aspect_ratios"
+        assert fields[f"visible_home_{ratio}"]["section"] == "visibility"
+
+    expected_mappings = {
+        "child_order_overrides": ("order_", "string", "child_override_maps", None, None),
+        "child_schedule_overrides": ("schedule_", "string", "child_override_maps", None, None),
+        "child_sort_by_overrides": ("sort_by_", "select", "child_override_maps", None, None),
+        "child_minimum_items_overrides": ("minimum_items_", "integer", "child_override_maps", None, None),
+        "child_sync_mode_overrides": ("sync_mode_", "select", "child_override_maps", None, None),
+        "child_url_poster_overrides": ("url_poster_", "string", "artwork", "url", None),
+        "child_file_poster_overrides": ("file_poster_", "string", "artwork", None, None),
+        "child_url_background_overrides": ("url_background_", "string", "artwork", "url", None),
+        "child_file_background_overrides": ("file_background_", "string", "artwork", None, None),
+        "child_url_logo_overrides": ("url_logo_", "string", "artwork", "url", None),
+        "child_file_logo_overrides": ("file_logo_", "string", "artwork", None, None),
+        "child_url_square_art_overrides": ("url_square_art_", "string", "artwork", "url", None),
+        "child_file_square_art_overrides": ("file_square_art_", "string", "artwork", None, None),
+        "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "visibility", None, ["movie"]),
+        "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list", "visibility", None, ["show"]),
+    }
+    for key, (child_prefix, value_kind, section, validation_preset, media_types) in expected_mappings.items():
+        _assert_mapping(fields[key], child_prefix, value_kind, "aspect_key", section, validation_preset, media_types)
+
+    assert "child_name_mapping_overrides" not in fields
+    assert "child_delete_collections_named_overrides" not in fields
+    for key in [
+        "child_use_overrides",
+        "child_name_overrides",
+        "child_summary_overrides",
+        "child_limit_overrides",
+        "child_visible_home_overrides",
+        "child_visible_library_overrides",
+        "child_visible_shared_overrides",
+        "child_hub_priority_overrides",
+    ]:
+        assert key not in fields
+
+
+def test_resolution_collection_exposes_smart_filter_defaults_other_collection_and_dynamic_maps():
+    collection = _load_collection("collection_resolution")
+    fields = _field_map(collection)
+
+    section_ids = [section.get("id") for section in collection.get("template_variable_sections") or [] if isinstance(section, dict)]
+    assert section_ids == ["basics", "naming", "scope", "other_collection", "child_override_maps", "artwork", "visibility"]
+
+    assert fields["search_term"]["default"] == "resolution"
+    assert fields["translation_key"]["default"] == "resolution"
+    assert fields["image"]["default"] == "resolution/<<key>>"
+    assert fields["use_other"]["section"] == "other_collection"
+    assert fields["name_other"]["section"] == "other_collection"
+    assert fields["summary_other"]["section"] == "other_collection"
+    assert fields["limit_other"]["section"] == "other_collection"
+
+    for key in ["include", "append_include", "exclude"]:
+        assert fields[key]["validation_preset"] == "resolution_key"
+        assert fields[key]["section"] == "scope"
+    assert fields["addons"]["section"] == "scope"
+    assert fields["append_addons"]["section"] == "scope"
+
+    expected_mappings = {
+        "child_use_overrides": ("use_", "boolean", "child_override_maps", None, None),
+        "child_name_overrides": ("name_", "string", "child_override_maps", None, None),
+        "child_summary_overrides": ("summary_", "string", "child_override_maps", None, None),
+        "child_order_overrides": ("order_", "string", "child_override_maps", None, None),
+        "child_schedule_overrides": ("schedule_", "string", "child_override_maps", None, None),
+        "child_sort_by_overrides": ("sort_by_", "select", "child_override_maps", None, None),
+        "child_limit_overrides": ("limit_", "integer", "child_override_maps", None, None),
+        "child_minimum_items_overrides": ("minimum_items_", "integer", "child_override_maps", None, None),
+        "child_url_poster_overrides": ("url_poster_", "string", "artwork", "url", None),
+        "child_file_poster_overrides": ("file_poster_", "string", "artwork", None, None),
+        "child_url_background_overrides": ("url_background_", "string", "artwork", "url", None),
+        "child_file_background_overrides": ("file_background_", "string", "artwork", None, None),
+        "child_url_logo_overrides": ("url_logo_", "string", "artwork", "url", None),
+        "child_file_logo_overrides": ("file_logo_", "string", "artwork", None, None),
+        "child_url_square_art_overrides": ("url_square_art_", "string", "artwork", "url", None),
+        "child_file_square_art_overrides": ("file_square_art_", "string", "artwork", None, None),
+        "child_visible_home_overrides": ("visible_home_", "boolean", "visibility", None, None),
+        "child_visible_library_overrides": ("visible_library_", "boolean", "visibility", None, None),
+        "child_visible_shared_overrides": ("visible_shared_", "boolean", "visibility", None, None),
+        "child_hub_priority_overrides": ("hub_priority_", "string", "visibility", None, None),
+        "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "visibility", None, ["movie"]),
+        "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list", "visibility", None, ["show"]),
+    }
+    for key, (child_prefix, value_kind, section, validation_preset, media_types) in expected_mappings.items():
+        _assert_mapping(fields[key], child_prefix, value_kind, "resolution_key", section, validation_preset, media_types)
+
+    assert "child_sync_mode_overrides" not in fields
+    assert "child_name_mapping_overrides" not in fields
+    assert "child_delete_collections_named_overrides" not in fields

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2688,6 +2688,72 @@ def test_build_libraries_section_expands_language_dynamic_child_override_maps(ap
     assert subtitle_language["template_variables"]["item_sonarr_tag_fr"] == ["subtitle", "french"]
 
 
+def test_build_libraries_section_expands_aspect_resolution_dynamic_child_override_maps(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            show_libraries={"sho-library_shows-library": "Shows"},
+            movie_collections={
+                "movies": {
+                    "mov-library_movies-collection_aspect": True,
+                    "mov-library_movies-template_collection_aspect_filter_term": "aspect",
+                    "mov-library_movies-template_collection_aspect_use_1.78": False,
+                    "mov-library_movies-template_collection_aspect_name_1.78": "Widescreen TV",
+                    "mov-library_movies-template_collection_aspect_child_schedule_overrides": '{"2.35": "weekly(sunday)"}',
+                    "mov-library_movies-template_collection_aspect_child_sync_mode_overrides": '{"2.35": "append"}',
+                    "mov-library_movies-template_collection_aspect_child_minimum_items_overrides": '{"1.33": "3"}',
+                    "mov-library_movies-template_collection_aspect_child_url_background_overrides": '{"1.78": "https://example.com/aspect-bg.jpg"}',
+                    "mov-library_movies-template_collection_aspect_child_item_radarr_tag_overrides": '{"1.78": "aspect,widescreen"}',
+                    "mov-library_movies-collection_resolution": True,
+                    "mov-library_movies-template_collection_resolution_include": '["4k", "1080"]',
+                    "mov-library_movies-template_collection_resolution_child_name_overrides": '{"4k": "Ultra HD"}',
+                    "mov-library_movies-template_collection_resolution_child_order_overrides": '{"4k": "01"}',
+                    "mov-library_movies-template_collection_resolution_child_schedule_overrides": '{"1080": "weekly(friday)"}',
+                    "mov-library_movies-template_collection_resolution_child_url_poster_overrides": '{"4k": "https://example.com/4k.jpg"}',
+                    "mov-library_movies-template_collection_resolution_child_item_radarr_tag_overrides": '{"4k": "resolution,4k"}',
+                }
+            },
+            show_collections={
+                "shows": {
+                    "sho-library_shows-collection_aspect": True,
+                    "sho-library_shows-template_collection_aspect_child_item_sonarr_tag_overrides": '{"2.35": ["aspect", "scope"]}',
+                    "sho-library_shows-collection_resolution": True,
+                    "sho-library_shows-template_collection_resolution_exclude": "480",
+                    "sho-library_shows-template_collection_resolution_child_file_square_art_overrides": '{"1080": "C:\\\\Square\\\\1080.png"}',
+                    "sho-library_shows-template_collection_resolution_child_item_sonarr_tag_overrides": '{"1080": ["resolution", "1080p"]}',
+                }
+            },
+        )
+
+    movie_entries = libraries_section["libraries"]["Movies"]["collection_files"]
+    show_entries = libraries_section["libraries"]["Shows"]["collection_files"]
+    movie_aspect = next(entry for entry in movie_entries if entry.get("default") == "aspect")
+    movie_resolution = next(entry for entry in movie_entries if entry.get("default") == "resolution")
+    show_aspect = next(entry for entry in show_entries if entry.get("default") == "aspect")
+    show_resolution = next(entry for entry in show_entries if entry.get("default") == "resolution")
+
+    assert movie_aspect["template_variables"]["filter_term"] == "aspect"
+    assert movie_aspect["template_variables"]["use_1.78"] is False
+    assert movie_aspect["template_variables"]["name_1.78"] == "Widescreen TV"
+    assert movie_aspect["template_variables"]["schedule_2.35"] == "weekly(sunday)"
+    assert movie_aspect["template_variables"]["sync_mode_2.35"] == "append"
+    assert movie_aspect["template_variables"]["minimum_items_1.33"] == 3
+    assert movie_aspect["template_variables"]["url_background_1.78"] == "https://example.com/aspect-bg.jpg"
+    assert movie_aspect["template_variables"]["item_radarr_tag_1.78"] == ["aspect", "widescreen"]
+    assert movie_resolution["template_variables"]["include"] == ["4k", "1080"]
+    assert movie_resolution["template_variables"]["name_4k"] == "Ultra HD"
+    assert movie_resolution["template_variables"]["order_4k"] == "01"
+    assert movie_resolution["template_variables"]["schedule_1080"] == "weekly(friday)"
+    assert movie_resolution["template_variables"]["url_poster_4k"] == "https://example.com/4k.jpg"
+    assert movie_resolution["template_variables"]["item_radarr_tag_4k"] == ["resolution", "4k"]
+    assert show_aspect["template_variables"]["item_sonarr_tag_2.35"] == ["aspect", "scope"]
+    assert show_resolution["template_variables"]["exclude"] == ["480"]
+    assert show_resolution["template_variables"]["file_square_art_1080"] == r"C:\Square\1080.png"
+    assert show_resolution["template_variables"]["item_sonarr_tag_1080"] == ["resolution", "1080p"]
+
+
 def test_build_libraries_section_emits_library_arr_overrides(app):
     from modules import output
 

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -869,6 +869,99 @@ def test_prepare_import_payload_collapses_language_dynamic_child_template_variab
     assert any("libraries.Shows.collection_files[0].template_variables.item_sonarr_tag_fr" in line for line in report.lines)
 
 
+def test_prepare_import_payload_collapses_aspect_and_resolution_dynamic_child_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "collection_files": [
+                        {
+                            "default": "aspect",
+                            "template_variables": {
+                                "filter_term": "aspect",
+                                "use_1.78": False,
+                                "name_1.78": "Widescreen TV",
+                                "summary_2.35": "Cinemascope favorites",
+                                "schedule_2.35": "weekly(sunday)",
+                                "sync_mode_2.35": "append",
+                                "sort_by_1.85": "title.asc",
+                                "minimum_items_1.33": 3,
+                                "url_background_1.78": "https://example.com/aspect-bg.jpg",
+                                "item_radarr_tag_1.78": ["aspect", "widescreen"],
+                            },
+                        },
+                        {
+                            "default": "resolution",
+                            "template_variables": {
+                                "search_term": "resolution",
+                                "include": ["4k", "1080"],
+                                "name_4k": "Ultra HD",
+                                "summary_1080": "HD favorites",
+                                "order_4k": "01",
+                                "schedule_1080": "weekly(friday)",
+                                "url_poster_4k": "https://example.com/4k.jpg",
+                                "item_radarr_tag_4k": ["resolution", "4k"],
+                            },
+                        },
+                    ]
+                },
+                "Shows": {
+                    "collection_files": [
+                        {
+                            "default": "aspect",
+                            "template_variables": {
+                                "name_2.35": "Scope TV",
+                                "item_sonarr_tag_2.35": ["aspect", "scope"],
+                            },
+                        },
+                        {
+                            "default": "resolution",
+                            "template_variables": {
+                                "exclude": ["480"],
+                                "file_square_art_1080": r"C:\Square\1080.png",
+                                "item_sonarr_tag_1080": ["resolution", "1080p"],
+                            },
+                        },
+                    ]
+                },
+            }
+        },
+        {"Movies"},
+        {"Shows"},
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-collection_aspect"] is True
+    assert libraries_payload["mov-library_movies-collection_resolution"] is True
+    assert libraries_payload["sho-library_shows-collection_aspect"] is True
+    assert libraries_payload["sho-library_shows-collection_resolution"] is True
+    assert libraries_payload["mov-library_movies-template_collection_aspect_filter_term"] == "aspect"
+    assert libraries_payload["mov-library_movies-template_collection_aspect_use_1.78"] is False
+    assert libraries_payload["mov-library_movies-template_collection_aspect_name_1.78"] == "Widescreen TV"
+    assert libraries_payload["mov-library_movies-template_collection_aspect_summary_2.35"] == "Cinemascope favorites"
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_aspect_child_schedule_overrides"]) == {"2.35": "weekly(sunday)"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_aspect_child_sync_mode_overrides"]) == {"2.35": "append"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_aspect_child_sort_by_overrides"]) == {"1.85": "title.asc"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_aspect_child_minimum_items_overrides"]) == {"1.33": "3"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_aspect_child_url_background_overrides"]) == {"1.78": "https://example.com/aspect-bg.jpg"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_aspect_child_item_radarr_tag_overrides"]) == {"1.78": "aspect,widescreen"}
+    assert libraries_payload["mov-library_movies-template_collection_resolution_search_term"] == "resolution"
+    assert libraries_payload["mov-library_movies-template_collection_resolution_include"] == '["4k", "1080"]'
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_resolution_child_name_overrides"]) == {"4k": "Ultra HD"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_resolution_child_summary_overrides"]) == {"1080": "HD favorites"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_resolution_child_order_overrides"]) == {"4k": "01"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_resolution_child_schedule_overrides"]) == {"1080": "weekly(friday)"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_resolution_child_url_poster_overrides"]) == {"4k": "https://example.com/4k.jpg"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_resolution_child_item_radarr_tag_overrides"]) == {"4k": "resolution,4k"}
+    assert libraries_payload["sho-library_shows-template_collection_aspect_name_2.35"] == "Scope TV"
+    assert json.loads(libraries_payload["sho-library_shows-template_collection_aspect_child_item_sonarr_tag_overrides"]) == {"2.35": "aspect,scope"}
+    assert libraries_payload["sho-library_shows-template_collection_resolution_exclude"] == '["480"]'
+    assert json.loads(libraries_payload["sho-library_shows-template_collection_resolution_child_file_square_art_overrides"]) == {"1080": r"C:\Square\1080.png"}
+    assert json.loads(libraries_payload["sho-library_shows-template_collection_resolution_child_item_sonarr_tag_overrides"]) == {"1080": "resolution,1080p"}
+    assert any("libraries.Movies.collection_files[0].template_variables.sync_mode_2.35" in line for line in report.lines)
+    assert any("libraries.Shows.collection_files[1].template_variables.file_square_art_1080" in line for line in report.lines)
+
+
 def test_prepare_import_payload_collapses_studio_dynamic_child_template_variables():
     payload, report = importer.prepare_import_payload(
         {

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -404,6 +404,62 @@ def test_apply_template_var_normalizers_expands_language_dynamic_child_override_
     assert template_vars["item_sonarr_tag_fr"] == ["subtitle", "french"]
 
 
+def test_apply_template_var_normalizers_expands_aspect_dynamic_child_override_maps():
+    template_vars = {
+        "child_schedule_overrides": '{"2.35": "weekly(sunday)"}',
+        "child_sync_mode_overrides": '{"2.35": "append"}',
+        "child_sort_by_overrides": '{"1.85": "title.asc"}',
+        "child_minimum_items_overrides": '{"1.33": "3"}',
+        "child_url_background_overrides": '{"1.78": "https://example.com/aspect-bg.jpg"}',
+        "child_file_logo_overrides": '{"2.35": "C:\\\\Logos\\\\scope.png"}',
+        "child_item_radarr_tag_overrides": '{"1.78": ["aspect", "widescreen"]}',
+        "child_item_sonarr_tag_overrides": '{"2.35": "aspect,scope"}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "aspect")
+
+    assert template_vars["schedule_2.35"] == "weekly(sunday)"
+    assert template_vars["sync_mode_2.35"] == "append"
+    assert template_vars["sort_by_1.85"] == "title.asc"
+    assert template_vars["minimum_items_1.33"] == 3
+    assert template_vars["url_background_1.78"] == "https://example.com/aspect-bg.jpg"
+    assert template_vars["file_logo_2.35"] == r"C:\Logos\scope.png"
+    assert template_vars["item_radarr_tag_1.78"] == ["aspect", "widescreen"]
+    assert template_vars["item_sonarr_tag_2.35"] == ["aspect", "scope"]
+
+
+def test_apply_template_var_normalizers_expands_resolution_dynamic_child_override_maps():
+    template_vars = {
+        "child_use_overrides": '{"4k": "false"}',
+        "child_name_overrides": '{"4k": "Ultra HD"}',
+        "child_summary_overrides": '{"1080": "HD favorites"}',
+        "child_order_overrides": '{"4k": "01"}',
+        "child_schedule_overrides": '{"1080": "weekly(friday)"}',
+        "child_sort_by_overrides": '{"720": "title.asc"}',
+        "child_limit_overrides": '{"480": "12"}',
+        "child_url_poster_overrides": '{"4k": "https://example.com/4k.jpg"}',
+        "child_file_square_art_overrides": '{"1080": "C:\\\\Square\\\\1080.png"}',
+        "child_visible_library_overrides": '{"4k": "false"}',
+        "child_item_radarr_tag_overrides": '{"4k": "resolution,4k"}',
+        "child_item_sonarr_tag_overrides": '{"1080": ["resolution", "1080p"]}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "resolution")
+
+    assert template_vars["use_4k"] is False
+    assert template_vars["name_4k"] == "Ultra HD"
+    assert template_vars["summary_1080"] == "HD favorites"
+    assert template_vars["order_4k"] == "01"
+    assert template_vars["schedule_1080"] == "weekly(friday)"
+    assert template_vars["sort_by_720"] == "title.asc"
+    assert template_vars["limit_480"] == 12
+    assert template_vars["url_poster_4k"] == "https://example.com/4k.jpg"
+    assert template_vars["file_square_art_1080"] == r"C:\Square\1080.png"
+    assert template_vars["visible_library_4k"] is False
+    assert template_vars["item_radarr_tag_4k"] == ["resolution", "4k"]
+    assert template_vars["item_sonarr_tag_1080"] == ["resolution", "1080p"]
+
+
 def test_apply_template_var_normalizers_expands_award_year_override_maps():
     template_vars = {
         "child_collection_order_overrides": '{"2024": "release"}',


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Add aspect and resolution collection template variable coverage

Description:
```markdown
## Summary
- Adds organized template variable sections for aspect and resolution collections.
- Expands aspect support with missing per-key override maps for schedule, sync mode, sort, minimum items, artwork, and item tags while preserving existing fixed ratio fields.
- Expands resolution support with smart-filter defaults, other-collection controls, artwork, visibility, and per-resolution override maps.
- Adds contract, importer, output normalizer, and backend export tests for aspect/resolution round-trip behavior.

## Testing
- `venv\Scripts\python.exe -m pytest tests\test_collection_aspect_resolution_contract.py tests\test_output_collection_child_override_contract.py tests\test_importer_collection_files.py tests\test_core_backend.py`

Result: `248 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
