### PR TITLE
organized the charts

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -25891,7 +25891,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -25933,7 +25933,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -25959,13 +25959,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -26023,7 +26023,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "sort_by",
@@ -26361,7 +26361,7 @@
                 ]
               }
             ],
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "limit_released",
@@ -26372,13 +26372,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sort_by_released",
             "label": "Newly Released Sort By",
             "type": "select",
-            "section": "builder",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -26418,13 +26418,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sort_by_episodes",
             "label": "New Episodes Sort By",
             "type": "select",
-            "section": "builder",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -26459,7 +26459,7 @@
             "tooltip_variant": "info",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_released",
@@ -26467,7 +26467,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Newly Released collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_released",
@@ -26475,13 +26475,13 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Newly Released collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "schedule_released",
             "label": "Newly Released Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -26494,7 +26494,7 @@
             "media_types": [
               "show"
             ],
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_episodes",
@@ -26502,7 +26502,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the New Episodes collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_episodes",
@@ -26510,13 +26510,13 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the New Episodes collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "schedule_episodes",
             "label": "New Episodes Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -26702,7 +26702,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -26711,7 +26711,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -26722,7 +26722,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag",
@@ -26733,7 +26733,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "radarr_add_missing_released",
@@ -26744,7 +26744,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "sonarr_add_missing_episodes",
@@ -26755,7 +26755,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_released",
@@ -26766,7 +26766,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "url_background_episodes",
@@ -27061,6 +27061,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -27090,7 +27133,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -27132,7 +27175,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -27150,7 +27193,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -27161,7 +27204,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -27517,7 +27560,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -27543,13 +27586,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -27607,7 +27650,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "list_size",
@@ -27618,7 +27661,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "use_popular",
@@ -27627,7 +27670,7 @@
             "tooltip_variant": "info",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_popular",
@@ -27635,7 +27678,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Plex Popular collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_popular",
@@ -27643,7 +27686,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Plex Popular collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "list_days_popular",
@@ -27653,7 +27696,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "list_size_popular",
@@ -27663,13 +27706,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_popular",
             "label": "Plex Popular Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -27689,14 +27732,14 @@
             "key": "cache_builders_popular",
             "label": "Plex Popular Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_popular",
             "label": "Plex Popular Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -27724,7 +27767,7 @@
             "key": "schedule_popular",
             "label": "Plex Popular Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -27734,7 +27777,7 @@
             "tooltip_variant": "info",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_watched",
@@ -27742,7 +27785,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Plex Watched collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_watched",
@@ -27750,7 +27793,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Plex Watched collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "list_days_watched",
@@ -27760,7 +27803,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "list_size_watched",
@@ -27770,13 +27813,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_watched",
             "label": "Plex Watched Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -27796,14 +27839,14 @@
             "key": "cache_builders_watched",
             "label": "Plex Watched Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_watched",
             "label": "Plex Watched Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -27831,7 +27874,7 @@
             "key": "schedule_watched",
             "label": "Plex Watched Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -28014,7 +28057,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -28023,7 +28066,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -28034,7 +28077,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag",
@@ -28045,7 +28088,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "url_background_popular",
@@ -28331,6 +28374,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -28358,7 +28444,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -28400,7 +28486,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -28418,7 +28504,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -28429,7 +28515,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -28785,7 +28871,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -28811,13 +28897,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -28874,7 +28960,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "use_popular",
@@ -28883,7 +28969,7 @@
             "tooltip_variant": "info",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_popular",
@@ -28891,7 +28977,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the IMDb Popular collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_popular",
@@ -28899,13 +28985,13 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the IMDb Popular collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_popular",
             "label": "IMDb Popular Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -28925,14 +29011,14 @@
             "key": "cache_builders_popular",
             "label": "IMDb Popular Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_popular",
             "label": "IMDb Popular Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -28960,7 +29046,7 @@
             "key": "schedule_popular",
             "label": "IMDb Popular Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -28970,7 +29056,7 @@
             "tooltip_variant": "info",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_top",
@@ -28978,7 +29064,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the IMDb Top 250 collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_top",
@@ -28986,13 +29072,13 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the IMDb Top 250 collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_top",
             "label": "IMDb Top 250 Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -29012,14 +29098,14 @@
             "key": "cache_builders_top",
             "label": "IMDb Top 250 Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_top",
             "label": "IMDb Top 250 Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -29047,7 +29133,7 @@
             "key": "schedule_top",
             "label": "IMDb Top 250 Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -29057,7 +29143,7 @@
             "tooltip_variant": "info",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_lowest",
@@ -29065,7 +29151,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the IMDb Lowest Rated collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_lowest",
@@ -29073,13 +29159,13 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the IMDb Lowest Rated collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_lowest",
             "label": "IMDb Lowest Rated Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -29099,14 +29185,14 @@
             "key": "cache_builders_lowest",
             "label": "IMDb Lowest Rated Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_lowest",
             "label": "IMDb Lowest Rated Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -29134,7 +29220,7 @@
             "key": "schedule_lowest",
             "label": "IMDb Lowest Rated Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -29363,7 +29449,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -29372,7 +29458,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -29383,13 +29469,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_lowest",
             "label": "IMDb Lowest Rated Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -29399,7 +29485,7 @@
             "key": "item_radarr_tag_popular",
             "label": "IMDb Popular Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -29409,7 +29495,7 @@
             "key": "item_radarr_tag_top",
             "label": "IMDb Top 250 Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -29424,13 +29510,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag_lowest",
             "label": "IMDb Lowest Rated Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -29440,7 +29526,7 @@
             "key": "item_sonarr_tag_popular",
             "label": "IMDb Popular Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -29450,7 +29536,7 @@
             "key": "item_sonarr_tag_top",
             "label": "IMDb Top 250 Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -29465,7 +29551,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_lowest",
@@ -29476,7 +29562,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_popular",
@@ -29487,7 +29573,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_top",
@@ -29498,7 +29584,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -29509,13 +29595,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_lowest",
             "label": "IMDb Lowest Rated Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29525,7 +29611,7 @@
             "key": "radarr_folder_popular",
             "label": "IMDb Popular Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29535,7 +29621,7 @@
             "key": "radarr_folder_top",
             "label": "IMDb Top 250 Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29549,7 +29635,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing",
@@ -29559,13 +29645,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_lowest",
             "label": "IMDb Lowest Rated Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29588,7 +29674,7 @@
             "key": "radarr_monitor_existing_popular",
             "label": "IMDb Popular Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29611,7 +29697,7 @@
             "key": "radarr_monitor_existing_top",
             "label": "IMDb Top 250 Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29634,7 +29720,7 @@
             "key": "radarr_monitor_lowest",
             "label": "IMDb Lowest Rated Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29657,7 +29743,7 @@
             "key": "radarr_monitor_popular",
             "label": "IMDb Popular Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29680,7 +29766,7 @@
             "key": "radarr_monitor_top",
             "label": "IMDb Top 250 Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29707,13 +29793,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_lowest",
             "label": "IMDb Lowest Rated Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29736,7 +29822,7 @@
             "key": "radarr_search_popular",
             "label": "IMDb Popular Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29759,7 +29845,7 @@
             "key": "radarr_search_top",
             "label": "IMDb Top 250 Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29787,13 +29873,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_lowest",
             "label": "IMDb Lowest Rated Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29803,7 +29889,7 @@
             "key": "radarr_tag_popular",
             "label": "IMDb Popular Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29813,7 +29899,7 @@
             "key": "radarr_tag_top",
             "label": "IMDb Top 250 Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29827,13 +29913,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_lowest",
             "label": "IMDb Lowest Rated Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29856,7 +29942,7 @@
             "key": "radarr_upgrade_existing_popular",
             "label": "IMDb Popular Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29879,7 +29965,7 @@
             "key": "radarr_upgrade_existing_top",
             "label": "IMDb Top 250 Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -29907,7 +29993,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_lowest",
@@ -29918,7 +30004,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_popular",
@@ -29929,7 +30015,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_top",
@@ -29940,7 +30026,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder",
@@ -29951,13 +30037,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder_lowest",
             "label": "IMDb Lowest Rated Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -29967,7 +30053,7 @@
             "key": "sonarr_folder_popular",
             "label": "IMDb Popular Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -29977,7 +30063,7 @@
             "key": "sonarr_folder_top",
             "label": "IMDb Top 250 Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30025,7 +30111,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing",
@@ -30035,13 +30121,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing_lowest",
             "label": "IMDb Lowest Rated Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30064,7 +30150,7 @@
             "key": "sonarr_monitor_existing_popular",
             "label": "IMDb Popular Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30087,7 +30173,7 @@
             "key": "sonarr_monitor_existing_top",
             "label": "IMDb Top 250 Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30110,7 +30196,7 @@
             "key": "sonarr_monitor_lowest",
             "label": "IMDb Lowest Rated Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30157,7 +30243,7 @@
             "key": "sonarr_monitor_popular",
             "label": "IMDb Popular Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30204,7 +30290,7 @@
             "key": "sonarr_monitor_top",
             "label": "IMDb Top 250 Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30255,13 +30341,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_search_lowest",
             "label": "IMDb Lowest Rated Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30284,7 +30370,7 @@
             "key": "sonarr_search_popular",
             "label": "IMDb Popular Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30307,7 +30393,7 @@
             "key": "sonarr_search_top",
             "label": "IMDb Top 250 Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30335,13 +30421,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_tag_lowest",
             "label": "IMDb Lowest Rated Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30351,7 +30437,7 @@
             "key": "sonarr_tag_popular",
             "label": "IMDb Popular Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30361,7 +30447,7 @@
             "key": "sonarr_tag_top",
             "label": "IMDb Top 250 Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30375,13 +30461,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_upgrade_existing_lowest",
             "label": "IMDb Lowest Rated Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30404,7 +30490,7 @@
             "key": "sonarr_upgrade_existing_popular",
             "label": "IMDb Popular Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30427,7 +30513,7 @@
             "key": "sonarr_upgrade_existing_top",
             "label": "IMDb Top 250 Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -30824,6 +30910,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -30851,7 +30980,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -30893,7 +31022,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -30911,7 +31040,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -30922,7 +31051,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -31278,7 +31407,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -31304,13 +31433,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -31368,7 +31497,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "use_popular",
@@ -31376,7 +31505,7 @@
             "tooltip": "Collection of the Most Popular Movies/Shows on TMDb.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_popular",
@@ -31384,7 +31513,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the TMDb Popular collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_popular",
@@ -31392,7 +31521,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the TMDb Popular collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_popular",
@@ -31402,13 +31531,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_popular",
             "label": "TMDb Popular Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31428,14 +31557,14 @@
             "key": "cache_builders_popular",
             "label": "TMDb Popular Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_popular",
             "label": "TMDb Popular Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31463,7 +31592,7 @@
             "key": "schedule_popular",
             "label": "TMDb Popular Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -31472,7 +31601,7 @@
             "tooltip": "Collection of the Top Rated Movies/Shows on TMDb.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_top",
@@ -31480,7 +31609,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the TMDb Top Rated collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_top",
@@ -31488,7 +31617,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the TMDb Top Rated collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_top",
@@ -31498,13 +31627,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_top",
             "label": "TMDb Top Rated Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31524,14 +31653,14 @@
             "key": "cache_builders_top",
             "label": "TMDb Top Rated Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_top",
             "label": "TMDb Top Rated Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31559,7 +31688,7 @@
             "key": "schedule_top",
             "label": "TMDb Top Rated Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -31568,7 +31697,7 @@
             "tooltip": "Collection of Trending Movies/Shows on TMDb.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_trending",
@@ -31576,7 +31705,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the TMDb Trending collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_trending",
@@ -31584,7 +31713,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the TMDb Trending collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_trending",
@@ -31594,13 +31723,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_trending",
             "label": "TMDb Trending Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31620,14 +31749,14 @@
             "key": "cache_builders_trending",
             "label": "TMDb Trending Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_trending",
             "label": "TMDb Trending Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31655,7 +31784,7 @@
             "key": "schedule_trending",
             "label": "TMDb Trending Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -31664,7 +31793,7 @@
             "tooltip": "Collection of Shows Airing Today on TMDb.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_airing",
@@ -31672,7 +31801,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the TMDb Airing Today collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_airing",
@@ -31680,7 +31809,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the TMDb Airing Today collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_airing",
@@ -31690,13 +31819,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_airing",
             "label": "TMDb Airing Today Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31716,14 +31845,14 @@
             "key": "cache_builders_airing",
             "label": "TMDb Airing Today Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_airing",
             "label": "TMDb Airing Today Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31751,7 +31880,7 @@
             "key": "schedule_airing",
             "label": "TMDb Airing Today Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -31760,7 +31889,7 @@
             "tooltip": "Collection of Shows currently On The Air on TMDb.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_air",
@@ -31768,7 +31897,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the TMDb On The Air collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_air",
@@ -31776,7 +31905,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the TMDb On The Air collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_air",
@@ -31786,13 +31915,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_air",
             "label": "TMDb On The Air Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31812,14 +31941,14 @@
             "key": "cache_builders_air",
             "label": "TMDb On The Air Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_air",
             "label": "TMDb On The Air Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -31847,7 +31976,7 @@
             "key": "schedule_air",
             "label": "TMDb On The Air Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -32168,7 +32297,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -32177,7 +32306,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -32188,13 +32317,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_air",
             "label": "TMDb On The Air Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -32204,7 +32333,7 @@
             "key": "item_radarr_tag_airing",
             "label": "TMDb Airing Today Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -32214,7 +32343,7 @@
             "key": "item_radarr_tag_popular",
             "label": "TMDb Popular Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -32224,7 +32353,7 @@
             "key": "item_radarr_tag_top",
             "label": "TMDb Top Rated Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -32234,7 +32363,7 @@
             "key": "item_radarr_tag_trending",
             "label": "TMDb Trending Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -32249,13 +32378,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag_air",
             "label": "TMDb On The Air Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -32265,7 +32394,7 @@
             "key": "item_sonarr_tag_airing",
             "label": "TMDb Airing Today Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -32275,7 +32404,7 @@
             "key": "item_sonarr_tag_popular",
             "label": "TMDb Popular Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -32285,7 +32414,7 @@
             "key": "item_sonarr_tag_top",
             "label": "TMDb Top Rated Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -32295,7 +32424,7 @@
             "key": "item_sonarr_tag_trending",
             "label": "TMDb Trending Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -32310,7 +32439,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_air",
@@ -32321,7 +32450,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_airing",
@@ -32332,7 +32461,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_popular",
@@ -32343,7 +32472,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_top",
@@ -32354,7 +32483,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_trending",
@@ -32365,7 +32494,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -32376,13 +32505,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_air",
             "label": "TMDb On The Air Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32392,7 +32521,7 @@
             "key": "radarr_folder_airing",
             "label": "TMDb Airing Today Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32402,7 +32531,7 @@
             "key": "radarr_folder_popular",
             "label": "TMDb Popular Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32412,7 +32541,7 @@
             "key": "radarr_folder_top",
             "label": "TMDb Top Rated Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32422,7 +32551,7 @@
             "key": "radarr_folder_trending",
             "label": "TMDb Trending Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32436,13 +32565,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_air",
             "label": "TMDb On The Air Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32465,7 +32594,7 @@
             "key": "radarr_monitor_airing",
             "label": "TMDb Airing Today Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32492,13 +32621,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_air",
             "label": "TMDb On The Air Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32521,7 +32650,7 @@
             "key": "radarr_monitor_existing_airing",
             "label": "TMDb Airing Today Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32544,7 +32673,7 @@
             "key": "radarr_monitor_existing_popular",
             "label": "TMDb Popular Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32567,7 +32696,7 @@
             "key": "radarr_monitor_existing_top",
             "label": "TMDb Top Rated Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32590,7 +32719,7 @@
             "key": "radarr_monitor_existing_trending",
             "label": "TMDb Trending Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32613,7 +32742,7 @@
             "key": "radarr_monitor_popular",
             "label": "TMDb Popular Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32636,7 +32765,7 @@
             "key": "radarr_monitor_top",
             "label": "TMDb Top Rated Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32659,7 +32788,7 @@
             "key": "radarr_monitor_trending",
             "label": "TMDb Trending Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32686,13 +32815,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_air",
             "label": "TMDb On The Air Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32715,7 +32844,7 @@
             "key": "radarr_search_airing",
             "label": "TMDb Airing Today Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32738,7 +32867,7 @@
             "key": "radarr_search_popular",
             "label": "TMDb Popular Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32761,7 +32890,7 @@
             "key": "radarr_search_top",
             "label": "TMDb Top Rated Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32784,7 +32913,7 @@
             "key": "radarr_search_trending",
             "label": "TMDb Trending Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32812,13 +32941,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_air",
             "label": "TMDb On The Air Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32828,7 +32957,7 @@
             "key": "radarr_tag_airing",
             "label": "TMDb Airing Today Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32838,7 +32967,7 @@
             "key": "radarr_tag_popular",
             "label": "TMDb Popular Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32848,7 +32977,7 @@
             "key": "radarr_tag_top",
             "label": "TMDb Top Rated Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32858,7 +32987,7 @@
             "key": "radarr_tag_trending",
             "label": "TMDb Trending Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32872,13 +33001,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_air",
             "label": "TMDb On The Air Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32901,7 +33030,7 @@
             "key": "radarr_upgrade_existing_airing",
             "label": "TMDb Airing Today Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32924,7 +33053,7 @@
             "key": "radarr_upgrade_existing_popular",
             "label": "TMDb Popular Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32947,7 +33076,7 @@
             "key": "radarr_upgrade_existing_top",
             "label": "TMDb Top Rated Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32970,7 +33099,7 @@
             "key": "radarr_upgrade_existing_trending",
             "label": "TMDb Trending Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -32998,7 +33127,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_air",
@@ -33009,7 +33138,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_airing",
@@ -33020,7 +33149,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_popular",
@@ -33031,7 +33160,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_top",
@@ -33042,7 +33171,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_trending",
@@ -33053,7 +33182,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder",
@@ -33064,13 +33193,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder_air",
             "label": "TMDb On The Air Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33080,7 +33209,7 @@
             "key": "sonarr_folder_airing",
             "label": "TMDb Airing Today Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33090,7 +33219,7 @@
             "key": "sonarr_folder_popular",
             "label": "TMDb Popular Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33100,7 +33229,7 @@
             "key": "sonarr_folder_top",
             "label": "TMDb Top Rated Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33110,7 +33239,7 @@
             "key": "sonarr_folder_trending",
             "label": "TMDb Trending Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33158,13 +33287,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_air",
             "label": "TMDb On The Air Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33211,7 +33340,7 @@
             "key": "sonarr_monitor_airing",
             "label": "TMDb Airing Today Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33262,13 +33391,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing_air",
             "label": "TMDb On The Air Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33291,7 +33420,7 @@
             "key": "sonarr_monitor_existing_airing",
             "label": "TMDb Airing Today Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33314,7 +33443,7 @@
             "key": "sonarr_monitor_existing_popular",
             "label": "TMDb Popular Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33337,7 +33466,7 @@
             "key": "sonarr_monitor_existing_top",
             "label": "TMDb Top Rated Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33360,7 +33489,7 @@
             "key": "sonarr_monitor_existing_trending",
             "label": "TMDb Trending Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33383,7 +33512,7 @@
             "key": "sonarr_monitor_popular",
             "label": "TMDb Popular Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33430,7 +33559,7 @@
             "key": "sonarr_monitor_top",
             "label": "TMDb Top Rated Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33477,7 +33606,7 @@
             "key": "sonarr_monitor_trending",
             "label": "TMDb Trending Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33528,13 +33657,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_search_air",
             "label": "TMDb On The Air Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33557,7 +33686,7 @@
             "key": "sonarr_search_airing",
             "label": "TMDb Airing Today Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33580,7 +33709,7 @@
             "key": "sonarr_search_popular",
             "label": "TMDb Popular Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33603,7 +33732,7 @@
             "key": "sonarr_search_top",
             "label": "TMDb Top Rated Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33626,7 +33755,7 @@
             "key": "sonarr_search_trending",
             "label": "TMDb Trending Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33654,13 +33783,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_tag_air",
             "label": "TMDb On The Air Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33670,7 +33799,7 @@
             "key": "sonarr_tag_airing",
             "label": "TMDb Airing Today Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33680,7 +33809,7 @@
             "key": "sonarr_tag_popular",
             "label": "TMDb Popular Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33690,7 +33819,7 @@
             "key": "sonarr_tag_top",
             "label": "TMDb Top Rated Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33700,7 +33829,7 @@
             "key": "sonarr_tag_trending",
             "label": "TMDb Trending Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33714,13 +33843,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_upgrade_existing_air",
             "label": "TMDb On The Air Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33743,7 +33872,7 @@
             "key": "sonarr_upgrade_existing_airing",
             "label": "TMDb Airing Today Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33766,7 +33895,7 @@
             "key": "sonarr_upgrade_existing_popular",
             "label": "TMDb Popular Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33789,7 +33918,7 @@
             "key": "sonarr_upgrade_existing_top",
             "label": "TMDb Top Rated Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -33812,7 +33941,7 @@
             "key": "sonarr_upgrade_existing_trending",
             "label": "TMDb Trending Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -34397,6 +34526,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -34426,7 +34598,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -34468,7 +34640,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -34486,7 +34658,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -34497,7 +34669,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -34853,7 +35025,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -34879,13 +35051,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -34943,7 +35115,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "use_collected",
@@ -34951,7 +35123,7 @@
             "tooltip": "Collection of the Most Collected Movies/Shows on Trakt.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_collected",
@@ -34959,7 +35131,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Trakt Collected collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_collected",
@@ -34967,7 +35139,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Trakt Collected collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_collected",
@@ -34977,13 +35149,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_collected",
             "label": "Trakt Collected Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35003,14 +35175,14 @@
             "key": "cache_builders_collected",
             "label": "Trakt Collected Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_collected",
             "label": "Trakt Collected Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35038,7 +35210,7 @@
             "key": "schedule_collected",
             "label": "Trakt Collected Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -35047,7 +35219,7 @@
             "tooltip": "Collection of the Most Popular Movies/Shows on Trakt.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_popular",
@@ -35055,7 +35227,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Trakt Popular collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_popular",
@@ -35063,7 +35235,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Trakt Popular collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_popular",
@@ -35073,13 +35245,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_popular",
             "label": "Trakt Popular Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35099,14 +35271,14 @@
             "key": "cache_builders_popular",
             "label": "Trakt Popular Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_popular",
             "label": "Trakt Popular Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35134,7 +35306,7 @@
             "key": "schedule_popular",
             "label": "Trakt Popular Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -35143,7 +35315,7 @@
             "tooltip": "Collection of Recommended Movies/Shows on Trakt.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_recommended",
@@ -35151,7 +35323,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Trakt Recommended collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_recommended",
@@ -35159,7 +35331,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Trakt Recommended collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_recommended",
@@ -35169,13 +35341,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_recommended",
             "label": "Trakt Recommended Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35195,14 +35367,14 @@
             "key": "cache_builders_recommended",
             "label": "Trakt Recommended Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_recommended",
             "label": "Trakt Recommended Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35230,7 +35402,7 @@
             "key": "schedule_recommended",
             "label": "Trakt Recommended Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -35239,7 +35411,7 @@
             "tooltip": "Collection of Trending Movies/Shows on Trakt.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_trending",
@@ -35247,7 +35419,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Trakt Trending collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_trending",
@@ -35255,7 +35427,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Trakt Trending collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_trending",
@@ -35265,13 +35437,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_trending",
             "label": "Trakt Trending Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35291,14 +35463,14 @@
             "key": "cache_builders_trending",
             "label": "Trakt Trending Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_trending",
             "label": "Trakt Trending Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35326,7 +35498,7 @@
             "key": "schedule_trending",
             "label": "Trakt Trending Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -35335,7 +35507,7 @@
             "tooltip": "Collection of the Most Watched Movies/Shows on Trakt.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_watched",
@@ -35343,7 +35515,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Trakt Watched collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_watched",
@@ -35351,7 +35523,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Trakt Watched collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_watched",
@@ -35361,13 +35533,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_watched",
             "label": "Trakt Watched Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35387,14 +35559,14 @@
             "key": "cache_builders_watched",
             "label": "Trakt Watched Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_watched",
             "label": "Trakt Watched Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -35422,7 +35594,7 @@
             "key": "schedule_watched",
             "label": "Trakt Watched Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -35743,7 +35915,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -35752,7 +35924,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -35763,13 +35935,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_collected",
             "label": "Trakt Collected Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -35779,7 +35951,7 @@
             "key": "item_radarr_tag_popular",
             "label": "Trakt Popular Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -35789,7 +35961,7 @@
             "key": "item_radarr_tag_recommended",
             "label": "Trakt Recommended Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -35799,7 +35971,7 @@
             "key": "item_radarr_tag_trending",
             "label": "Trakt Trending Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -35809,7 +35981,7 @@
             "key": "item_radarr_tag_watched",
             "label": "Trakt Watched Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -35824,13 +35996,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag_collected",
             "label": "Trakt Collected Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -35840,7 +36012,7 @@
             "key": "item_sonarr_tag_popular",
             "label": "Trakt Popular Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -35850,7 +36022,7 @@
             "key": "item_sonarr_tag_recommended",
             "label": "Trakt Recommended Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -35860,7 +36032,7 @@
             "key": "item_sonarr_tag_trending",
             "label": "Trakt Trending Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -35870,7 +36042,7 @@
             "key": "item_sonarr_tag_watched",
             "label": "Trakt Watched Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -35885,7 +36057,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_collected",
@@ -35896,7 +36068,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_popular",
@@ -35907,7 +36079,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_recommended",
@@ -35918,7 +36090,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_trending",
@@ -35929,7 +36101,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_watched",
@@ -35940,7 +36112,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -35951,13 +36123,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_collected",
             "label": "Trakt Collected Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -35967,7 +36139,7 @@
             "key": "radarr_folder_popular",
             "label": "Trakt Popular Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -35977,7 +36149,7 @@
             "key": "radarr_folder_recommended",
             "label": "Trakt Recommended Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -35987,7 +36159,7 @@
             "key": "radarr_folder_trending",
             "label": "Trakt Trending Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -35997,7 +36169,7 @@
             "key": "radarr_folder_watched",
             "label": "Trakt Watched Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36011,13 +36183,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_collected",
             "label": "Trakt Collected Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36044,13 +36216,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_collected",
             "label": "Trakt Collected Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36073,7 +36245,7 @@
             "key": "radarr_monitor_existing_popular",
             "label": "Trakt Popular Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36096,7 +36268,7 @@
             "key": "radarr_monitor_existing_recommended",
             "label": "Trakt Recommended Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36119,7 +36291,7 @@
             "key": "radarr_monitor_existing_trending",
             "label": "Trakt Trending Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36142,7 +36314,7 @@
             "key": "radarr_monitor_existing_watched",
             "label": "Trakt Watched Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36165,7 +36337,7 @@
             "key": "radarr_monitor_popular",
             "label": "Trakt Popular Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36188,7 +36360,7 @@
             "key": "radarr_monitor_recommended",
             "label": "Trakt Recommended Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36211,7 +36383,7 @@
             "key": "radarr_monitor_trending",
             "label": "Trakt Trending Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36234,7 +36406,7 @@
             "key": "radarr_monitor_watched",
             "label": "Trakt Watched Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36261,13 +36433,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_collected",
             "label": "Trakt Collected Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36290,7 +36462,7 @@
             "key": "radarr_search_popular",
             "label": "Trakt Popular Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36313,7 +36485,7 @@
             "key": "radarr_search_recommended",
             "label": "Trakt Recommended Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36336,7 +36508,7 @@
             "key": "radarr_search_trending",
             "label": "Trakt Trending Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36359,7 +36531,7 @@
             "key": "radarr_search_watched",
             "label": "Trakt Watched Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36387,13 +36559,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_collected",
             "label": "Trakt Collected Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36403,7 +36575,7 @@
             "key": "radarr_tag_popular",
             "label": "Trakt Popular Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36413,7 +36585,7 @@
             "key": "radarr_tag_recommended",
             "label": "Trakt Recommended Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36423,7 +36595,7 @@
             "key": "radarr_tag_trending",
             "label": "Trakt Trending Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36433,7 +36605,7 @@
             "key": "radarr_tag_watched",
             "label": "Trakt Watched Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36447,13 +36619,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_collected",
             "label": "Trakt Collected Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36476,7 +36648,7 @@
             "key": "radarr_upgrade_existing_popular",
             "label": "Trakt Popular Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36499,7 +36671,7 @@
             "key": "radarr_upgrade_existing_recommended",
             "label": "Trakt Recommended Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36522,7 +36694,7 @@
             "key": "radarr_upgrade_existing_trending",
             "label": "Trakt Trending Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36545,7 +36717,7 @@
             "key": "radarr_upgrade_existing_watched",
             "label": "Trakt Watched Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -36573,7 +36745,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_collected",
@@ -36584,7 +36756,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_popular",
@@ -36595,7 +36767,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_recommended",
@@ -36606,7 +36778,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_trending",
@@ -36617,7 +36789,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_watched",
@@ -36628,7 +36800,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder",
@@ -36639,13 +36811,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder_collected",
             "label": "Trakt Collected Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36655,7 +36827,7 @@
             "key": "sonarr_folder_popular",
             "label": "Trakt Popular Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36665,7 +36837,7 @@
             "key": "sonarr_folder_recommended",
             "label": "Trakt Recommended Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36675,7 +36847,7 @@
             "key": "sonarr_folder_trending",
             "label": "Trakt Trending Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36685,7 +36857,7 @@
             "key": "sonarr_folder_watched",
             "label": "Trakt Watched Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36733,13 +36905,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_collected",
             "label": "Trakt Collected Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36790,13 +36962,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing_collected",
             "label": "Trakt Collected Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36819,7 +36991,7 @@
             "key": "sonarr_monitor_existing_popular",
             "label": "Trakt Popular Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36842,7 +37014,7 @@
             "key": "sonarr_monitor_existing_recommended",
             "label": "Trakt Recommended Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36865,7 +37037,7 @@
             "key": "sonarr_monitor_existing_trending",
             "label": "Trakt Trending Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36888,7 +37060,7 @@
             "key": "sonarr_monitor_existing_watched",
             "label": "Trakt Watched Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36911,7 +37083,7 @@
             "key": "sonarr_monitor_popular",
             "label": "Trakt Popular Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -36958,7 +37130,7 @@
             "key": "sonarr_monitor_recommended",
             "label": "Trakt Recommended Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37005,7 +37177,7 @@
             "key": "sonarr_monitor_trending",
             "label": "Trakt Trending Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37052,7 +37224,7 @@
             "key": "sonarr_monitor_watched",
             "label": "Trakt Watched Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37103,13 +37275,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_search_collected",
             "label": "Trakt Collected Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37132,7 +37304,7 @@
             "key": "sonarr_search_popular",
             "label": "Trakt Popular Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37155,7 +37327,7 @@
             "key": "sonarr_search_recommended",
             "label": "Trakt Recommended Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37178,7 +37350,7 @@
             "key": "sonarr_search_trending",
             "label": "Trakt Trending Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37201,7 +37373,7 @@
             "key": "sonarr_search_watched",
             "label": "Trakt Watched Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37229,13 +37401,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_tag_collected",
             "label": "Trakt Collected Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37245,7 +37417,7 @@
             "key": "sonarr_tag_popular",
             "label": "Trakt Popular Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37255,7 +37427,7 @@
             "key": "sonarr_tag_recommended",
             "label": "Trakt Recommended Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37265,7 +37437,7 @@
             "key": "sonarr_tag_trending",
             "label": "Trakt Trending Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37275,7 +37447,7 @@
             "key": "sonarr_tag_watched",
             "label": "Trakt Watched Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37289,13 +37461,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_upgrade_existing_collected",
             "label": "Trakt Collected Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37318,7 +37490,7 @@
             "key": "sonarr_upgrade_existing_popular",
             "label": "Trakt Popular Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37341,7 +37513,7 @@
             "key": "sonarr_upgrade_existing_recommended",
             "label": "Trakt Recommended Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37364,7 +37536,7 @@
             "key": "sonarr_upgrade_existing_trending",
             "label": "Trakt Trending Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37387,7 +37559,7 @@
             "key": "sonarr_upgrade_existing_watched",
             "label": "Trakt Watched Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -37972,6 +38144,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -37998,7 +38213,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -38040,7 +38255,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -38058,7 +38273,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -38069,7 +38284,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -38097,7 +38312,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -38123,13 +38338,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -38187,13 +38402,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "period",
             "label": "Trending Period",
             "type": "select",
-            "section": "builder",
+            "section": "shared_defaults",
             "options": [
               {
                 "value": "",
@@ -38219,7 +38434,7 @@
             "tooltip": "Collection of Simkl's Trending Today list.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_trending_today",
@@ -38227,7 +38442,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Simkl Trending Today collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_trending_today",
@@ -38235,7 +38450,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Simkl Trending Today collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_trending_today",
@@ -38245,13 +38460,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_trending_today",
             "label": "Simkl Trending Today Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38271,14 +38486,14 @@
             "key": "cache_builders_trending_today",
             "label": "Simkl Trending Today Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_trending_today",
             "label": "Simkl Trending Today Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38306,7 +38521,7 @@
             "key": "schedule_trending_today",
             "label": "Simkl Trending Today Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -38315,7 +38530,7 @@
             "tooltip": "Collection of Simkl's Trending This Week list.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_trending_week",
@@ -38323,7 +38538,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Simkl Trending This Week collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_trending_week",
@@ -38331,7 +38546,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Simkl Trending This Week collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_trending_week",
@@ -38341,13 +38556,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_trending_week",
             "label": "Simkl Trending This Week Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38367,14 +38582,14 @@
             "key": "cache_builders_trending_week",
             "label": "Simkl Trending This Week Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_trending_week",
             "label": "Simkl Trending This Week Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38402,7 +38617,7 @@
             "key": "schedule_trending_week",
             "label": "Simkl Trending This Week Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -38411,7 +38626,7 @@
             "tooltip": "Collection of Simkl's Trending This Month list.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_trending_month",
@@ -38419,7 +38634,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Simkl Trending This Month collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_trending_month",
@@ -38427,7 +38642,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Simkl Trending This Month collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_trending_month",
@@ -38437,13 +38652,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_trending_month",
             "label": "Simkl Trending This Month Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38463,14 +38678,14 @@
             "key": "cache_builders_trending_month",
             "label": "Simkl Trending This Month Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_trending_month",
             "label": "Simkl Trending This Month Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38498,7 +38713,7 @@
             "key": "schedule_trending_month",
             "label": "Simkl Trending This Month Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -38507,7 +38722,7 @@
             "tooltip": "Collection of Simkl's Recently Released on DVD list.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_dvd",
@@ -38515,7 +38730,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Simkl DVD collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_dvd",
@@ -38523,7 +38738,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Simkl DVD collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_dvd",
@@ -38533,13 +38748,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_dvd",
             "label": "Simkl DVD Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38559,14 +38774,14 @@
             "key": "cache_builders_dvd",
             "label": "Simkl DVD Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_dvd",
             "label": "Simkl DVD Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -38594,7 +38809,7 @@
             "key": "schedule_dvd",
             "label": "Simkl DVD Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -38869,7 +39084,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -38878,7 +39093,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -38889,13 +39104,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_dvd",
             "label": "Simkl DVD Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -38905,7 +39120,7 @@
             "key": "item_radarr_tag_trending_month",
             "label": "Simkl Trending This Month Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -38915,7 +39130,7 @@
             "key": "item_radarr_tag_trending_today",
             "label": "Simkl Trending Today Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -38925,7 +39140,7 @@
             "key": "item_radarr_tag_trending_week",
             "label": "Simkl Trending This Week Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -38940,13 +39155,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag_dvd",
             "label": "Simkl DVD Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -38956,7 +39171,7 @@
             "key": "item_sonarr_tag_trending_month",
             "label": "Simkl Trending This Month Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -38966,7 +39181,7 @@
             "key": "item_sonarr_tag_trending_today",
             "label": "Simkl Trending Today Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -38976,7 +39191,7 @@
             "key": "item_sonarr_tag_trending_week",
             "label": "Simkl Trending This Week Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -38991,7 +39206,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_dvd",
@@ -39002,7 +39217,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_trending_month",
@@ -39013,7 +39228,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_trending_today",
@@ -39024,7 +39239,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_trending_week",
@@ -39035,7 +39250,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -39046,13 +39261,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_dvd",
             "label": "Simkl DVD Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39062,7 +39277,7 @@
             "key": "radarr_folder_trending_month",
             "label": "Simkl Trending This Month Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39072,7 +39287,7 @@
             "key": "radarr_folder_trending_today",
             "label": "Simkl Trending Today Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39082,7 +39297,7 @@
             "key": "radarr_folder_trending_week",
             "label": "Simkl Trending This Week Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39096,13 +39311,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_dvd",
             "label": "Simkl DVD Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39129,13 +39344,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_dvd",
             "label": "Simkl DVD Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39158,7 +39373,7 @@
             "key": "radarr_monitor_existing_trending_month",
             "label": "Simkl Trending This Month Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39181,7 +39396,7 @@
             "key": "radarr_monitor_existing_trending_today",
             "label": "Simkl Trending Today Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39204,7 +39419,7 @@
             "key": "radarr_monitor_existing_trending_week",
             "label": "Simkl Trending This Week Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39227,7 +39442,7 @@
             "key": "radarr_monitor_trending_month",
             "label": "Simkl Trending This Month Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39250,7 +39465,7 @@
             "key": "radarr_monitor_trending_today",
             "label": "Simkl Trending Today Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39273,7 +39488,7 @@
             "key": "radarr_monitor_trending_week",
             "label": "Simkl Trending This Week Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39300,13 +39515,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_dvd",
             "label": "Simkl DVD Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39329,7 +39544,7 @@
             "key": "radarr_search_trending_month",
             "label": "Simkl Trending This Month Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39352,7 +39567,7 @@
             "key": "radarr_search_trending_today",
             "label": "Simkl Trending Today Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39375,7 +39590,7 @@
             "key": "radarr_search_trending_week",
             "label": "Simkl Trending This Week Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39403,13 +39618,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_dvd",
             "label": "Simkl DVD Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39419,7 +39634,7 @@
             "key": "radarr_tag_trending_month",
             "label": "Simkl Trending This Month Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39429,7 +39644,7 @@
             "key": "radarr_tag_trending_today",
             "label": "Simkl Trending Today Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39439,7 +39654,7 @@
             "key": "radarr_tag_trending_week",
             "label": "Simkl Trending This Week Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39453,13 +39668,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_dvd",
             "label": "Simkl DVD Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39482,7 +39697,7 @@
             "key": "radarr_upgrade_existing_trending_month",
             "label": "Simkl Trending This Month Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39505,7 +39720,7 @@
             "key": "radarr_upgrade_existing_trending_today",
             "label": "Simkl Trending Today Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39528,7 +39743,7 @@
             "key": "radarr_upgrade_existing_trending_week",
             "label": "Simkl Trending This Week Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -39556,7 +39771,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_dvd",
@@ -39567,7 +39782,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_trending_month",
@@ -39578,7 +39793,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_trending_today",
@@ -39589,7 +39804,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_trending_week",
@@ -39600,7 +39815,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder",
@@ -39611,13 +39826,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder_dvd",
             "label": "Simkl DVD Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39627,7 +39842,7 @@
             "key": "sonarr_folder_trending_month",
             "label": "Simkl Trending This Month Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39637,7 +39852,7 @@
             "key": "sonarr_folder_trending_today",
             "label": "Simkl Trending Today Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39647,7 +39862,7 @@
             "key": "sonarr_folder_trending_week",
             "label": "Simkl Trending This Week Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39695,13 +39910,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_dvd",
             "label": "Simkl DVD Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39752,13 +39967,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing_dvd",
             "label": "Simkl DVD Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39781,7 +39996,7 @@
             "key": "sonarr_monitor_existing_trending_month",
             "label": "Simkl Trending This Month Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39804,7 +40019,7 @@
             "key": "sonarr_monitor_existing_trending_today",
             "label": "Simkl Trending Today Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39827,7 +40042,7 @@
             "key": "sonarr_monitor_existing_trending_week",
             "label": "Simkl Trending This Week Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39850,7 +40065,7 @@
             "key": "sonarr_monitor_trending_month",
             "label": "Simkl Trending This Month Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39897,7 +40112,7 @@
             "key": "sonarr_monitor_trending_today",
             "label": "Simkl Trending Today Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39944,7 +40159,7 @@
             "key": "sonarr_monitor_trending_week",
             "label": "Simkl Trending This Week Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -39995,13 +40210,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_search_dvd",
             "label": "Simkl DVD Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40024,7 +40239,7 @@
             "key": "sonarr_search_trending_month",
             "label": "Simkl Trending This Month Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40047,7 +40262,7 @@
             "key": "sonarr_search_trending_today",
             "label": "Simkl Trending Today Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40070,7 +40285,7 @@
             "key": "sonarr_search_trending_week",
             "label": "Simkl Trending This Week Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40098,13 +40313,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_tag_dvd",
             "label": "Simkl DVD Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40114,7 +40329,7 @@
             "key": "sonarr_tag_trending_month",
             "label": "Simkl Trending This Month Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40124,7 +40339,7 @@
             "key": "sonarr_tag_trending_today",
             "label": "Simkl Trending Today Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40134,7 +40349,7 @@
             "key": "sonarr_tag_trending_week",
             "label": "Simkl Trending This Week Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40148,13 +40363,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_upgrade_existing_dvd",
             "label": "Simkl DVD Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40177,7 +40392,7 @@
             "key": "sonarr_upgrade_existing_trending_month",
             "label": "Simkl Trending This Month Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40200,7 +40415,7 @@
             "key": "sonarr_upgrade_existing_trending_today",
             "label": "Simkl Trending Today Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40223,7 +40438,7 @@
             "key": "sonarr_upgrade_existing_trending_week",
             "label": "Simkl Trending This Week Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -40714,6 +40929,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -40741,7 +40999,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -40783,7 +41041,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -40801,7 +41059,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -40812,7 +41070,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -41168,7 +41426,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -41194,13 +41452,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -41258,7 +41516,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "use_popular",
@@ -41266,7 +41524,7 @@
             "tooltip": "Collection of the most Popular Anime on AniList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_popular",
@@ -41274,7 +41532,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the AniList Popular collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_popular",
@@ -41282,7 +41540,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the AniList Popular collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_popular",
@@ -41292,13 +41550,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_popular",
             "label": "AniList Popular Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41318,14 +41576,14 @@
             "key": "cache_builders_popular",
             "label": "AniList Popular Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_popular",
             "label": "AniList Popular Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41353,7 +41611,7 @@
             "key": "schedule_popular",
             "label": "AniList Popular Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -41362,7 +41620,7 @@
             "tooltip": "Collection of the Top Rated Anime on AniList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_top",
@@ -41370,7 +41628,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the AniList Top Rated collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_top",
@@ -41378,7 +41636,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the AniList Top Rated collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_top",
@@ -41388,13 +41646,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_top",
             "label": "AniList Top Rated Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41414,14 +41672,14 @@
             "key": "cache_builders_top",
             "label": "AniList Top Rated Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_top",
             "label": "AniList Top Rated Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41449,7 +41707,7 @@
             "key": "schedule_top",
             "label": "AniList Top Rated Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -41458,7 +41716,7 @@
             "tooltip": "Collection of the Trending Anime on AniList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_trending",
@@ -41466,7 +41724,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the AniList Trending collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_trending",
@@ -41474,7 +41732,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the AniList Trending collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_trending",
@@ -41484,13 +41742,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_trending",
             "label": "AniList Trending Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41510,14 +41768,14 @@
             "key": "cache_builders_trending",
             "label": "AniList Trending Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_trending",
             "label": "AniList Trending Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41545,7 +41803,7 @@
             "key": "schedule_trending",
             "label": "AniList Trending Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -41554,7 +41812,7 @@
             "tooltip": "Collection of the Current Season's Anime on AniList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_season",
@@ -41562,7 +41820,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the AniList Season collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_season",
@@ -41570,7 +41828,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the AniList Season collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_season",
@@ -41580,13 +41838,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_season",
             "label": "AniList Season Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41606,14 +41864,14 @@
             "key": "cache_builders_season",
             "label": "AniList Season Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_season",
             "label": "AniList Season Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -41641,7 +41899,7 @@
             "key": "schedule_season",
             "label": "AniList Season Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -41916,7 +42174,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -41925,7 +42183,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -41936,13 +42194,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_popular",
             "label": "AniList Popular Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -41952,7 +42210,7 @@
             "key": "item_radarr_tag_season",
             "label": "AniList Season Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -41962,7 +42220,7 @@
             "key": "item_radarr_tag_top",
             "label": "AniList Top Rated Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -41972,7 +42230,7 @@
             "key": "item_radarr_tag_trending",
             "label": "AniList Trending Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -41987,13 +42245,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag_popular",
             "label": "AniList Popular Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -42003,7 +42261,7 @@
             "key": "item_sonarr_tag_season",
             "label": "AniList Season Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -42013,7 +42271,7 @@
             "key": "item_sonarr_tag_top",
             "label": "AniList Top Rated Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -42023,7 +42281,7 @@
             "key": "item_sonarr_tag_trending",
             "label": "AniList Trending Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -42038,7 +42296,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_popular",
@@ -42049,7 +42307,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_season",
@@ -42060,7 +42318,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_top",
@@ -42071,7 +42329,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_trending",
@@ -42082,7 +42340,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -42093,13 +42351,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_popular",
             "label": "AniList Popular Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42109,7 +42367,7 @@
             "key": "radarr_folder_season",
             "label": "AniList Season Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42119,7 +42377,7 @@
             "key": "radarr_folder_top",
             "label": "AniList Top Rated Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42129,7 +42387,7 @@
             "key": "radarr_folder_trending",
             "label": "AniList Trending Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42143,7 +42401,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing",
@@ -42153,13 +42411,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_popular",
             "label": "AniList Popular Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42182,7 +42440,7 @@
             "key": "radarr_monitor_existing_season",
             "label": "AniList Season Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42205,7 +42463,7 @@
             "key": "radarr_monitor_existing_top",
             "label": "AniList Top Rated Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42228,7 +42486,7 @@
             "key": "radarr_monitor_existing_trending",
             "label": "AniList Trending Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42251,7 +42509,7 @@
             "key": "radarr_monitor_popular",
             "label": "AniList Popular Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42274,7 +42532,7 @@
             "key": "radarr_monitor_season",
             "label": "AniList Season Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42297,7 +42555,7 @@
             "key": "radarr_monitor_top",
             "label": "AniList Top Rated Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42320,7 +42578,7 @@
             "key": "radarr_monitor_trending",
             "label": "AniList Trending Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42347,13 +42605,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_popular",
             "label": "AniList Popular Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42376,7 +42634,7 @@
             "key": "radarr_search_season",
             "label": "AniList Season Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42399,7 +42657,7 @@
             "key": "radarr_search_top",
             "label": "AniList Top Rated Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42422,7 +42680,7 @@
             "key": "radarr_search_trending",
             "label": "AniList Trending Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42450,13 +42708,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_popular",
             "label": "AniList Popular Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42466,7 +42724,7 @@
             "key": "radarr_tag_season",
             "label": "AniList Season Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42476,7 +42734,7 @@
             "key": "radarr_tag_top",
             "label": "AniList Top Rated Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42486,7 +42744,7 @@
             "key": "radarr_tag_trending",
             "label": "AniList Trending Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42500,13 +42758,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_popular",
             "label": "AniList Popular Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42529,7 +42787,7 @@
             "key": "radarr_upgrade_existing_season",
             "label": "AniList Season Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42552,7 +42810,7 @@
             "key": "radarr_upgrade_existing_top",
             "label": "AniList Top Rated Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42575,7 +42833,7 @@
             "key": "radarr_upgrade_existing_trending",
             "label": "AniList Trending Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -42603,7 +42861,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_popular",
@@ -42614,7 +42872,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_season",
@@ -42625,7 +42883,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_top",
@@ -42636,7 +42894,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_trending",
@@ -42647,7 +42905,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder",
@@ -42658,13 +42916,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder_popular",
             "label": "AniList Popular Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42674,7 +42932,7 @@
             "key": "sonarr_folder_season",
             "label": "AniList Season Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42684,7 +42942,7 @@
             "key": "sonarr_folder_top",
             "label": "AniList Top Rated Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42694,7 +42952,7 @@
             "key": "sonarr_folder_trending",
             "label": "AniList Trending Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42742,7 +43000,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing",
@@ -42752,13 +43010,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing_popular",
             "label": "AniList Popular Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42781,7 +43039,7 @@
             "key": "sonarr_monitor_existing_season",
             "label": "AniList Season Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42804,7 +43062,7 @@
             "key": "sonarr_monitor_existing_top",
             "label": "AniList Top Rated Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42827,7 +43085,7 @@
             "key": "sonarr_monitor_existing_trending",
             "label": "AniList Trending Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42850,7 +43108,7 @@
             "key": "sonarr_monitor_popular",
             "label": "AniList Popular Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42897,7 +43155,7 @@
             "key": "sonarr_monitor_season",
             "label": "AniList Season Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42944,7 +43202,7 @@
             "key": "sonarr_monitor_top",
             "label": "AniList Top Rated Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -42991,7 +43249,7 @@
             "key": "sonarr_monitor_trending",
             "label": "AniList Trending Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43042,13 +43300,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_search_popular",
             "label": "AniList Popular Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43071,7 +43329,7 @@
             "key": "sonarr_search_season",
             "label": "AniList Season Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43094,7 +43352,7 @@
             "key": "sonarr_search_top",
             "label": "AniList Top Rated Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43117,7 +43375,7 @@
             "key": "sonarr_search_trending",
             "label": "AniList Trending Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43145,13 +43403,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_tag_popular",
             "label": "AniList Popular Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43161,7 +43419,7 @@
             "key": "sonarr_tag_season",
             "label": "AniList Season Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43171,7 +43429,7 @@
             "key": "sonarr_tag_top",
             "label": "AniList Top Rated Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43181,7 +43439,7 @@
             "key": "sonarr_tag_trending",
             "label": "AniList Trending Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43195,13 +43453,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_upgrade_existing_popular",
             "label": "AniList Popular Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43224,7 +43482,7 @@
             "key": "sonarr_upgrade_existing_season",
             "label": "AniList Season Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43247,7 +43505,7 @@
             "key": "sonarr_upgrade_existing_top",
             "label": "AniList Top Rated Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43270,7 +43528,7 @@
             "key": "sonarr_upgrade_existing_trending",
             "label": "AniList Trending Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -43761,6 +44019,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -43788,7 +44089,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -43830,7 +44131,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -43848,7 +44149,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -43859,7 +44160,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -44215,7 +44516,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -44241,13 +44542,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -44305,13 +44606,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "starting_only",
             "label": "Starting Only",
             "type": "select",
-            "section": "builder",
+            "section": "shared_defaults",
             "options": [
               {
                 "value": "",
@@ -44331,7 +44632,7 @@
             "key": "starting_only_season",
             "label": "Season Starting Only",
             "type": "select",
-            "section": "builder",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44353,7 +44654,7 @@
             "tooltip": "Collection of the most Popular Anime on MyAnimeList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_popular",
@@ -44361,7 +44662,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the MyAnimeList Popular collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_popular",
@@ -44369,7 +44670,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the MyAnimeList Popular collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_popular",
@@ -44379,13 +44680,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_popular",
             "label": "MyAnimeList Popular Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44405,14 +44706,14 @@
             "key": "cache_builders_popular",
             "label": "MyAnimeList Popular Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_popular",
             "label": "MyAnimeList Popular Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44440,7 +44741,7 @@
             "key": "schedule_popular",
             "label": "MyAnimeList Popular Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -44449,7 +44750,7 @@
             "tooltip": "Collection of most Favorited Anime on MyAnimeList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_favorited",
@@ -44457,7 +44758,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the MyAnimeList Favorited collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_favorited",
@@ -44465,7 +44766,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the MyAnimeList Favorited collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_favorited",
@@ -44475,13 +44776,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_favorited",
             "label": "MyAnimeList Favorited Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44501,14 +44802,14 @@
             "key": "cache_builders_favorited",
             "label": "MyAnimeList Favorited Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_favorited",
             "label": "MyAnimeList Favorited Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44536,7 +44837,7 @@
             "key": "schedule_favorited",
             "label": "MyAnimeList Favorited Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -44545,7 +44846,7 @@
             "tooltip": "Collection of the Top Rated Anime on MyAnimeList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_top",
@@ -44553,7 +44854,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the MyAnimeList Top Rated collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_top",
@@ -44561,7 +44862,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the MyAnimeList Top Rated collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_top",
@@ -44571,13 +44872,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_top",
             "label": "MyAnimeList Top Rated Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44597,14 +44898,14 @@
             "key": "cache_builders_top",
             "label": "MyAnimeList Top Rated Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_top",
             "label": "MyAnimeList Top Rated Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44632,7 +44933,7 @@
             "key": "schedule_top",
             "label": "MyAnimeList Top Rated Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -44641,7 +44942,7 @@
             "tooltip": "Collection of the Top Rated Airing on MyAnimeList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_airing",
@@ -44649,7 +44950,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the MyAnimeList Top Airing collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_airing",
@@ -44657,7 +44958,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the MyAnimeList Top Airing collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_airing",
@@ -44667,13 +44968,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_airing",
             "label": "MyAnimeList Top Airing Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44693,14 +44994,14 @@
             "key": "cache_builders_airing",
             "label": "MyAnimeList Top Airing Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_airing",
             "label": "MyAnimeList Top Airing Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44728,7 +45029,7 @@
             "key": "schedule_airing",
             "label": "MyAnimeList Top Airing Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -44737,7 +45038,7 @@
             "tooltip": "Collection of the Current Seasons Anime on MyAnimeList.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_season",
@@ -44745,7 +45046,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the MyAnimeList Season collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_season",
@@ -44753,7 +45054,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the MyAnimeList Season collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_season",
@@ -44763,13 +45064,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_season",
             "label": "MyAnimeList Season Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44789,14 +45090,14 @@
             "key": "cache_builders_season",
             "label": "MyAnimeList Season Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_season",
             "label": "MyAnimeList Season Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -44824,7 +45125,7 @@
             "key": "schedule_season",
             "label": "MyAnimeList Season Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -45145,7 +45446,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -45154,7 +45455,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -45165,13 +45466,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_airing",
             "label": "MyAnimeList Top Airing Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -45181,7 +45482,7 @@
             "key": "item_radarr_tag_favorited",
             "label": "MyAnimeList Favorited Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -45191,7 +45492,7 @@
             "key": "item_radarr_tag_popular",
             "label": "MyAnimeList Popular Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -45201,7 +45502,7 @@
             "key": "item_radarr_tag_season",
             "label": "MyAnimeList Season Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -45211,7 +45512,7 @@
             "key": "item_radarr_tag_top",
             "label": "MyAnimeList Top Rated Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -45226,13 +45527,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_sonarr_tag_airing",
             "label": "MyAnimeList Top Airing Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -45242,7 +45543,7 @@
             "key": "item_sonarr_tag_favorited",
             "label": "MyAnimeList Favorited Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -45252,7 +45553,7 @@
             "key": "item_sonarr_tag_popular",
             "label": "MyAnimeList Popular Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -45262,7 +45563,7 @@
             "key": "item_sonarr_tag_season",
             "label": "MyAnimeList Season Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -45272,7 +45573,7 @@
             "key": "item_sonarr_tag_top",
             "label": "MyAnimeList Top Rated Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -45287,7 +45588,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_airing",
@@ -45298,7 +45599,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_favorited",
@@ -45309,7 +45610,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_popular",
@@ -45320,7 +45621,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_season",
@@ -45331,7 +45632,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_top",
@@ -45342,7 +45643,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -45353,13 +45654,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_airing",
             "label": "MyAnimeList Top Airing Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45369,7 +45670,7 @@
             "key": "radarr_folder_favorited",
             "label": "MyAnimeList Favorited Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45379,7 +45680,7 @@
             "key": "radarr_folder_popular",
             "label": "MyAnimeList Popular Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45389,7 +45690,7 @@
             "key": "radarr_folder_season",
             "label": "MyAnimeList Season Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45399,7 +45700,7 @@
             "key": "radarr_folder_top",
             "label": "MyAnimeList Top Rated Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45413,13 +45714,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_airing",
             "label": "MyAnimeList Top Airing Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45446,13 +45747,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_airing",
             "label": "MyAnimeList Top Airing Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45475,7 +45776,7 @@
             "key": "radarr_monitor_existing_favorited",
             "label": "MyAnimeList Favorited Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45498,7 +45799,7 @@
             "key": "radarr_monitor_existing_popular",
             "label": "MyAnimeList Popular Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45521,7 +45822,7 @@
             "key": "radarr_monitor_existing_season",
             "label": "MyAnimeList Season Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45544,7 +45845,7 @@
             "key": "radarr_monitor_existing_top",
             "label": "MyAnimeList Top Rated Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45567,7 +45868,7 @@
             "key": "radarr_monitor_favorited",
             "label": "MyAnimeList Favorited Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45590,7 +45891,7 @@
             "key": "radarr_monitor_popular",
             "label": "MyAnimeList Popular Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45613,7 +45914,7 @@
             "key": "radarr_monitor_season",
             "label": "MyAnimeList Season Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45636,7 +45937,7 @@
             "key": "radarr_monitor_top",
             "label": "MyAnimeList Top Rated Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45663,13 +45964,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_airing",
             "label": "MyAnimeList Top Airing Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45692,7 +45993,7 @@
             "key": "radarr_search_favorited",
             "label": "MyAnimeList Favorited Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45715,7 +46016,7 @@
             "key": "radarr_search_popular",
             "label": "MyAnimeList Popular Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45738,7 +46039,7 @@
             "key": "radarr_search_season",
             "label": "MyAnimeList Season Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45761,7 +46062,7 @@
             "key": "radarr_search_top",
             "label": "MyAnimeList Top Rated Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45789,13 +46090,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_airing",
             "label": "MyAnimeList Top Airing Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45805,7 +46106,7 @@
             "key": "radarr_tag_favorited",
             "label": "MyAnimeList Favorited Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45815,7 +46116,7 @@
             "key": "radarr_tag_popular",
             "label": "MyAnimeList Popular Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45825,7 +46126,7 @@
             "key": "radarr_tag_season",
             "label": "MyAnimeList Season Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45835,7 +46136,7 @@
             "key": "radarr_tag_top",
             "label": "MyAnimeList Top Rated Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45849,13 +46150,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_airing",
             "label": "MyAnimeList Top Airing Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45878,7 +46179,7 @@
             "key": "radarr_upgrade_existing_favorited",
             "label": "MyAnimeList Favorited Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45901,7 +46202,7 @@
             "key": "radarr_upgrade_existing_popular",
             "label": "MyAnimeList Popular Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45924,7 +46225,7 @@
             "key": "radarr_upgrade_existing_season",
             "label": "MyAnimeList Season Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45947,7 +46248,7 @@
             "key": "radarr_upgrade_existing_top",
             "label": "MyAnimeList Top Rated Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -45975,7 +46276,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_airing",
@@ -45986,7 +46287,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_favorited",
@@ -45997,7 +46298,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_popular",
@@ -46008,7 +46309,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_season",
@@ -46019,7 +46320,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_add_missing_top",
@@ -46030,7 +46331,7 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder",
@@ -46041,13 +46342,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_folder_airing",
             "label": "MyAnimeList Top Airing Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46057,7 +46358,7 @@
             "key": "sonarr_folder_favorited",
             "label": "MyAnimeList Favorited Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46067,7 +46368,7 @@
             "key": "sonarr_folder_popular",
             "label": "MyAnimeList Popular Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46077,7 +46378,7 @@
             "key": "sonarr_folder_season",
             "label": "MyAnimeList Season Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46087,7 +46388,7 @@
             "key": "sonarr_folder_top",
             "label": "MyAnimeList Top Rated Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46135,13 +46436,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_airing",
             "label": "MyAnimeList Top Airing Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46192,13 +46493,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_monitor_existing_airing",
             "label": "MyAnimeList Top Airing Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46221,7 +46522,7 @@
             "key": "sonarr_monitor_existing_favorited",
             "label": "MyAnimeList Favorited Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46244,7 +46545,7 @@
             "key": "sonarr_monitor_existing_popular",
             "label": "MyAnimeList Popular Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46267,7 +46568,7 @@
             "key": "sonarr_monitor_existing_season",
             "label": "MyAnimeList Season Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46290,7 +46591,7 @@
             "key": "sonarr_monitor_existing_top",
             "label": "MyAnimeList Top Rated Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46313,7 +46614,7 @@
             "key": "sonarr_monitor_favorited",
             "label": "MyAnimeList Favorited Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46360,7 +46661,7 @@
             "key": "sonarr_monitor_popular",
             "label": "MyAnimeList Popular Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46407,7 +46708,7 @@
             "key": "sonarr_monitor_season",
             "label": "MyAnimeList Season Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46454,7 +46755,7 @@
             "key": "sonarr_monitor_top",
             "label": "MyAnimeList Top Rated Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46505,13 +46806,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_search_airing",
             "label": "MyAnimeList Top Airing Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46534,7 +46835,7 @@
             "key": "sonarr_search_favorited",
             "label": "MyAnimeList Favorited Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46557,7 +46858,7 @@
             "key": "sonarr_search_popular",
             "label": "MyAnimeList Popular Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46580,7 +46881,7 @@
             "key": "sonarr_search_season",
             "label": "MyAnimeList Season Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46603,7 +46904,7 @@
             "key": "sonarr_search_top",
             "label": "MyAnimeList Top Rated Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46631,13 +46932,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_tag_airing",
             "label": "MyAnimeList Top Airing Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46647,7 +46948,7 @@
             "key": "sonarr_tag_favorited",
             "label": "MyAnimeList Favorited Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46657,7 +46958,7 @@
             "key": "sonarr_tag_popular",
             "label": "MyAnimeList Popular Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46667,7 +46968,7 @@
             "key": "sonarr_tag_season",
             "label": "MyAnimeList Season Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46677,7 +46978,7 @@
             "key": "sonarr_tag_top",
             "label": "MyAnimeList Top Rated Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46691,13 +46992,13 @@
             "media_types": [
               "show"
             ],
-            "section": "automation"
+            "section": "sonarr"
           },
           {
             "key": "sonarr_upgrade_existing_airing",
             "label": "MyAnimeList Top Airing Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46720,7 +47021,7 @@
             "key": "sonarr_upgrade_existing_favorited",
             "label": "MyAnimeList Favorited Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46743,7 +47044,7 @@
             "key": "sonarr_upgrade_existing_popular",
             "label": "MyAnimeList Popular Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46766,7 +47067,7 @@
             "key": "sonarr_upgrade_existing_season",
             "label": "MyAnimeList Season Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -46789,7 +47090,7 @@
             "key": "sonarr_upgrade_existing_top",
             "label": "MyAnimeList Top Rated Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -47374,6 +47675,49 @@
             "id": "visibility",
             "label": "Visibility"
           }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
+          }
         ]
       },
       {
@@ -47400,7 +47744,7 @@
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "basics"
           },
           {
             "key": "allowed_libraries",
@@ -47442,7 +47786,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "sync_mode",
@@ -47460,7 +47804,7 @@
                 "label": "Sync"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "cache_builders",
@@ -47471,7 +47815,7 @@
             "input_type": "number",
             "min": 0,
             "step": 1,
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_order",
@@ -47827,7 +48171,7 @@
                 ]
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "collection_mode",
@@ -47853,13 +48197,13 @@
                 "label": "Show this Collection and its Items"
               }
             ],
-            "section": "basics"
+            "section": "shared_defaults"
           },
           {
             "key": "schedule",
             "label": "Schedule",
             "type": "text",
-            "section": "basics",
+            "section": "shared_defaults",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -47917,7 +48261,7 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "shared_defaults"
           },
           {
             "key": "use_top_500",
@@ -47925,7 +48269,7 @@
             "tooltip": "Collection of the Top 500 films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_top_500",
@@ -47933,7 +48277,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Letterboxd Top 500 collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_top_500",
@@ -47941,7 +48285,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Letterboxd Top 500 collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_top_500",
@@ -47952,13 +48296,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_top_500",
             "label": "Letterboxd Top 500 Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -47978,14 +48322,14 @@
             "key": "cache_builders_top_500",
             "label": "Letterboxd Top 500 Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_top_500",
             "label": "Letterboxd Top 500 Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48013,7 +48357,7 @@
             "key": "schedule_top_500",
             "label": "Letterboxd Top 500 Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48022,7 +48366,7 @@
             "tooltip": "Collection of Box Office Mojo's all-time top 100 films.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_boxofficemojo_100",
@@ -48030,7 +48374,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Box Office Mojo All Time 100 collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_boxofficemojo_100",
@@ -48038,7 +48382,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Box Office Mojo All Time 100 collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_boxofficemojo_100",
@@ -48049,13 +48393,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48075,14 +48419,14 @@
             "key": "cache_builders_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48110,7 +48454,7 @@
             "key": "schedule_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48119,7 +48463,7 @@
             "tooltip": "Collection of AFI's 100 Years...100 Movies.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_afi_100",
@@ -48127,7 +48471,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the AFI 100 Years 100 Movies collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_afi_100",
@@ -48135,7 +48479,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the AFI 100 Years 100 Movies collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_afi_100",
@@ -48146,13 +48490,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_afi_100",
             "label": "AFI 100 Years 100 Movies Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48172,14 +48516,14 @@
             "key": "cache_builders_afi_100",
             "label": "AFI 100 Years 100 Movies Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_afi_100",
             "label": "AFI 100 Years 100 Movies Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48207,7 +48551,7 @@
             "key": "schedule_afi_100",
             "label": "AFI 100 Years 100 Movies Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48216,7 +48560,7 @@
             "tooltip": "Collection of Sight and Sound's Greatest Films of All Time.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_sight_sound",
@@ -48224,7 +48568,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Sight & Sound Greatest Films collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_sight_sound",
@@ -48232,7 +48576,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Sight & Sound Greatest Films collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_sight_sound",
@@ -48243,13 +48587,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_sight_sound",
             "label": "Sight & Sound Greatest Films Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48269,14 +48613,14 @@
             "key": "cache_builders_sight_sound",
             "label": "Sight & Sound Greatest Films Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_sight_sound",
             "label": "Sight & Sound Greatest Films Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48304,7 +48648,7 @@
             "key": "schedule_sight_sound",
             "label": "Sight & Sound Greatest Films Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48313,7 +48657,7 @@
             "tooltip": "Collection of 1,001 Movies You Must See Before You Die.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_1001_movies",
@@ -48321,7 +48665,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the 1,001 To See Before You Die collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_1001_movies",
@@ -48329,7 +48673,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the 1,001 To See Before You Die collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_1001_movies",
@@ -48340,13 +48684,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_1001_movies",
             "label": "1,001 To See Before You Die Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48366,14 +48710,14 @@
             "key": "cache_builders_1001_movies",
             "label": "1,001 To See Before You Die Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_1001_movies",
             "label": "1,001 To See Before You Die Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48401,7 +48745,7 @@
             "key": "schedule_1001_movies",
             "label": "1,001 To See Before You Die Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48410,7 +48754,7 @@
             "tooltip": "Collection of Edgar Wright's 1,000 Favorite Movies.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_edgarwright",
@@ -48418,7 +48762,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Edgar Wright's 1,000 Favorites collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_edgarwright",
@@ -48426,7 +48770,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Edgar Wright's 1,000 Favorites collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_edgarwright",
@@ -48437,13 +48781,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48463,14 +48807,14 @@
             "key": "cache_builders_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48498,7 +48842,7 @@
             "key": "schedule_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48507,7 +48851,7 @@
             "tooltip": "Collection of films from Roger Ebert's \"Great Movies\" essays.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_rogerebert",
@@ -48515,7 +48859,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Roger Ebert's Great Movies collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_rogerebert",
@@ -48523,7 +48867,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Roger Ebert's Great Movies collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_rogerebert",
@@ -48534,13 +48878,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_rogerebert",
             "label": "Roger Ebert's Great Movies Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48560,14 +48904,14 @@
             "key": "cache_builders_rogerebert",
             "label": "Roger Ebert's Great Movies Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_rogerebert",
             "label": "Roger Ebert's Great Movies Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48595,7 +48939,7 @@
             "key": "schedule_rogerebert",
             "label": "Roger Ebert's Great Movies Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48604,7 +48948,7 @@
             "tooltip": "Collection of the Top 250 Women-Directed films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_women_directors",
@@ -48612,7 +48956,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 Women-Directed collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_women_directors",
@@ -48620,7 +48964,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 Women-Directed collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_women_directors",
@@ -48631,13 +48975,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_women_directors",
             "label": "Top 250 Women-Directed Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48657,14 +49001,14 @@
             "key": "cache_builders_women_directors",
             "label": "Top 250 Women-Directed Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_women_directors",
             "label": "Top 250 Women-Directed Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48692,7 +49036,7 @@
             "key": "schedule_women_directors",
             "label": "Top 250 Women-Directed Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48701,7 +49045,7 @@
             "tooltip": "Collection of the Top 250 Black-Directed films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_black_directors",
@@ -48709,7 +49053,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 Black-Directed collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_black_directors",
@@ -48717,7 +49061,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 Black-Directed collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_black_directors",
@@ -48728,13 +49072,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_black_directors",
             "label": "Top 250 Black-Directed Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48754,14 +49098,14 @@
             "key": "cache_builders_black_directors",
             "label": "Top 250 Black-Directed Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_black_directors",
             "label": "Top 250 Black-Directed Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48789,7 +49133,7 @@
             "key": "schedule_black_directors",
             "label": "Top 250 Black-Directed Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48798,7 +49142,7 @@
             "tooltip": "Collection of the Top 250 films with the most fans on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_most_fans",
@@ -48806,7 +49150,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 Most Fans collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_most_fans",
@@ -48814,7 +49158,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 Most Fans collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_most_fans",
@@ -48825,13 +49169,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_most_fans",
             "label": "Top 250 Most Fans Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48851,14 +49195,14 @@
             "key": "cache_builders_most_fans",
             "label": "Top 250 Most Fans Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_most_fans",
             "label": "Top 250 Most Fans Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48886,7 +49230,7 @@
             "key": "schedule_most_fans",
             "label": "Top 250 Most Fans Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48895,7 +49239,7 @@
             "tooltip": "Collection of the Top 250 documentary films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_documentaries",
@@ -48903,7 +49247,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 Documentaries collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_documentaries",
@@ -48911,7 +49255,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 Documentaries collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_documentaries",
@@ -48922,13 +49266,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_documentaries",
             "label": "Top 250 Documentaries Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48948,14 +49292,14 @@
             "key": "cache_builders_documentaries",
             "label": "Top 250 Documentaries Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_documentaries",
             "label": "Top 250 Documentaries Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -48983,7 +49327,7 @@
             "key": "schedule_documentaries",
             "label": "Top 250 Documentaries Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -48992,7 +49336,7 @@
             "tooltip": "Collection of the Top 100 animated films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_animation",
@@ -49000,7 +49344,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 100 Animation collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_animation",
@@ -49008,7 +49352,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 100 Animation collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_animation",
@@ -49019,13 +49363,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_animation",
             "label": "Top 100 Animation Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49045,14 +49389,14 @@
             "key": "cache_builders_animation",
             "label": "Top 100 Animation Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_animation",
             "label": "Top 100 Animation Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49080,7 +49424,7 @@
             "key": "schedule_animation",
             "label": "Top 100 Animation Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49089,7 +49433,7 @@
             "tooltip": "Collection of the Top 250 horror films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_horror",
@@ -49097,7 +49441,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 Horror collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_horror",
@@ -49105,7 +49449,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 Horror collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_horror",
@@ -49116,13 +49460,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_horror",
             "label": "Top 250 Horror Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49142,14 +49486,14 @@
             "key": "cache_builders_horror",
             "label": "Top 250 Horror Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_horror",
             "label": "Top 250 Horror Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49177,7 +49521,7 @@
             "key": "schedule_horror",
             "label": "Top 250 Horror Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49186,7 +49530,7 @@
             "tooltip": "Collection of the Top 250 international films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_international",
@@ -49194,7 +49538,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 International collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_international",
@@ -49202,7 +49546,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 International collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_international",
@@ -49213,13 +49557,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_international",
             "label": "Top 250 International Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49239,14 +49583,14 @@
             "key": "cache_builders_international",
             "label": "Top 250 International Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_international",
             "label": "Top 250 International Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49274,7 +49618,7 @@
             "key": "schedule_international",
             "label": "Top 250 International Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49283,7 +49627,7 @@
             "tooltip": "Collection of the Top 250 science-fiction films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_science",
@@ -49291,7 +49635,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 250 Sci-Fi Films collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_science",
@@ -49299,7 +49643,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 250 Sci-Fi Films collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_science",
@@ -49310,13 +49654,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_science",
             "label": "Top 250 Sci-Fi Films Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49336,14 +49680,14 @@
             "key": "cache_builders_science",
             "label": "Top 250 Sci-Fi Films Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_science",
             "label": "Top 250 Sci-Fi Films Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49371,7 +49715,7 @@
             "key": "schedule_science",
             "label": "Top 250 Sci-Fi Films Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49380,7 +49724,7 @@
             "tooltip": "Collection of films in the One Million Watched Club on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_million",
@@ -49388,7 +49732,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the One Million Watched Club collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_million",
@@ -49396,7 +49740,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the One Million Watched Club collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_million",
@@ -49407,13 +49751,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_million",
             "label": "One Million Watched Club Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49433,14 +49777,14 @@
             "key": "cache_builders_million",
             "label": "One Million Watched Club Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_million",
             "label": "One Million Watched Club Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49468,7 +49812,7 @@
             "key": "schedule_million",
             "label": "One Million Watched Club Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49477,7 +49821,7 @@
             "tooltip": "Collection of the Top 100 western films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_western",
@@ -49485,7 +49829,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 100 Western Films collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_western",
@@ -49493,7 +49837,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 100 Western Films collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_western",
@@ -49504,13 +49848,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_western",
             "label": "Top 100 Western Films Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49530,14 +49874,14 @@
             "key": "cache_builders_western",
             "label": "Top 100 Western Films Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_western",
             "label": "Top 100 Western Films Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49565,7 +49909,7 @@
             "key": "schedule_western",
             "label": "Top 100 Western Films Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49574,7 +49918,7 @@
             "tooltip": "Collection of the Top 100 silent films on Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_silent",
@@ -49582,7 +49926,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Top 100 Silent Films collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_silent",
@@ -49590,7 +49934,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Top 100 Silent Films collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_silent",
@@ -49601,13 +49945,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_silent",
             "label": "Top 100 Silent Films Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49627,14 +49971,14 @@
             "key": "cache_builders_silent",
             "label": "Top 100 Silent Films Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_silent",
             "label": "Top 100 Silent Films Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49662,7 +50006,7 @@
             "key": "schedule_silent",
             "label": "Top 100 Silent Films Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49671,7 +50015,7 @@
             "tooltip": "Collection of the Top 250 Movies on IMDb, from Letterboxd.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_imdb_top_250",
@@ -49679,7 +50023,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the IMDb Top 250 (Letterboxd) collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_imdb_top_250",
@@ -49687,7 +50031,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the IMDb Top 250 (Letterboxd) collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_imdb_top_250",
@@ -49698,13 +50042,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49724,14 +50068,14 @@
             "key": "cache_builders_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49759,7 +50103,7 @@
             "key": "schedule_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49768,7 +50112,7 @@
             "tooltip": "Collection of films that have won the Academy Award for Best Picture.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_oscars",
@@ -49776,7 +50120,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Oscar Best Picture Winners collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_oscars",
@@ -49784,7 +50128,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Oscar Best Picture Winners collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_oscars",
@@ -49795,13 +50139,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_oscars",
             "label": "Oscar Best Picture Winners Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49821,14 +50165,14 @@
             "key": "cache_builders_oscars",
             "label": "Oscar Best Picture Winners Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_oscars",
             "label": "Oscar Best Picture Winners Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49856,7 +50200,7 @@
             "key": "schedule_oscars",
             "label": "Oscar Best Picture Winners Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -49865,7 +50209,7 @@
             "tooltip": "Collection of films that have won the Palme d'Or at the Cannes Film Festival.",
             "type": "toggle",
             "default": true,
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "name_cannes",
@@ -49873,7 +50217,7 @@
             "type": "text_input",
             "tooltip": "Override the collection name for the Cannes Palme d'Or Winners collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "summary_cannes",
@@ -49881,7 +50225,7 @@
             "type": "text_input",
             "tooltip": "Override the collection summary for the Cannes Palme d'Or Winners collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format",
-            "section": "children"
+            "section": "child_collections"
           },
           {
             "key": "limit_cannes",
@@ -49892,13 +50236,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "section": "builder"
+            "section": "child_collections"
           },
           {
             "key": "sync_mode_cannes",
             "label": "Cannes Palme d'Or Winners Sync Mode",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49918,14 +50262,14 @@
             "key": "cache_builders_cannes",
             "label": "Cannes Palme d'Or Winners Cache Builders",
             "type": "number",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "0"
           },
           {
             "key": "collection_order_cannes",
             "label": "Cannes Palme d'Or Winners Collection Order",
             "type": "select",
-            "section": "children",
+            "section": "child_collections",
             "options": [
               {
                 "value": "",
@@ -49953,7 +50297,7 @@
             "key": "schedule_cannes",
             "label": "Cannes Palme d'Or Winners Schedule",
             "type": "text",
-            "section": "children",
+            "section": "child_collections",
             "placeholder": "weekly(sunday)"
           },
           {
@@ -51076,7 +51420,7 @@
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
             "validation_preset": "numeric_id",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "ignore_imdb_ids",
@@ -51085,7 +51429,7 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex",
-            "section": "basics"
+            "section": "filtering"
           },
           {
             "key": "item_radarr_tag",
@@ -51096,13 +51440,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "item_tags"
           },
           {
             "key": "item_radarr_tag_1001_movies",
             "label": "1,001 To See Before You Die Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51112,7 +51456,7 @@
             "key": "item_radarr_tag_afi_100",
             "label": "AFI 100 Years 100 Movies Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51122,7 +51466,7 @@
             "key": "item_radarr_tag_animation",
             "label": "Top 100 Animation Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51132,7 +51476,7 @@
             "key": "item_radarr_tag_black_directors",
             "label": "Top 250 Black-Directed Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51142,7 +51486,7 @@
             "key": "item_radarr_tag_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51152,7 +51496,7 @@
             "key": "item_radarr_tag_cannes",
             "label": "Cannes Palme d'Or Winners Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51162,7 +51506,7 @@
             "key": "item_radarr_tag_documentaries",
             "label": "Top 250 Documentaries Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51172,7 +51516,7 @@
             "key": "item_radarr_tag_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51182,7 +51526,7 @@
             "key": "item_radarr_tag_horror",
             "label": "Top 250 Horror Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51192,7 +51536,7 @@
             "key": "item_radarr_tag_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51202,7 +51546,7 @@
             "key": "item_radarr_tag_international",
             "label": "Top 250 International Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51212,7 +51556,7 @@
             "key": "item_radarr_tag_million",
             "label": "One Million Watched Club Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51222,7 +51566,7 @@
             "key": "item_radarr_tag_most_fans",
             "label": "Top 250 Most Fans Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51232,7 +51576,7 @@
             "key": "item_radarr_tag_oscars",
             "label": "Oscar Best Picture Winners Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51242,7 +51586,7 @@
             "key": "item_radarr_tag_rogerebert",
             "label": "Roger Ebert's Great Movies Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51252,7 +51596,7 @@
             "key": "item_radarr_tag_science",
             "label": "Top 250 Sci-Fi Films Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51262,7 +51606,7 @@
             "key": "item_radarr_tag_sight_sound",
             "label": "Sight & Sound Greatest Films Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51272,7 +51616,7 @@
             "key": "item_radarr_tag_silent",
             "label": "Top 100 Silent Films Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51282,7 +51626,7 @@
             "key": "item_radarr_tag_top_500",
             "label": "Letterboxd Top 500 Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51292,7 +51636,7 @@
             "key": "item_radarr_tag_western",
             "label": "Top 100 Western Films Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51302,7 +51646,7 @@
             "key": "item_radarr_tag_women_directors",
             "label": "Top 250 Women-Directed Item Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "movie"
             ],
@@ -51312,7 +51656,7 @@
             "key": "item_sonarr_tag_1001_movies",
             "label": "1,001 To See Before You Die Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51322,7 +51666,7 @@
             "key": "item_sonarr_tag_afi_100",
             "label": "AFI 100 Years 100 Movies Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51332,7 +51676,7 @@
             "key": "item_sonarr_tag_animation",
             "label": "Top 100 Animation Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51342,7 +51686,7 @@
             "key": "item_sonarr_tag_black_directors",
             "label": "Top 250 Black-Directed Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51352,7 +51696,7 @@
             "key": "item_sonarr_tag_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51362,7 +51706,7 @@
             "key": "item_sonarr_tag_cannes",
             "label": "Cannes Palme d'Or Winners Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51372,7 +51716,7 @@
             "key": "item_sonarr_tag_documentaries",
             "label": "Top 250 Documentaries Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51382,7 +51726,7 @@
             "key": "item_sonarr_tag_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51392,7 +51736,7 @@
             "key": "item_sonarr_tag_horror",
             "label": "Top 250 Horror Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51402,7 +51746,7 @@
             "key": "item_sonarr_tag_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51412,7 +51756,7 @@
             "key": "item_sonarr_tag_international",
             "label": "Top 250 International Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51422,7 +51766,7 @@
             "key": "item_sonarr_tag_million",
             "label": "One Million Watched Club Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51432,7 +51776,7 @@
             "key": "item_sonarr_tag_most_fans",
             "label": "Top 250 Most Fans Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51442,7 +51786,7 @@
             "key": "item_sonarr_tag_oscars",
             "label": "Oscar Best Picture Winners Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51452,7 +51796,7 @@
             "key": "item_sonarr_tag_rogerebert",
             "label": "Roger Ebert's Great Movies Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51462,7 +51806,7 @@
             "key": "item_sonarr_tag_science",
             "label": "Top 250 Sci-Fi Films Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51472,7 +51816,7 @@
             "key": "item_sonarr_tag_sight_sound",
             "label": "Sight & Sound Greatest Films Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51482,7 +51826,7 @@
             "key": "item_sonarr_tag_silent",
             "label": "Top 100 Silent Films Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51492,7 +51836,7 @@
             "key": "item_sonarr_tag_top_500",
             "label": "Letterboxd Top 500 Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51502,7 +51846,7 @@
             "key": "item_sonarr_tag_western",
             "label": "Top 100 Western Films Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51512,7 +51856,7 @@
             "key": "item_sonarr_tag_women_directors",
             "label": "Top 250 Women-Directed Item Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "item_tags",
             "media_types": [
               "show"
             ],
@@ -51527,7 +51871,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_1001_movies",
@@ -51538,7 +51882,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_afi_100",
@@ -51549,7 +51893,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_animation",
@@ -51560,7 +51904,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_black_directors",
@@ -51571,7 +51915,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_boxofficemojo_100",
@@ -51582,7 +51926,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_cannes",
@@ -51593,7 +51937,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_documentaries",
@@ -51604,7 +51948,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_edgarwright",
@@ -51615,7 +51959,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_horror",
@@ -51626,7 +51970,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_imdb_top_250",
@@ -51637,7 +51981,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_international",
@@ -51648,7 +51992,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_million",
@@ -51659,7 +52003,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_most_fans",
@@ -51670,7 +52014,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_oscars",
@@ -51681,7 +52025,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_rogerebert",
@@ -51692,7 +52036,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_science",
@@ -51703,7 +52047,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_sight_sound",
@@ -51714,7 +52058,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_silent",
@@ -51725,7 +52069,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_top_500",
@@ -51736,7 +52080,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_western",
@@ -51747,7 +52091,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_add_missing_women_directors",
@@ -51758,7 +52102,7 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder",
@@ -51769,13 +52113,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_folder_1001_movies",
             "label": "1,001 To See Before You Die Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51785,7 +52129,7 @@
             "key": "radarr_folder_afi_100",
             "label": "AFI 100 Years 100 Movies Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51795,7 +52139,7 @@
             "key": "radarr_folder_animation",
             "label": "Top 100 Animation Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51805,7 +52149,7 @@
             "key": "radarr_folder_black_directors",
             "label": "Top 250 Black-Directed Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51815,7 +52159,7 @@
             "key": "radarr_folder_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51825,7 +52169,7 @@
             "key": "radarr_folder_cannes",
             "label": "Cannes Palme d'Or Winners Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51835,7 +52179,7 @@
             "key": "radarr_folder_documentaries",
             "label": "Top 250 Documentaries Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51845,7 +52189,7 @@
             "key": "radarr_folder_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51855,7 +52199,7 @@
             "key": "radarr_folder_horror",
             "label": "Top 250 Horror Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51865,7 +52209,7 @@
             "key": "radarr_folder_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51875,7 +52219,7 @@
             "key": "radarr_folder_international",
             "label": "Top 250 International Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51885,7 +52229,7 @@
             "key": "radarr_folder_million",
             "label": "One Million Watched Club Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51895,7 +52239,7 @@
             "key": "radarr_folder_most_fans",
             "label": "Top 250 Most Fans Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51905,7 +52249,7 @@
             "key": "radarr_folder_oscars",
             "label": "Oscar Best Picture Winners Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51915,7 +52259,7 @@
             "key": "radarr_folder_rogerebert",
             "label": "Roger Ebert's Great Movies Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51925,7 +52269,7 @@
             "key": "radarr_folder_science",
             "label": "Top 250 Sci-Fi Films Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51935,7 +52279,7 @@
             "key": "radarr_folder_sight_sound",
             "label": "Sight & Sound Greatest Films Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51945,7 +52289,7 @@
             "key": "radarr_folder_silent",
             "label": "Top 100 Silent Films Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51955,7 +52299,7 @@
             "key": "radarr_folder_top_500",
             "label": "Letterboxd Top 500 Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51965,7 +52309,7 @@
             "key": "radarr_folder_western",
             "label": "Top 100 Western Films Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51975,7 +52319,7 @@
             "key": "radarr_folder_women_directors",
             "label": "Top 250 Women-Directed Radarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -51989,13 +52333,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_1001_movies",
             "label": "1,001 To See Before You Die Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52018,7 +52362,7 @@
             "key": "radarr_monitor_afi_100",
             "label": "AFI 100 Years 100 Movies Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52041,7 +52385,7 @@
             "key": "radarr_monitor_animation",
             "label": "Top 100 Animation Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52064,7 +52408,7 @@
             "key": "radarr_monitor_black_directors",
             "label": "Top 250 Black-Directed Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52087,7 +52431,7 @@
             "key": "radarr_monitor_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52110,7 +52454,7 @@
             "key": "radarr_monitor_cannes",
             "label": "Cannes Palme d'Or Winners Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52133,7 +52477,7 @@
             "key": "radarr_monitor_documentaries",
             "label": "Top 250 Documentaries Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52156,7 +52500,7 @@
             "key": "radarr_monitor_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52183,13 +52527,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_monitor_existing_1001_movies",
             "label": "1,001 To See Before You Die Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52212,7 +52556,7 @@
             "key": "radarr_monitor_existing_afi_100",
             "label": "AFI 100 Years 100 Movies Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52235,7 +52579,7 @@
             "key": "radarr_monitor_existing_animation",
             "label": "Top 100 Animation Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52258,7 +52602,7 @@
             "key": "radarr_monitor_existing_black_directors",
             "label": "Top 250 Black-Directed Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52281,7 +52625,7 @@
             "key": "radarr_monitor_existing_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52304,7 +52648,7 @@
             "key": "radarr_monitor_existing_cannes",
             "label": "Cannes Palme d'Or Winners Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52327,7 +52671,7 @@
             "key": "radarr_monitor_existing_documentaries",
             "label": "Top 250 Documentaries Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52350,7 +52694,7 @@
             "key": "radarr_monitor_existing_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52373,7 +52717,7 @@
             "key": "radarr_monitor_existing_horror",
             "label": "Top 250 Horror Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52396,7 +52740,7 @@
             "key": "radarr_monitor_existing_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52419,7 +52763,7 @@
             "key": "radarr_monitor_existing_international",
             "label": "Top 250 International Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52442,7 +52786,7 @@
             "key": "radarr_monitor_existing_million",
             "label": "One Million Watched Club Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52465,7 +52809,7 @@
             "key": "radarr_monitor_existing_most_fans",
             "label": "Top 250 Most Fans Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52488,7 +52832,7 @@
             "key": "radarr_monitor_existing_oscars",
             "label": "Oscar Best Picture Winners Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52511,7 +52855,7 @@
             "key": "radarr_monitor_existing_rogerebert",
             "label": "Roger Ebert's Great Movies Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52534,7 +52878,7 @@
             "key": "radarr_monitor_existing_science",
             "label": "Top 250 Sci-Fi Films Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52557,7 +52901,7 @@
             "key": "radarr_monitor_existing_sight_sound",
             "label": "Sight & Sound Greatest Films Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52580,7 +52924,7 @@
             "key": "radarr_monitor_existing_silent",
             "label": "Top 100 Silent Films Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52603,7 +52947,7 @@
             "key": "radarr_monitor_existing_top_500",
             "label": "Letterboxd Top 500 Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52626,7 +52970,7 @@
             "key": "radarr_monitor_existing_western",
             "label": "Top 100 Western Films Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52649,7 +52993,7 @@
             "key": "radarr_monitor_existing_women_directors",
             "label": "Top 250 Women-Directed Radarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52672,7 +53016,7 @@
             "key": "radarr_monitor_horror",
             "label": "Top 250 Horror Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52695,7 +53039,7 @@
             "key": "radarr_monitor_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52718,7 +53062,7 @@
             "key": "radarr_monitor_international",
             "label": "Top 250 International Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52741,7 +53085,7 @@
             "key": "radarr_monitor_million",
             "label": "One Million Watched Club Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52764,7 +53108,7 @@
             "key": "radarr_monitor_most_fans",
             "label": "Top 250 Most Fans Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52787,7 +53131,7 @@
             "key": "radarr_monitor_oscars",
             "label": "Oscar Best Picture Winners Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52810,7 +53154,7 @@
             "key": "radarr_monitor_rogerebert",
             "label": "Roger Ebert's Great Movies Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52833,7 +53177,7 @@
             "key": "radarr_monitor_science",
             "label": "Top 250 Sci-Fi Films Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52856,7 +53200,7 @@
             "key": "radarr_monitor_sight_sound",
             "label": "Sight & Sound Greatest Films Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52879,7 +53223,7 @@
             "key": "radarr_monitor_silent",
             "label": "Top 100 Silent Films Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52902,7 +53246,7 @@
             "key": "radarr_monitor_top_500",
             "label": "Letterboxd Top 500 Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52925,7 +53269,7 @@
             "key": "radarr_monitor_western",
             "label": "Top 100 Western Films Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52948,7 +53292,7 @@
             "key": "radarr_monitor_women_directors",
             "label": "Top 250 Women-Directed Radarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -52975,13 +53319,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_search_1001_movies",
             "label": "1,001 To See Before You Die Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53004,7 +53348,7 @@
             "key": "radarr_search_afi_100",
             "label": "AFI 100 Years 100 Movies Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53027,7 +53371,7 @@
             "key": "radarr_search_animation",
             "label": "Top 100 Animation Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53050,7 +53394,7 @@
             "key": "radarr_search_black_directors",
             "label": "Top 250 Black-Directed Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53073,7 +53417,7 @@
             "key": "radarr_search_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53096,7 +53440,7 @@
             "key": "radarr_search_cannes",
             "label": "Cannes Palme d'Or Winners Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53119,7 +53463,7 @@
             "key": "radarr_search_documentaries",
             "label": "Top 250 Documentaries Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53142,7 +53486,7 @@
             "key": "radarr_search_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53165,7 +53509,7 @@
             "key": "radarr_search_horror",
             "label": "Top 250 Horror Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53188,7 +53532,7 @@
             "key": "radarr_search_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53211,7 +53555,7 @@
             "key": "radarr_search_international",
             "label": "Top 250 International Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53234,7 +53578,7 @@
             "key": "radarr_search_million",
             "label": "One Million Watched Club Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53257,7 +53601,7 @@
             "key": "radarr_search_most_fans",
             "label": "Top 250 Most Fans Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53280,7 +53624,7 @@
             "key": "radarr_search_oscars",
             "label": "Oscar Best Picture Winners Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53303,7 +53647,7 @@
             "key": "radarr_search_rogerebert",
             "label": "Roger Ebert's Great Movies Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53326,7 +53670,7 @@
             "key": "radarr_search_science",
             "label": "Top 250 Sci-Fi Films Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53349,7 +53693,7 @@
             "key": "radarr_search_sight_sound",
             "label": "Sight & Sound Greatest Films Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53372,7 +53716,7 @@
             "key": "radarr_search_silent",
             "label": "Top 100 Silent Films Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53395,7 +53739,7 @@
             "key": "radarr_search_top_500",
             "label": "Letterboxd Top 500 Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53418,7 +53762,7 @@
             "key": "radarr_search_western",
             "label": "Top 100 Western Films Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53441,7 +53785,7 @@
             "key": "radarr_search_women_directors",
             "label": "Top 250 Women-Directed Radarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53469,13 +53813,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_tag_1001_movies",
             "label": "1,001 To See Before You Die Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53485,7 +53829,7 @@
             "key": "radarr_tag_afi_100",
             "label": "AFI 100 Years 100 Movies Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53495,7 +53839,7 @@
             "key": "radarr_tag_animation",
             "label": "Top 100 Animation Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53505,7 +53849,7 @@
             "key": "radarr_tag_black_directors",
             "label": "Top 250 Black-Directed Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53515,7 +53859,7 @@
             "key": "radarr_tag_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53525,7 +53869,7 @@
             "key": "radarr_tag_cannes",
             "label": "Cannes Palme d'Or Winners Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53535,7 +53879,7 @@
             "key": "radarr_tag_documentaries",
             "label": "Top 250 Documentaries Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53545,7 +53889,7 @@
             "key": "radarr_tag_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53555,7 +53899,7 @@
             "key": "radarr_tag_horror",
             "label": "Top 250 Horror Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53565,7 +53909,7 @@
             "key": "radarr_tag_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53575,7 +53919,7 @@
             "key": "radarr_tag_international",
             "label": "Top 250 International Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53585,7 +53929,7 @@
             "key": "radarr_tag_million",
             "label": "One Million Watched Club Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53595,7 +53939,7 @@
             "key": "radarr_tag_most_fans",
             "label": "Top 250 Most Fans Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53605,7 +53949,7 @@
             "key": "radarr_tag_oscars",
             "label": "Oscar Best Picture Winners Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53615,7 +53959,7 @@
             "key": "radarr_tag_rogerebert",
             "label": "Roger Ebert's Great Movies Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53625,7 +53969,7 @@
             "key": "radarr_tag_science",
             "label": "Top 250 Sci-Fi Films Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53635,7 +53979,7 @@
             "key": "radarr_tag_sight_sound",
             "label": "Sight & Sound Greatest Films Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53645,7 +53989,7 @@
             "key": "radarr_tag_silent",
             "label": "Top 100 Silent Films Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53655,7 +53999,7 @@
             "key": "radarr_tag_top_500",
             "label": "Letterboxd Top 500 Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53665,7 +54009,7 @@
             "key": "radarr_tag_western",
             "label": "Top 100 Western Films Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53675,7 +54019,7 @@
             "key": "radarr_tag_women_directors",
             "label": "Top 250 Women-Directed Radarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53689,13 +54033,13 @@
             "media_types": [
               "movie"
             ],
-            "section": "automation"
+            "section": "radarr"
           },
           {
             "key": "radarr_upgrade_existing_1001_movies",
             "label": "1,001 To See Before You Die Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53718,7 +54062,7 @@
             "key": "radarr_upgrade_existing_afi_100",
             "label": "AFI 100 Years 100 Movies Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53741,7 +54085,7 @@
             "key": "radarr_upgrade_existing_animation",
             "label": "Top 100 Animation Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53764,7 +54108,7 @@
             "key": "radarr_upgrade_existing_black_directors",
             "label": "Top 250 Black-Directed Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53787,7 +54131,7 @@
             "key": "radarr_upgrade_existing_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53810,7 +54154,7 @@
             "key": "radarr_upgrade_existing_cannes",
             "label": "Cannes Palme d'Or Winners Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53833,7 +54177,7 @@
             "key": "radarr_upgrade_existing_documentaries",
             "label": "Top 250 Documentaries Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53856,7 +54200,7 @@
             "key": "radarr_upgrade_existing_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53879,7 +54223,7 @@
             "key": "radarr_upgrade_existing_horror",
             "label": "Top 250 Horror Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53902,7 +54246,7 @@
             "key": "radarr_upgrade_existing_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53925,7 +54269,7 @@
             "key": "radarr_upgrade_existing_international",
             "label": "Top 250 International Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53948,7 +54292,7 @@
             "key": "radarr_upgrade_existing_million",
             "label": "One Million Watched Club Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53971,7 +54315,7 @@
             "key": "radarr_upgrade_existing_most_fans",
             "label": "Top 250 Most Fans Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -53994,7 +54338,7 @@
             "key": "radarr_upgrade_existing_oscars",
             "label": "Oscar Best Picture Winners Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54017,7 +54361,7 @@
             "key": "radarr_upgrade_existing_rogerebert",
             "label": "Roger Ebert's Great Movies Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54040,7 +54384,7 @@
             "key": "radarr_upgrade_existing_science",
             "label": "Top 250 Sci-Fi Films Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54063,7 +54407,7 @@
             "key": "radarr_upgrade_existing_sight_sound",
             "label": "Sight & Sound Greatest Films Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54086,7 +54430,7 @@
             "key": "radarr_upgrade_existing_silent",
             "label": "Top 100 Silent Films Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54109,7 +54453,7 @@
             "key": "radarr_upgrade_existing_top_500",
             "label": "Letterboxd Top 500 Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54132,7 +54476,7 @@
             "key": "radarr_upgrade_existing_western",
             "label": "Top 100 Western Films Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54155,7 +54499,7 @@
             "key": "radarr_upgrade_existing_women_directors",
             "label": "Top 250 Women-Directed Radarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "radarr",
             "media_types": [
               "movie"
             ],
@@ -54178,7 +54522,7 @@
             "key": "sonarr_folder_1001_movies",
             "label": "1,001 To See Before You Die Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54188,7 +54532,7 @@
             "key": "sonarr_folder_afi_100",
             "label": "AFI 100 Years 100 Movies Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54198,7 +54542,7 @@
             "key": "sonarr_folder_animation",
             "label": "Top 100 Animation Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54208,7 +54552,7 @@
             "key": "sonarr_folder_black_directors",
             "label": "Top 250 Black-Directed Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54218,7 +54562,7 @@
             "key": "sonarr_folder_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54228,7 +54572,7 @@
             "key": "sonarr_folder_cannes",
             "label": "Cannes Palme d'Or Winners Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54238,7 +54582,7 @@
             "key": "sonarr_folder_documentaries",
             "label": "Top 250 Documentaries Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54248,7 +54592,7 @@
             "key": "sonarr_folder_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54258,7 +54602,7 @@
             "key": "sonarr_folder_horror",
             "label": "Top 250 Horror Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54268,7 +54612,7 @@
             "key": "sonarr_folder_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54278,7 +54622,7 @@
             "key": "sonarr_folder_international",
             "label": "Top 250 International Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54288,7 +54632,7 @@
             "key": "sonarr_folder_million",
             "label": "One Million Watched Club Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54298,7 +54642,7 @@
             "key": "sonarr_folder_most_fans",
             "label": "Top 250 Most Fans Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54308,7 +54652,7 @@
             "key": "sonarr_folder_oscars",
             "label": "Oscar Best Picture Winners Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54318,7 +54662,7 @@
             "key": "sonarr_folder_rogerebert",
             "label": "Roger Ebert's Great Movies Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54328,7 +54672,7 @@
             "key": "sonarr_folder_science",
             "label": "Top 250 Sci-Fi Films Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54338,7 +54682,7 @@
             "key": "sonarr_folder_sight_sound",
             "label": "Sight & Sound Greatest Films Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54348,7 +54692,7 @@
             "key": "sonarr_folder_silent",
             "label": "Top 100 Silent Films Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54358,7 +54702,7 @@
             "key": "sonarr_folder_top_500",
             "label": "Letterboxd Top 500 Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54368,7 +54712,7 @@
             "key": "sonarr_folder_western",
             "label": "Top 100 Western Films Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54378,7 +54722,7 @@
             "key": "sonarr_folder_women_directors",
             "label": "Top 250 Women-Directed Sonarr Folder",
             "type": "text",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54388,7 +54732,7 @@
             "key": "sonarr_monitor_1001_movies",
             "label": "1,001 To See Before You Die Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54435,7 +54779,7 @@
             "key": "sonarr_monitor_afi_100",
             "label": "AFI 100 Years 100 Movies Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54482,7 +54826,7 @@
             "key": "sonarr_monitor_animation",
             "label": "Top 100 Animation Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54529,7 +54873,7 @@
             "key": "sonarr_monitor_black_directors",
             "label": "Top 250 Black-Directed Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54576,7 +54920,7 @@
             "key": "sonarr_monitor_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54623,7 +54967,7 @@
             "key": "sonarr_monitor_cannes",
             "label": "Cannes Palme d'Or Winners Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54670,7 +55014,7 @@
             "key": "sonarr_monitor_documentaries",
             "label": "Top 250 Documentaries Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54717,7 +55061,7 @@
             "key": "sonarr_monitor_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54764,7 +55108,7 @@
             "key": "sonarr_monitor_existing_1001_movies",
             "label": "1,001 To See Before You Die Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54787,7 +55131,7 @@
             "key": "sonarr_monitor_existing_afi_100",
             "label": "AFI 100 Years 100 Movies Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54810,7 +55154,7 @@
             "key": "sonarr_monitor_existing_animation",
             "label": "Top 100 Animation Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54833,7 +55177,7 @@
             "key": "sonarr_monitor_existing_black_directors",
             "label": "Top 250 Black-Directed Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54856,7 +55200,7 @@
             "key": "sonarr_monitor_existing_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54879,7 +55223,7 @@
             "key": "sonarr_monitor_existing_cannes",
             "label": "Cannes Palme d'Or Winners Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54902,7 +55246,7 @@
             "key": "sonarr_monitor_existing_documentaries",
             "label": "Top 250 Documentaries Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54925,7 +55269,7 @@
             "key": "sonarr_monitor_existing_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54948,7 +55292,7 @@
             "key": "sonarr_monitor_existing_horror",
             "label": "Top 250 Horror Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54971,7 +55315,7 @@
             "key": "sonarr_monitor_existing_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -54994,7 +55338,7 @@
             "key": "sonarr_monitor_existing_international",
             "label": "Top 250 International Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55017,7 +55361,7 @@
             "key": "sonarr_monitor_existing_million",
             "label": "One Million Watched Club Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55040,7 +55384,7 @@
             "key": "sonarr_monitor_existing_most_fans",
             "label": "Top 250 Most Fans Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55063,7 +55407,7 @@
             "key": "sonarr_monitor_existing_oscars",
             "label": "Oscar Best Picture Winners Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55086,7 +55430,7 @@
             "key": "sonarr_monitor_existing_rogerebert",
             "label": "Roger Ebert's Great Movies Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55109,7 +55453,7 @@
             "key": "sonarr_monitor_existing_science",
             "label": "Top 250 Sci-Fi Films Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55132,7 +55476,7 @@
             "key": "sonarr_monitor_existing_sight_sound",
             "label": "Sight & Sound Greatest Films Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55155,7 +55499,7 @@
             "key": "sonarr_monitor_existing_silent",
             "label": "Top 100 Silent Films Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55178,7 +55522,7 @@
             "key": "sonarr_monitor_existing_top_500",
             "label": "Letterboxd Top 500 Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55201,7 +55545,7 @@
             "key": "sonarr_monitor_existing_western",
             "label": "Top 100 Western Films Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55224,7 +55568,7 @@
             "key": "sonarr_monitor_existing_women_directors",
             "label": "Top 250 Women-Directed Sonarr Monitor Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55247,7 +55591,7 @@
             "key": "sonarr_monitor_horror",
             "label": "Top 250 Horror Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55294,7 +55638,7 @@
             "key": "sonarr_monitor_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55341,7 +55685,7 @@
             "key": "sonarr_monitor_international",
             "label": "Top 250 International Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55388,7 +55732,7 @@
             "key": "sonarr_monitor_million",
             "label": "One Million Watched Club Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55435,7 +55779,7 @@
             "key": "sonarr_monitor_most_fans",
             "label": "Top 250 Most Fans Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55482,7 +55826,7 @@
             "key": "sonarr_monitor_oscars",
             "label": "Oscar Best Picture Winners Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55529,7 +55873,7 @@
             "key": "sonarr_monitor_rogerebert",
             "label": "Roger Ebert's Great Movies Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55576,7 +55920,7 @@
             "key": "sonarr_monitor_science",
             "label": "Top 250 Sci-Fi Films Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55623,7 +55967,7 @@
             "key": "sonarr_monitor_sight_sound",
             "label": "Sight & Sound Greatest Films Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55670,7 +56014,7 @@
             "key": "sonarr_monitor_silent",
             "label": "Top 100 Silent Films Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55717,7 +56061,7 @@
             "key": "sonarr_monitor_top_500",
             "label": "Letterboxd Top 500 Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55764,7 +56108,7 @@
             "key": "sonarr_monitor_western",
             "label": "Top 100 Western Films Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55811,7 +56155,7 @@
             "key": "sonarr_monitor_women_directors",
             "label": "Top 250 Women-Directed Sonarr Monitor",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55858,7 +56202,7 @@
             "key": "sonarr_search_1001_movies",
             "label": "1,001 To See Before You Die Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55881,7 +56225,7 @@
             "key": "sonarr_search_afi_100",
             "label": "AFI 100 Years 100 Movies Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55904,7 +56248,7 @@
             "key": "sonarr_search_animation",
             "label": "Top 100 Animation Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55927,7 +56271,7 @@
             "key": "sonarr_search_black_directors",
             "label": "Top 250 Black-Directed Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55950,7 +56294,7 @@
             "key": "sonarr_search_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55973,7 +56317,7 @@
             "key": "sonarr_search_cannes",
             "label": "Cannes Palme d'Or Winners Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -55996,7 +56340,7 @@
             "key": "sonarr_search_documentaries",
             "label": "Top 250 Documentaries Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56019,7 +56363,7 @@
             "key": "sonarr_search_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56042,7 +56386,7 @@
             "key": "sonarr_search_horror",
             "label": "Top 250 Horror Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56065,7 +56409,7 @@
             "key": "sonarr_search_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56088,7 +56432,7 @@
             "key": "sonarr_search_international",
             "label": "Top 250 International Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56111,7 +56455,7 @@
             "key": "sonarr_search_million",
             "label": "One Million Watched Club Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56134,7 +56478,7 @@
             "key": "sonarr_search_most_fans",
             "label": "Top 250 Most Fans Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56157,7 +56501,7 @@
             "key": "sonarr_search_oscars",
             "label": "Oscar Best Picture Winners Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56180,7 +56524,7 @@
             "key": "sonarr_search_rogerebert",
             "label": "Roger Ebert's Great Movies Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56203,7 +56547,7 @@
             "key": "sonarr_search_science",
             "label": "Top 250 Sci-Fi Films Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56226,7 +56570,7 @@
             "key": "sonarr_search_sight_sound",
             "label": "Sight & Sound Greatest Films Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56249,7 +56593,7 @@
             "key": "sonarr_search_silent",
             "label": "Top 100 Silent Films Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56272,7 +56616,7 @@
             "key": "sonarr_search_top_500",
             "label": "Letterboxd Top 500 Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56295,7 +56639,7 @@
             "key": "sonarr_search_western",
             "label": "Top 100 Western Films Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56318,7 +56662,7 @@
             "key": "sonarr_search_women_directors",
             "label": "Top 250 Women-Directed Sonarr Search",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56341,7 +56685,7 @@
             "key": "sonarr_tag_1001_movies",
             "label": "1,001 To See Before You Die Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56351,7 +56695,7 @@
             "key": "sonarr_tag_afi_100",
             "label": "AFI 100 Years 100 Movies Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56361,7 +56705,7 @@
             "key": "sonarr_tag_animation",
             "label": "Top 100 Animation Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56371,7 +56715,7 @@
             "key": "sonarr_tag_black_directors",
             "label": "Top 250 Black-Directed Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56381,7 +56725,7 @@
             "key": "sonarr_tag_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56391,7 +56735,7 @@
             "key": "sonarr_tag_cannes",
             "label": "Cannes Palme d'Or Winners Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56401,7 +56745,7 @@
             "key": "sonarr_tag_documentaries",
             "label": "Top 250 Documentaries Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56411,7 +56755,7 @@
             "key": "sonarr_tag_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56421,7 +56765,7 @@
             "key": "sonarr_tag_horror",
             "label": "Top 250 Horror Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56431,7 +56775,7 @@
             "key": "sonarr_tag_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56441,7 +56785,7 @@
             "key": "sonarr_tag_international",
             "label": "Top 250 International Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56451,7 +56795,7 @@
             "key": "sonarr_tag_million",
             "label": "One Million Watched Club Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56461,7 +56805,7 @@
             "key": "sonarr_tag_most_fans",
             "label": "Top 250 Most Fans Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56471,7 +56815,7 @@
             "key": "sonarr_tag_oscars",
             "label": "Oscar Best Picture Winners Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56481,7 +56825,7 @@
             "key": "sonarr_tag_rogerebert",
             "label": "Roger Ebert's Great Movies Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56491,7 +56835,7 @@
             "key": "sonarr_tag_science",
             "label": "Top 250 Sci-Fi Films Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56501,7 +56845,7 @@
             "key": "sonarr_tag_sight_sound",
             "label": "Sight & Sound Greatest Films Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56511,7 +56855,7 @@
             "key": "sonarr_tag_silent",
             "label": "Top 100 Silent Films Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56521,7 +56865,7 @@
             "key": "sonarr_tag_top_500",
             "label": "Letterboxd Top 500 Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56531,7 +56875,7 @@
             "key": "sonarr_tag_western",
             "label": "Top 100 Western Films Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56541,7 +56885,7 @@
             "key": "sonarr_tag_women_directors",
             "label": "Top 250 Women-Directed Sonarr Tags",
             "type": "string_list",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56551,7 +56895,7 @@
             "key": "sonarr_upgrade_existing_1001_movies",
             "label": "1,001 To See Before You Die Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56574,7 +56918,7 @@
             "key": "sonarr_upgrade_existing_afi_100",
             "label": "AFI 100 Years 100 Movies Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56597,7 +56941,7 @@
             "key": "sonarr_upgrade_existing_animation",
             "label": "Top 100 Animation Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56620,7 +56964,7 @@
             "key": "sonarr_upgrade_existing_black_directors",
             "label": "Top 250 Black-Directed Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56643,7 +56987,7 @@
             "key": "sonarr_upgrade_existing_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56666,7 +57010,7 @@
             "key": "sonarr_upgrade_existing_cannes",
             "label": "Cannes Palme d'Or Winners Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56689,7 +57033,7 @@
             "key": "sonarr_upgrade_existing_documentaries",
             "label": "Top 250 Documentaries Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56712,7 +57056,7 @@
             "key": "sonarr_upgrade_existing_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56735,7 +57079,7 @@
             "key": "sonarr_upgrade_existing_horror",
             "label": "Top 250 Horror Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56758,7 +57102,7 @@
             "key": "sonarr_upgrade_existing_imdb_top_250",
             "label": "IMDb Top 250 (Letterboxd) Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56781,7 +57125,7 @@
             "key": "sonarr_upgrade_existing_international",
             "label": "Top 250 International Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56804,7 +57148,7 @@
             "key": "sonarr_upgrade_existing_million",
             "label": "One Million Watched Club Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56827,7 +57171,7 @@
             "key": "sonarr_upgrade_existing_most_fans",
             "label": "Top 250 Most Fans Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56850,7 +57194,7 @@
             "key": "sonarr_upgrade_existing_oscars",
             "label": "Oscar Best Picture Winners Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56873,7 +57217,7 @@
             "key": "sonarr_upgrade_existing_rogerebert",
             "label": "Roger Ebert's Great Movies Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56896,7 +57240,7 @@
             "key": "sonarr_upgrade_existing_science",
             "label": "Top 250 Sci-Fi Films Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56919,7 +57263,7 @@
             "key": "sonarr_upgrade_existing_sight_sound",
             "label": "Sight & Sound Greatest Films Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56942,7 +57286,7 @@
             "key": "sonarr_upgrade_existing_silent",
             "label": "Top 100 Silent Films Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56965,7 +57309,7 @@
             "key": "sonarr_upgrade_existing_top_500",
             "label": "Letterboxd Top 500 Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -56988,7 +57332,7 @@
             "key": "sonarr_upgrade_existing_western",
             "label": "Top 100 Western Films Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -57011,7 +57355,7 @@
             "key": "sonarr_upgrade_existing_women_directors",
             "label": "Top 250 Women-Directed Sonarr Upgrade Existing",
             "type": "select",
-            "section": "automation",
+            "section": "sonarr",
             "media_types": [
               "show"
             ],
@@ -59297,6 +59641,49 @@
           {
             "id": "visibility",
             "label": "Visibility"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "shared_defaults",
+            "label": "Shared Defaults"
+          },
+          {
+            "id": "child_collections",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "filtering",
+            "label": "Filtering and Exclusions"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          },
+          {
+            "id": "item_tags",
+            "label": "Item Tags"
+          },
+          {
+            "id": "radarr",
+            "label": "Radarr"
+          },
+          {
+            "id": "sonarr",
+            "label": "Sonarr"
           }
         ]
       },

--- a/tests/test_collection_chart_organization_contract.py
+++ b/tests/test_collection_chart_organization_contract.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+
+QS_COLLECTIONS_PATH = Path("static/json/quickstart_collections.json")
+
+CHART_COLLECTION_IDS = [
+    "collection_basic",
+    "collection_tautulli",
+    "collection_imdb",
+    "collection_tmdb",
+    "collection_trakt",
+    "collection_simkl",
+    "collection_anilist",
+    "collection_myanimelist",
+    "collection_letterboxd",
+]
+
+EXPECTED_TEMPLATE_SECTIONS = [
+    "basics",
+    "naming",
+    "shared_defaults",
+    "child_collections",
+    "filtering",
+    "artwork",
+    "visibility",
+    "item_tags",
+    "radarr",
+    "sonarr",
+]
+
+
+def _load_collections():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    return {collection["id"]: collection for group in data for collection in group.get("collections", []) if collection.get("id") in CHART_COLLECTION_IDS}
+
+
+def _field_map(collection):
+    return {field["key"]: field for field in collection.get("template_variables", []) if isinstance(field, dict) and field.get("key")}
+
+
+def test_chart_source_collections_define_collapsible_template_variable_sections():
+    collections = _load_collections()
+
+    assert set(collections) == set(CHART_COLLECTION_IDS)
+    for collection_id in CHART_COLLECTION_IDS:
+        collection = collections[collection_id]
+        section_defs = collection.get("template_variable_sections") or []
+
+        assert [section["id"] for section in section_defs] == EXPECTED_TEMPLATE_SECTIONS
+        assert section_defs[0]["default_open"] is True
+
+        field_sections = {field.get("section") for field in collection.get("template_variables") or []}
+        assert None not in field_sections
+        assert field_sections <= set(EXPECTED_TEMPLATE_SECTIONS)
+
+
+def test_chart_source_common_fields_are_grouped_by_ui_purpose():
+    fields = _field_map(_load_collections()["collection_imdb"])
+
+    assert fields["collection_section"]["section"] == "basics"
+    assert fields["allowed_libraries"]["section"] == "basics"
+    assert fields["sort_title"]["section"] == "naming"
+    assert fields["delete_collections_named"]["section"] == "naming"
+    assert fields["limit"]["section"] == "shared_defaults"
+    assert fields["sync_mode"]["section"] == "shared_defaults"
+    assert fields["ignore_ids"]["section"] == "filtering"
+    assert fields["ignore_imdb_ids"]["section"] == "filtering"
+    assert fields["image"]["section"] == "artwork"
+    assert fields["url_logo_lowest"]["section"] == "artwork"
+    assert fields["hub_priority_top"]["section"] == "visibility"
+    assert fields["visible_home_popular"]["section"] == "visibility"
+    assert fields["item_radarr_tag_top"]["section"] == "item_tags"
+    assert fields["item_sonarr_tag_lowest"]["section"] == "item_tags"
+    assert fields["radarr_folder_top"]["section"] == "radarr"
+    assert fields["radarr_monitor_existing_lowest"]["section"] == "radarr"
+    assert fields["sonarr_folder_popular"]["section"] == "sonarr"
+    assert fields["sonarr_search_popular"]["section"] == "sonarr"
+
+
+def test_chart_source_child_specific_controls_share_chart_collections_section():
+    collections = _load_collections()
+
+    examples = {
+        "collection_basic": ["use_released", "name_episodes", "sort_by_released", "limit_episodes"],
+        "collection_tautulli": ["list_days_popular", "list_size_watched", "cache_builders_popular", "collection_order_watched"],
+        "collection_tmdb": ["use_trending", "limit_airing", "sync_mode_top", "schedule_air"],
+        "collection_simkl": ["period", "limit_trending_today", "schedule_dvd"],
+        "collection_myanimelist": ["starting_only", "starting_only_season", "limit_favorited", "schedule_airing"],
+        "collection_letterboxd": ["use_top_500", "limit_1001_movies", "cache_builders_black_directors", "collection_order_cannes"],
+    }
+
+    for collection_id, keys in examples.items():
+        fields = _field_map(collections[collection_id])
+        for key in keys:
+            if key in {"period", "starting_only"}:
+                assert fields[key]["section"] == "shared_defaults"
+            else:
+                assert fields[key]["section"] == "child_collections"


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Organize chart collection template variables

Description:
```markdown
## Summary
- Adds collapsible template variable sections for chart-source collections.
- Organizes `basic`, `tautulli`, `imdb`, `tmdb`, `trakt`, `simkl`, `anilist`, `myanimelist`, and `letterboxd` fields into logical UI groups.
- Groups existing fields under basics, naming, shared defaults, chart collections, filtering, artwork, visibility, item tags, Radarr, and Sonarr.
- Adds contract coverage to ensure chart collections keep section metadata and no chart template variables are left unsectioned.

## Testing
- `venv\Scripts\python.exe -m pytest tests\test_collection_chart_organization_contract.py tests\test_collection_chart_basic_tautulli_imdb_contract.py tests\test_collection_chart_tmdb_trakt_simkl_contract.py tests\test_collection_chart_anilist_mal_letterboxd_contract.py tests\test_importer_collection_files.py::test_prepare_import_payload_accepts_chart_builder_size_template_variables tests\test_core_backend.py::test_build_libraries_section_preserves_chart_builder_size_template_variables`

Result: `14 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
