### PR TITLE
added content rating

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -69756,42 +69756,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these US content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional US content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. PG-13)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional US content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional US content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -69800,89 +69881,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these US content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. PG-13)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional US content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. PG-13)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. PG-13)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional US content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. PG-13)",
-            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional US content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. PG-13)",
-            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -69891,7 +69891,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -69899,7 +69900,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -69907,108 +69909,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -70345,7 +70247,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/us/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -70355,7 +70520,111 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -70374,42 +70643,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these US content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional US content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. TV-14)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional US content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional US content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -70418,89 +70768,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these US content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. PG-13)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional US content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. PG-13)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. TV-14)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional US content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. PG-13)",
-            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional US content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. PG-13)",
-            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -70509,7 +70778,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -70517,7 +70787,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -70525,108 +70796,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -70963,7 +71134,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/us/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -70973,7 +71407,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -70993,42 +71531,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these UK content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. 15)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional UK content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. 15)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. 15)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional UK content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional UK content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -71037,89 +71656,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these UK content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. 15)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional UK content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. 15)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. 15)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional UK content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. 15)",
-            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional UK content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. 15)",
-            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -71128,7 +71666,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -71136,7 +71675,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -71144,108 +71684,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -71582,7 +72022,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/uk/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -71592,7 +72295,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -71602,7 +72306,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -71622,42 +72430,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these DE content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. 16)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional DE content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. 16)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. 12)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional DE content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. 16)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional DE content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. 16)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -71666,89 +72555,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these DE content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. 16)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional DE content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. 16)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. 12)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional DE content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. 16)",
-            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional DE content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. 16)",
-            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -71757,7 +72565,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -71765,7 +72574,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -71773,108 +72583,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -72211,7 +72921,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/de/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -72221,7 +73194,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -72231,7 +73205,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -72251,42 +73329,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these AU content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. MA15+)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional AU content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. MA15+)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. M)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional AU content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. MA15+)",
+            "value_placeholder": "Add comma-separated ratings (e.g. M, R18+)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional AU content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. MA15+)",
+            "value_placeholder": "Add comma-separated ratings (e.g. M, R18+)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -72295,89 +73454,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these AU content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. MA15+)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional AU content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. MA15+)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. M)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional AU content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. MA15+)",
-            "value_placeholder": "Add comma-separated ratings (e.g. M, R18+)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional AU content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. MA15+)",
-            "value_placeholder": "Add comma-separated ratings (e.g. M, R18+)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -72386,7 +73464,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -72394,7 +73473,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -72402,108 +73482,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -72840,7 +73820,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/au/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -72850,7 +74093,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -72860,7 +74104,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -72880,42 +74228,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these NZ content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. M)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional NZ content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. M)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. PG)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional NZ content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. M)",
+            "value_placeholder": "Add comma-separated ratings (e.g. PG, R16)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional NZ content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. M)",
+            "value_placeholder": "Add comma-separated ratings (e.g. PG, R16)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -72924,89 +74353,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these NZ content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. M)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional NZ content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. M)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. PG)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional NZ content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. M)",
-            "value_placeholder": "Add comma-separated ratings (e.g. PG, R16)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional NZ content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. M)",
-            "value_placeholder": "Add comma-separated ratings (e.g. PG, R16)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -73015,7 +74363,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -73023,7 +74372,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -73031,108 +74381,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -73469,7 +74719,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/nz/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -73479,7 +74992,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -73489,7 +75003,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -73509,42 +75127,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these MAL content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional MAL content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. PG-13)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional MAL content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. G, R)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional MAL content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. G, R)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -73553,89 +75252,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these MAL content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. PG-13)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional MAL content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. PG-13)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. PG-13)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional MAL content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. PG-13)",
-            "value_placeholder": "Add comma-separated ratings (e.g. G, R)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional MAL content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. PG-13)",
-            "value_placeholder": "Add comma-separated ratings (e.g. G, R)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -73644,7 +75262,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -73652,7 +75271,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -73660,108 +75280,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -74098,7 +75618,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/mal/<<key_name_encoded>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -74108,7 +75891,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -74118,7 +75902,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       },
@@ -74138,42 +76026,123 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "110",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "title_format",
             "label": "Title Format",
             "type": "text_input",
             "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the Kometa translation key for generated collection names and summaries.",
+            "section": "naming",
+            "default": "content_rating_cs"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Smart-filter search term used by content rating collections.",
+            "section": "scope",
+            "default": "content_rating"
+          },
+          {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these CS content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. 15)",
+            "mutually_exclusive_with": "exclude",
+            "section": "scope"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional CS content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. 15)",
+            "section": "scope"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. 13)",
+            "section": "scope"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional CS content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)",
+            "section": "scope"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional CS content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)",
+            "section": "scope"
           },
           {
             "key": "limit",
@@ -74182,89 +76151,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "use_other",
-            "label": "Other",
-            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_other",
-            "label": "Other Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_other",
-            "label": "Other Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_other",
-            "label": "Other Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "include",
-            "label": "Include",
-            "type": "string_list",
-            "tooltip": "Only create collections for these CS content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
-            "placeholder": "Add rating (e.g. 15)",
-            "mutually_exclusive_with": "exclude"
-          },
-          {
-            "key": "append_include",
-            "label": "Append Include",
-            "type": "string_list",
-            "tooltip": "Append additional CS content ratings to the default include list for this Defaults File.",
-            "placeholder": "Add rating (e.g. 15)"
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific content ratings from these collections.",
-            "placeholder": "Add content rating (e.g. 13)"
-          },
-          {
-            "key": "addons",
-            "label": "Addons",
-            "type": "mapping_list",
-            "tooltip": "Map a base value to additional CS content ratings that should be grouped into that collection.",
-            "key_placeholder": "Base rating (e.g. 15)",
-            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
-          },
-          {
-            "key": "append_addons",
-            "label": "Append Addons",
-            "type": "mapping_list",
-            "tooltip": "Append additional CS content ratings mappings to the default addons dictionary for this Defaults File.",
-            "key_placeholder": "Base rating (e.g. 15)",
-            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "minimum_items",
@@ -74273,7 +76161,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "scope"
           },
           {
             "key": "ignore_ids",
@@ -74281,7 +76170,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -74289,108 +76179,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_other",
-            "label": "Other Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_other",
-            "label": "Other Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_other",
-            "label": "Other Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_other",
-            "label": "Other Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_other",
-              "visible_library_other",
-              "visible_shared_other"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "sort_by",
@@ -74727,7 +76517,270 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "use_other",
+            "label": "Other",
+            "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
+            "type": "toggle",
+            "default": true,
+            "section": "other_collection"
+          },
+          {
+            "key": "name_other",
+            "label": "Other Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "other_collection"
+          },
+          {
+            "key": "summary_other",
+            "label": "Other Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "other_collection"
+          },
+          {
+            "key": "limit_other",
+            "label": "Other Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "other_collection"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Content Rating Use Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Content Rating Name Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection name",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Content Rating Summary Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "Custom collection summary",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Content Rating Order Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "01",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Content Rating Schedule Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "weekly(sunday)",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Content Rating Sort By Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "title.asc",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Content Rating Limit Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "25",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Content Rating Minimum Items Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "3",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text_input",
+            "tooltip": "Default image path used to build Kometa default poster URLs.",
+            "section": "artwork",
+            "default": "content_rating/cs/<<key_name>>"
+          },
+          {
+            "key": "child_image_overrides",
+            "label": "Content Rating Image Path Overrides",
+            "type": "mapping_list",
+            "section": "artwork",
+            "dynamic_child_prefix": "image_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating/us/PG-13",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_translation_key_overrides",
+            "label": "Content Rating Translation Key Overrides",
+            "type": "mapping_list",
+            "section": "child_override_maps",
+            "dynamic_child_prefix": "translation_key_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "content_rating",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -74737,7 +76790,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -74747,7 +76801,111 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Content Rating Visible Home Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Content Rating Visible Library Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Content Rating Visible Shared Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "true or false",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Content Rating Hub Priority Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "1",
+            "lookup_display_mode": "inline"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Content Rating Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,pg13",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Content Rating Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "section": "visibility",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "key_placeholder": "Rating key (e.g. PG-13, 12A, TV-MA)",
+            "value_placeholder": "rating,tvma",
+            "lookup_display_mode": "inline",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "scope",
+            "label": "Scope and Filtering"
+          },
+          {
+            "id": "other_collection",
+            "label": "Other Collection"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Per-Rating Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility and Item Tags"
           }
         ]
       }
@@ -75023,14 +77181,16 @@
             "label": "Other Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "defaults"
           },
           {
             "key": "summary_other",
             "label": "Other Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "defaults"
           },
           {
             "key": "limit_other",
@@ -75039,7 +77199,8 @@
             "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "defaults"
           },
           {
             "key": "include",
@@ -76130,14 +78291,16 @@
             "label": "Other Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Other collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "defaults"
           },
           {
             "key": "summary_other",
             "label": "Other Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Other collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "defaults"
           },
           {
             "key": "limit_other",
@@ -76146,7 +78309,8 @@
             "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "defaults"
           },
           {
             "key": "include",
@@ -80740,21 +82904,24 @@
             "label": "Africa Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Africa collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library_Africa",
             "label": "Africa Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared_Africa",
             "label": "Africa Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority_Africa",
@@ -80771,28 +82938,32 @@
               "visible_library_Africa",
               "visible_shared_Africa"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "visible_home_Americas",
             "label": "Americas Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Americas collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library_Americas",
             "label": "Americas Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Americas collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared_Americas",
             "label": "Americas Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Americas collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority_Americas",
@@ -80809,28 +82980,32 @@
               "visible_library_Americas",
               "visible_shared_Americas"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "visible_home_Antarctica",
             "label": "Antarctica Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Antarctica collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library_Antarctica",
             "label": "Antarctica Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Antarctica collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared_Antarctica",
             "label": "Antarctica Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Antarctica collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority_Antarctica",
@@ -80847,28 +83022,32 @@
               "visible_library_Antarctica",
               "visible_shared_Antarctica"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "visible_home_Asia",
             "label": "Asia Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Asia collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library_Asia",
             "label": "Asia Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared_Asia",
             "label": "Asia Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority_Asia",
@@ -80885,28 +83064,32 @@
               "visible_library_Asia",
               "visible_shared_Asia"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "visible_home_Europe",
             "label": "Europe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Europe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library_Europe",
             "label": "Europe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Europe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared_Europe",
             "label": "Europe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority_Europe",
@@ -80923,28 +83106,32 @@
               "visible_library_Europe",
               "visible_shared_Europe"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "visible_home_Oceania",
             "label": "Oceania Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Oceania collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library_Oceania",
             "label": "Oceania Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Oceania collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared_Oceania",
             "label": "Oceania Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Oceania collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority_Oceania",
@@ -80961,7 +83148,8 @@
               "visible_library_Oceania",
               "visible_shared_Oceania"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "visible_home_other",
@@ -100080,7 +102268,8 @@
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific seasonal collections from these collections.",
-            "placeholder": "Add seasonal key (e.g. halloween)"
+            "placeholder": "Add seasonal key (e.g. halloween)",
+            "section": "scope_schedule"
           }
         ],
         "template_variable_sections": [

--- a/tests/test_collection_content_rating_contract.py
+++ b/tests/test_collection_content_rating_contract.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+
+QS_COLLECTIONS_PATH = Path("static/json/quickstart_collections.json")
+
+EXPECTED_SECTIONS = [
+    "basics",
+    "naming",
+    "scope",
+    "other_collection",
+    "child_override_maps",
+    "artwork",
+    "visibility",
+]
+
+EXPECTED_DEFAULTS = {
+    ("collection_content_rating_us", ("movie",)): ("content_rating/us/<<key_name>>", "content_rating"),
+    ("collection_content_rating_us", ("show",)): ("content_rating/us/<<key_name>>", "content_rating"),
+    ("collection_content_rating_uk", ("movie", "show")): ("content_rating/uk/<<key_name>>", "content_rating"),
+    ("collection_content_rating_de", ("movie", "show")): ("content_rating/de/<<key_name>>", "content_rating"),
+    ("collection_content_rating_au", ("movie", "show")): ("content_rating/au/<<key_name>>", "content_rating"),
+    ("collection_content_rating_nz", ("movie", "show")): ("content_rating/nz/<<key_name>>", "content_rating"),
+    ("collection_content_rating_mal", ("movie", "show")): ("content_rating/mal/<<key_name_encoded>>", "content_rating"),
+    ("collection_content_rating_cs", ("movie", "show")): ("content_rating/cs/<<key_name>>", "content_rating_cs"),
+}
+
+
+def _load_collections():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    collections = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            collection_id = collection.get("id")
+            if collection_id and collection_id.startswith("collection_content_rating"):
+                collections[(collection_id, tuple(collection.get("media_types") or []))] = collection
+    return collections
+
+
+def _field_map(collection):
+    return {field["key"]: field for field in collection.get("template_variables", []) if isinstance(field, dict) and field.get("key")}
+
+
+def _assert_mapping(field, child_prefix, value_kind, section, media_types=None):
+    assert field["type"] == "mapping_list"
+    assert field["dynamic_child_prefix"] == child_prefix
+    assert field["dynamic_child_value_kind"] == value_kind
+    assert field["section"] == section
+    assert "key_input_mode" not in field
+    if media_types is None:
+        assert "media_types" not in field
+    else:
+        assert field["media_types"] == media_types
+
+
+def test_content_rating_collections_expose_defaults_and_collapsible_sections():
+    collections = _load_collections()
+
+    assert set(collections) == set(EXPECTED_DEFAULTS)
+    for key, (image_default, translation_default) in EXPECTED_DEFAULTS.items():
+        collection = collections[key]
+        fields = _field_map(collection)
+
+        assert [section["id"] for section in collection.get("template_variable_sections") or []] == EXPECTED_SECTIONS
+        assert fields["search_term"]["default"] == "content_rating"
+        assert fields["search_term"]["section"] == "scope"
+        assert fields["image"]["default"] == image_default
+        assert fields["image"]["section"] == "artwork"
+        assert fields["translation_key"]["default"] == translation_default
+        assert fields["translation_key"]["section"] == "naming"
+        assert fields["use_other"]["section"] == "other_collection"
+        assert fields["limit_other"]["section"] == "other_collection"
+
+
+def test_content_rating_collections_expose_per_rating_override_maps():
+    fields = _field_map(_load_collections()[("collection_content_rating_uk", ("movie", "show"))])
+
+    expected_mappings = {
+        "child_use_overrides": ("use_", "boolean", "child_override_maps", None),
+        "child_name_overrides": ("name_", "string", "child_override_maps", None),
+        "child_summary_overrides": ("summary_", "string", "child_override_maps", None),
+        "child_order_overrides": ("order_", "string", "child_override_maps", None),
+        "child_schedule_overrides": ("schedule_", "string", "child_override_maps", None),
+        "child_sort_by_overrides": ("sort_by_", "select", "child_override_maps", None),
+        "child_limit_overrides": ("limit_", "integer", "child_override_maps", None),
+        "child_minimum_items_overrides": ("minimum_items_", "integer", "child_override_maps", None),
+        "child_image_overrides": ("image_", "string", "artwork", None),
+        "child_translation_key_overrides": ("translation_key_", "string", "child_override_maps", None),
+        "child_visible_home_overrides": ("visible_home_", "boolean", "visibility", None),
+        "child_visible_library_overrides": ("visible_library_", "boolean", "visibility", None),
+        "child_visible_shared_overrides": ("visible_shared_", "boolean", "visibility", None),
+        "child_hub_priority_overrides": ("hub_priority_", "string", "visibility", None),
+        "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "visibility", ["movie"]),
+        "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list", "visibility", ["show"]),
+    }
+    for key, (child_prefix, value_kind, section, media_types) in expected_mappings.items():
+        _assert_mapping(fields[key], child_prefix, value_kind, section, media_types)
+
+
+def test_all_collection_template_variable_entries_are_sectioned_after_content_rating_pass():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    unsectioned = []
+    missing_sections = []
+    for group in data:
+        for collection in group.get("collections", []):
+            collection_id = collection.get("id")
+            if not collection_id or collection_id.startswith("collection_separator"):
+                continue
+            if collection.get("template_variables") and not collection.get("template_variable_sections"):
+                missing_sections.append(collection_id)
+            for field in collection.get("template_variables") or []:
+                if not field.get("section"):
+                    unsectioned.append((collection_id, field.get("key")))
+
+    assert missing_sections == []
+    assert unsectioned == []

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2158,8 +2158,15 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
                     "mov-library_movies-collection_year": True,
                     "mov-library_movies-template_collection_year_limit": "8",
                     "mov-library_movies-collection_content_rating_us": True,
+                    "mov-library_movies-template_collection_content_rating_us_search_term": "content_rating",
+                    "mov-library_movies-template_collection_content_rating_us_image": "content_rating/us/<<key_name>>",
+                    "mov-library_movies-template_collection_content_rating_us_translation_key": "content_rating",
                     "mov-library_movies-template_collection_content_rating_us_limit": "40",
                     "mov-library_movies-template_collection_content_rating_us_limit_other": "5",
+                    "mov-library_movies-template_collection_content_rating_us_child_visible_home_overrides": '{"PG-13": "true"}',
+                    "mov-library_movies-template_collection_content_rating_us_child_hub_priority_overrides": '{"PG-13": "1"}',
+                    "mov-library_movies-template_collection_content_rating_us_child_image_overrides": '{"PG-13": "content_rating/us/PG-13-custom"}',
+                    "mov-library_movies-template_collection_content_rating_us_child_item_radarr_tag_overrides": '{"R": "rating,r"}',
                 }
             },
         )
@@ -2271,8 +2278,15 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
     assert seasonal_entry["template_variables"]["limit"] == "30"
     assert seasonal_entry["template_variables"]["limit_halloween"] == "12"
     assert year_entry["template_variables"]["limit"] == "8"
+    assert content_rating_us_entry["template_variables"]["search_term"] == "content_rating"
+    assert content_rating_us_entry["template_variables"]["image"] == "content_rating/us/<<key_name>>"
+    assert content_rating_us_entry["template_variables"]["translation_key"] == "content_rating"
     assert content_rating_us_entry["template_variables"]["limit"] == "40"
     assert content_rating_us_entry["template_variables"]["limit_other"] == "5"
+    assert content_rating_us_entry["template_variables"]["visible_home_PG-13"] is True
+    assert content_rating_us_entry["template_variables"]["hub_priority_PG-13"] == "1"
+    assert content_rating_us_entry["template_variables"]["image_PG-13"] == "content_rating/us/PG-13-custom"
+    assert content_rating_us_entry["template_variables"]["item_radarr_tag_R"] == ["rating", "r"]
 
 
 def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -199,8 +199,15 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
                         {
                             "default": "content_rating_us",
                             "template_variables": {
+                                "search_term": "content_rating",
+                                "image": "content_rating/us/<<key_name>>",
+                                "translation_key": "content_rating",
                                 "limit": 40,
                                 "limit_other": 5,
+                                "visible_home_PG-13": True,
+                                "hub_priority_PG-13": 1,
+                                "image_PG-13": "content_rating/us/PG-13-custom",
+                                "item_radarr_tag_R": ["rating", "r"],
                             },
                         },
                     ]
@@ -303,8 +310,15 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
     assert libraries_payload["mov-library_movies-template_collection_seasonal_limit"] == 30
     assert libraries_payload["mov-library_movies-template_collection_seasonal_limit_halloween"] == 12
     assert libraries_payload["mov-library_movies-template_collection_year_limit"] == 8
+    assert libraries_payload["mov-library_movies-template_collection_content_rating_us_search_term"] == "content_rating"
+    assert libraries_payload["mov-library_movies-template_collection_content_rating_us_image"] == "content_rating/us/<<key_name>>"
+    assert libraries_payload["mov-library_movies-template_collection_content_rating_us_translation_key"] == "content_rating"
     assert libraries_payload["mov-library_movies-template_collection_content_rating_us_limit"] == 40
     assert libraries_payload["mov-library_movies-template_collection_content_rating_us_limit_other"] == 5
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_content_rating_us_child_visible_home_overrides"]) == {"PG-13": "true"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_content_rating_us_child_hub_priority_overrides"]) == {"PG-13": "1"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_content_rating_us_child_image_overrides"]) == {"PG-13": "content_rating/us/PG-13-custom"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_content_rating_us_child_item_radarr_tag_overrides"]) == {"R": "rating,r"}
     assert any("libraries.Movies.collection_files[0].template_variables.list_days" in line for line in report.lines)
     assert any("libraries.Movies.collection_files[1].template_variables.limit_popular" in line for line in report.lines)
     assert any("libraries.Movies.collection_files[2].template_variables.limit_airing" in line for line in report.lines)
@@ -319,6 +333,7 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
     assert any("libraries.Movies.collection_files[11].template_variables.limit_halloween" in line for line in report.lines)
     assert any("libraries.Movies.collection_files[12].template_variables.limit" in line for line in report.lines)
     assert any("libraries.Movies.collection_files[13].template_variables.limit_other" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[13].template_variables.visible_home_PG-13" in line for line in report.lines)
 
 
 def test_prepare_import_payload_collapses_franchise_dynamic_child_template_variables():

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -460,6 +460,38 @@ def test_apply_template_var_normalizers_expands_resolution_dynamic_child_overrid
     assert template_vars["item_sonarr_tag_1080"] == ["resolution", "1080p"]
 
 
+def test_apply_template_var_normalizers_expands_content_rating_dynamic_child_override_maps():
+    template_vars = {
+        "child_use_overrides": '{"PG-13": "false"}',
+        "child_name_overrides": '{"PG-13": "Teen Ratings"}',
+        "child_schedule_overrides": '{"12A": "weekly(sunday)"}',
+        "child_sort_by_overrides": '{"R": "title.asc"}',
+        "child_limit_overrides": '{"R": "25"}',
+        "child_minimum_items_overrides": '{"NC-17": "3"}',
+        "child_image_overrides": '{"PG-13": "content_rating/us/PG-13-custom"}',
+        "child_translation_key_overrides": '{"PG-13": "content_rating_pg13"}',
+        "child_visible_home_overrides": '{"12A": "true"}',
+        "child_hub_priority_overrides": '{"12A": "1"}',
+        "child_item_radarr_tag_overrides": '{"R": ["rating", "r"]}',
+        "child_item_sonarr_tag_overrides": '{"TV-MA": "rating,tvma"}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "content_rating_uk")
+
+    assert template_vars["use_PG-13"] is False
+    assert template_vars["name_PG-13"] == "Teen Ratings"
+    assert template_vars["schedule_12A"] == "weekly(sunday)"
+    assert template_vars["sort_by_R"] == "title.asc"
+    assert template_vars["limit_R"] == 25
+    assert template_vars["minimum_items_NC-17"] == 3
+    assert template_vars["image_PG-13"] == "content_rating/us/PG-13-custom"
+    assert template_vars["translation_key_PG-13"] == "content_rating_pg13"
+    assert template_vars["visible_home_12A"] is True
+    assert template_vars["hub_priority_12A"] == "1"
+    assert template_vars["item_radarr_tag_R"] == ["rating", "r"]
+    assert template_vars["item_sonarr_tag_TV-MA"] == ["rating", "tvma"]
+
+
 def test_apply_template_var_normalizers_expands_award_year_override_maps():
     template_vars = {
         "child_collection_order_overrides": '{"2024": "release"}',


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Add content rating collection template variable coverage

Description:
```markdown
## Summary
- Adds organized template variable sections for all content rating collection defaults.
- Adds missing smart-filter defaults for `search_term`, `image`, and `translation_key`.
- Adds per-rating override maps for use/name/summary/schedule/sort/limit/minimum items/image/translation/visibility/hub priority/item tags.
- Confirms all collection template variables now have section metadata.

## Testing
- `venv\Scripts\python.exe -m pytest tests\test_collection_content_rating_contract.py tests\test_collection_region_studio_network_contract.py tests\test_collection_seasonal_contract.py tests\test_output_collection_child_override_contract.py tests\test_importer_collection_files.py tests\test_core_backend.py`

Result: `258 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
