### PR TITLE
New env vars

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -267,7 +267,10 @@ document.querySelectorAll('input[name="log-flag"]').forEach(el => el.addEventLis
 function syncValidationCommandOptions () {
   const validateMode = (document.querySelector('input[name="validate-mode"]:checked') || {}).value || ''
   const schemaChecked = Boolean(document.getElementById('opt-validate-schema')?.checked)
-  document.getElementById('validate-config-options')?.classList.toggle('d-none', validateMode !== '--validate')
+  const validateLevel = document.getElementById('opt-validate-level')
+  const validateSchema = document.getElementById('opt-validate-schema')
+  if (validateLevel) validateLevel.disabled = validateMode !== '--validate'
+  if (validateSchema) validateSchema.disabled = validateMode !== '--validate'
   document.getElementById('validate-file-options')?.classList.toggle('d-none', validateMode !== '--validate-file')
   document.getElementById('validate-dir-options')?.classList.toggle('d-none', validateMode !== '--validate-dir')
   document.getElementById('validate-schema-path-options')?.classList.toggle(

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -264,6 +264,39 @@ document.getElementById('library-multiselect')?.addEventListener('change', build
 document.querySelectorAll('input[name="mode-flag"]').forEach(el => el.addEventListener('change', buildCommand))
 document.querySelectorAll('input[name="log-flag"]').forEach(el => el.addEventListener('change', buildCommand))
 
+function syncValidationCommandOptions () {
+  const validateMode = (document.querySelector('input[name="validate-mode"]:checked') || {}).value || ''
+  const schemaChecked = Boolean(document.getElementById('opt-validate-schema')?.checked)
+  document.getElementById('validate-config-options')?.classList.toggle('d-none', validateMode !== '--validate')
+  document.getElementById('validate-file-options')?.classList.toggle('d-none', validateMode !== '--validate-file')
+  document.getElementById('validate-dir-options')?.classList.toggle('d-none', validateMode !== '--validate-dir')
+  document.getElementById('validate-schema-path-options')?.classList.toggle(
+    'd-none',
+    !(validateMode === '--validate-file' || validateMode === '--validate-dir' || (validateMode === '--validate' && schemaChecked))
+  )
+  if (validateMode !== '--validate-file') {
+    document.getElementById('validate-file-error')?.classList.add('d-none')
+  }
+  if (validateMode !== '--validate-dir') {
+    document.getElementById('validate-dir-error')?.classList.add('d-none')
+  }
+}
+
+document.querySelectorAll('input[name="validate-mode"]').forEach(el => {
+  el.addEventListener('change', function () {
+    syncValidationCommandOptions()
+    buildCommand()
+  })
+})
+document.getElementById('opt-validate-level')?.addEventListener('change', buildCommand)
+document.getElementById('opt-validate-schema')?.addEventListener('change', function () {
+  syncValidationCommandOptions()
+  buildCommand()
+})
+document.getElementById('opt-validate-file-val')?.addEventListener('input', buildCommand)
+document.getElementById('opt-validate-dir-val')?.addEventListener('input', buildCommand)
+document.getElementById('opt-schema-path')?.addEventListener('input', buildCommand)
+
 const checkboxFlags = [
   'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
   'no-report', 'no-missing', 'no-countdown', 'ignore-ghost',
@@ -280,6 +313,7 @@ if (document.getElementById('run-command-output')) {
   const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value
   checkMaintenanceWarning(mainOption)
   updateLibraryVisibility(mainOption)
+  syncValidationCommandOptions()
   buildCommand()
 }
 

--- a/static/local-js/modules/kometa/_cliFlags.js
+++ b/static/local-js/modules/kometa/_cliFlags.js
@@ -88,6 +88,30 @@ export const KOMETA_CLI_FLAGS = Object.freeze({
     label: 'Log Requests Logging',
     description: 'Most verbose logging. If you enable this, every external network request made by Kometa will be logged, along with the data that is returned. This will add a lot of data to the logs, and will probably contain things like tokens, since the auto-redaction of such things is not generalized enough to catch any token that may be in any URL.<br><strong>WARNING</strong>:<br><code>This can potentially have personal information in it.</code>'
   },
+  '--validate': {
+    label: 'Validate Generated Config',
+    description: 'Parse and validate the generated config.yml and linked YAML files, print a structured report, then exit without performing a normal run. Environment variable: <code>KOMETA_VALIDATE</code>.'
+  },
+  '--validate-file': {
+    label: 'Validate File',
+    description: 'Validate one YAML file against its auto-detected JSON schema and print any errors or schema gaps. Environment variable: <code>KOMETA_VALIDATE_FILE</code>.'
+  },
+  '--validate-dir': {
+    label: 'Validate Directory',
+    description: 'Recursively validate YAML files in a directory and print a combined schema-gap report. Environment variable: <code>KOMETA_VALIDATE_DIR</code>.'
+  },
+  '--validate-level': {
+    label: 'Validate Level',
+    description: 'Controls how deep config validation goes. Accepted values: <code>syntax</code>, <code>structure</code>, or <code>full</code>. Environment variable: <code>KOMETA_VALIDATE_LEVEL</code>.'
+  },
+  '--validate-schema': {
+    label: 'Validate Schema',
+    description: 'When set with config validation, also check YAML files against JSON schemas. Environment variable: <code>KOMETA_VALIDATE_SCHEMA</code>.'
+  },
+  '--schema-path': {
+    label: 'Schema Path',
+    description: 'Override the path to the json-schema directory used by schema validation. Environment variable: <code>KOMETA_SCHEMA_PATH</code>.'
+  },
   '--delete-collections': {
     label: 'Delete Collections',
     description: 'Delete all collections in each library as the first step in the run.<br><strong>WARNING</strong>:<br><code>You will lose all collections in the library - this will delete all collections, including ones not created or maintained by Kometa.</code>'
@@ -157,6 +181,10 @@ const MODE_FLAGS = [
   '--overlays-only', '--playlists-only'
 ]
 const LOG_FLAGS = ['--debug', '--trace', '--log-requests']
+const VALIDATION_FLAGS = [
+  '--validate', '--validate-file', '--validate-dir',
+  '--validate-level', '--validate-schema', '--schema-path'
+]
 const OTHER_FLAGS = [
   '--delete-collections', '--delete-labels', '--read-only-config', '--low-priority',
   '--no-report', '--no-missing', '--no-countdown', '--ignore-ghost',
@@ -203,6 +231,7 @@ export function updateFlagLabels (showCli, opts = {}) {
   updateLabels(RUN_OPTION_FLAGS, 'opt-')
   updateLabels(MODE_FLAGS, 'opt-')
   updateLabels(LOG_FLAGS, 'opt-')
+  updateLabels(VALIDATION_FLAGS, 'opt-')
   updateLabels(OTHER_FLAGS, 'opt-')
 
   if (onInitTooltips) onInitTooltips(document)

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -176,6 +176,30 @@ export function updateLogFlagsHeaderBadge () {
 }
 
 /**
+ * "Validation / Schema Checks" selects a validate-and-exit command
+ * instead of a normal Kometa run. Badge state mirrors the selected
+ * validation mode and dependent path fields.
+ */
+export function updateValidationFlagsHeaderBadge () {
+  const validateMode = (document.querySelector('input[name="validate-mode"]:checked') || {}).value || ''
+  if (!validateMode) {
+    setHeaderRollupBadge('heading-validationflags-rollup-badge', 'unknown', 'Default')
+    return
+  }
+  if (validateMode === '--validate-file') {
+    const filePath = (document.getElementById('opt-validate-file-val') || {}).value?.trim?.() || ''
+    setHeaderRollupBadge('heading-validationflags-rollup-badge', filePath ? 'ok' : 'warn', filePath ? 'Validate File' : 'File needed')
+    return
+  }
+  if (validateMode === '--validate-dir') {
+    const dirPath = (document.getElementById('opt-validate-dir-val') || {}).value?.trim?.() || ''
+    setHeaderRollupBadge('heading-validationflags-rollup-badge', dirPath ? 'ok' : 'warn', dirPath ? 'Validate Directory' : 'Directory needed')
+    return
+  }
+  setHeaderRollupBadge('heading-validationflags-rollup-badge', 'ok', 'Validate Config')
+}
+
+/**
  * "Other flags" == the checkbox grid of boolean CLI flags plus the
  * three "with-value" extras (timeout, divider, width). Badge shows
  * a count of enabled flags.
@@ -320,6 +344,7 @@ export function syncFinalAccordionRollups () {
   updateRunOptionHeaderBadge()
   updateModeFlagsHeaderBadge()
   updateLogFlagsHeaderBadge()
+  updateValidationFlagsHeaderBadge()
   updateOtherFlagsHeaderBadge()
   updateConfigOutputHeaderBadges()
   updateRunCommandHeaderBadge()

--- a/static/local-js/modules/kometa/_runCommand.js
+++ b/static/local-js/modules/kometa/_runCommand.js
@@ -242,6 +242,59 @@ export function buildCommand () {
 
   let cli = `${quoteIfNeeded(finalPythonBin)} ${quoteIfNeeded(finalKometaPy)}`
 
+  // ---- Validation modes: validate and exit, not a normal run -------
+  const validateMode = (document.querySelector('input[name="validate-mode"]:checked') || {}).value || ''
+  const clearValidationErrors = () => {
+    document.getElementById('validate-file-error')?.classList.add('d-none')
+    document.getElementById('validate-dir-error')?.classList.add('d-none')
+  }
+  if (validateMode) {
+    clearValidationErrors()
+    if (validateMode === '--validate') {
+      cli += ' --validate'
+      const validateLevel = (document.getElementById('opt-validate-level') || {}).value?.trim?.() || ''
+      if (validateLevel) cli += ` --validate-level ${validateLevel}`
+      const validateSchema = document.getElementById('opt-validate-schema')
+      if (validateSchema && validateSchema.checked) cli += ' --validate-schema'
+      const schemaPath = (document.getElementById('opt-schema-path') || {}).value?.trim?.() || ''
+      if (schemaPath) cli += ` --schema-path ${quoteIfNeeded(schemaPath)}`
+      cli += ` --config ${quoteIfNeeded(finalConfigPath)}`
+    } else if (validateMode === '--validate-file') {
+      const validateFile = (document.getElementById('opt-validate-file-val') || {}).value?.trim?.() || ''
+      if (!validateFile) {
+        document.getElementById('validate-file-error')?.classList.remove('d-none')
+        const errorEl = document.getElementById('validate-file-error')
+        if (errorEl) errorEl.textContent = 'Please enter a YAML file path.'
+        runCmdOutput.textContent = '⚠️ Please enter a YAML file path for --validate-file.'
+        notify()
+        return false
+      }
+      cli += ` --validate-file ${quoteIfNeeded(validateFile)}`
+      const schemaPath = (document.getElementById('opt-schema-path') || {}).value?.trim?.() || ''
+      if (schemaPath) cli += ` --schema-path ${quoteIfNeeded(schemaPath)}`
+    } else if (validateMode === '--validate-dir') {
+      const validateDir = (document.getElementById('opt-validate-dir-val') || {}).value?.trim?.() || ''
+      if (!validateDir) {
+        document.getElementById('validate-dir-error')?.classList.remove('d-none')
+        const errorEl = document.getElementById('validate-dir-error')
+        if (errorEl) errorEl.textContent = 'Please enter a YAML directory path.'
+        runCmdOutput.textContent = '⚠️ Please enter a YAML directory path for --validate-dir.'
+        notify()
+        return false
+      }
+      cli += ` --validate-dir ${quoteIfNeeded(validateDir)}`
+      const schemaPath = (document.getElementById('opt-schema-path') || {}).value?.trim?.() || ''
+      if (schemaPath) cli += ` --schema-path ${quoteIfNeeded(schemaPath)}`
+    }
+
+    runCmdOutput.dataset.builtCommand = cli
+    if (!kometaState.activeRunCommandOverride) {
+      runCmdOutput.textContent = cli
+    }
+    notify()
+    return true
+  }
+
   // ---- Primary run option (one radio in run-option group) ---------
   const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value || ''
   const libSelectEl = document.getElementById('library-multiselect')

--- a/static/local-js/modules/kometa/_runCommand.js
+++ b/static/local-js/modules/kometa/_runCommand.js
@@ -252,8 +252,8 @@ export function buildCommand () {
     clearValidationErrors()
     if (validateMode === '--validate') {
       cli += ' --validate'
-      const validateLevel = (document.getElementById('opt-validate-level') || {}).value?.trim?.() || ''
-      if (validateLevel) cli += ` --validate-level ${validateLevel}`
+      const validateLevel = (document.getElementById('opt-validate-level') || {}).value?.trim?.() || 'structure'
+      cli += ` --validate-level ${validateLevel}`
       const validateSchema = document.getElementById('opt-validate-schema')
       if (validateSchema && validateSchema.checked) cli += ' --validate-schema'
       const schemaPath = (document.getElementById('opt-schema-path') || {}).value?.trim?.() || ''

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -727,15 +727,14 @@
                 <label class="form-check-label" for="opt-validate-dir">--validate-dir</label>
               </div>
 
-              <div id="validate-config-options" class="mt-3 d-none">
+              <div id="validate-config-options" class="mt-3">
                 <label class="form-label" for="opt-validate-level">--validate-level</label>
                 <select class="form-select" id="opt-validate-level">
-                  <option value="">Default (structure)</option>
                   <option value="syntax">syntax</option>
-                  <option value="structure">structure</option>
+                  <option value="structure" selected>structure</option>
                   <option value="full">full</option>
                 </select>
-                <div class="form-text">Controls how deep validation goes when validating the generated config.</div>
+                <div class="form-text">Controls how deep validation goes when validating the generated config. Default is <code>structure</code>.</div>
 
                 <div class="form-check mt-3">
                   <input class="form-check-input" type="checkbox" id="opt-validate-schema" value="--validate-schema">

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -691,6 +691,80 @@
         </div>
       </div>
 
+      <!-- Validation Options -->
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="heading-validationflags">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            data-bs-target="#collapse-validationflags" aria-expanded="false" aria-controls="collapse-validationflags">
+            Validation / Schema Checks
+            <span id="heading-validationflags-rollup-badge" class="badge ms-2 qs-validation-rollup-badge qs-validation-rollup-badge--unknown">
+              Default
+            </span>
+          </button>
+        </h2>
+        <div id="collapse-validationflags" class="accordion-collapse collapse" aria-labelledby="heading-validationflags"
+          data-bs-parent="#run-command-accordion">
+          <div class="accordion-body">
+            <div class="alert alert-secondary small mb-3">
+              Validation modes make Kometa validate and exit instead of running collections, overlays, operations, or schedules.
+              Normal run options are ignored while a validation mode is selected.
+            </div>
+            <fieldset>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="validate-mode" id="opt-validate-none" value="" checked>
+                <label class="form-check-label" for="opt-validate-none">Default</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="validate-mode" id="opt-validate" value="--validate">
+                <label class="form-check-label" for="opt-validate">--validate</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="validate-mode" id="opt-validate-file" value="--validate-file">
+                <label class="form-check-label" for="opt-validate-file">--validate-file</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="validate-mode" id="opt-validate-dir" value="--validate-dir">
+                <label class="form-check-label" for="opt-validate-dir">--validate-dir</label>
+              </div>
+
+              <div id="validate-config-options" class="mt-3 d-none">
+                <label class="form-label" for="opt-validate-level">--validate-level</label>
+                <select class="form-select" id="opt-validate-level">
+                  <option value="">Default (structure)</option>
+                  <option value="syntax">syntax</option>
+                  <option value="structure">structure</option>
+                  <option value="full">full</option>
+                </select>
+                <div class="form-text">Controls how deep validation goes when validating the generated config.</div>
+
+                <div class="form-check mt-3">
+                  <input class="form-check-input" type="checkbox" id="opt-validate-schema" value="--validate-schema">
+                  <label class="form-check-label" for="opt-validate-schema">--validate-schema</label>
+                </div>
+              </div>
+
+              <div id="validate-file-options" class="mt-3 d-none">
+                <label class="form-label" for="opt-validate-file-val">YAML File Path</label>
+                <input type="text" class="form-control" id="opt-validate-file-val" placeholder="/path/to/collections.yml">
+                <div id="validate-file-error" class="text-danger small d-none mt-1"></div>
+              </div>
+
+              <div id="validate-dir-options" class="mt-3 d-none">
+                <label class="form-label" for="opt-validate-dir-val">YAML Directory Path</label>
+                <input type="text" class="form-control" id="opt-validate-dir-val" placeholder="/path/to/configs">
+                <div id="validate-dir-error" class="text-danger small d-none mt-1"></div>
+              </div>
+
+              <div id="validate-schema-path-options" class="mt-3 d-none">
+                <label class="form-label" for="opt-schema-path">--schema-path</label>
+                <input type="text" class="form-control" id="opt-schema-path" placeholder="/path/to/json-schema">
+                <div class="form-text">Optional path to the json-schema directory.</div>
+              </div>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+
       <!-- Other Flags -->
       <div class="accordion-item">
         <h2 class="accordion-header" id="heading-otherflags">

--- a/tests/e2e/test_ratings_matrix_artifacts_e2e.py
+++ b/tests/e2e/test_ratings_matrix_artifacts_e2e.py
@@ -499,15 +499,27 @@ def _load_library_with_ratings(page, builder_level=None, library_type=None):
             try:
                 page.select_option("#libraryPicker", library_id)
                 page.wait_for_function(
-                    """(libraryId) => {
-                      return !!document.querySelector(
+                    """([libraryId, builderLevel]) => {
+                      const card = document.querySelector(
                         `#library-form-container .library-settings-card[data-library-id="${libraryId}"]`
                       );
+                      if (!card) return false;
+                      const groups = Array.from(card.querySelectorAll('.template-toggle-group[data-overlay-id="overlay_ratings"]'));
+                      if (!groups.length) return false;
+                      const wantedLevel = (builderLevel || '').toString().toLowerCase();
+                      return groups.some(group => {
+                        const templateName = group?.dataset?.overlayTemplate || '';
+                        if (!templateName) return false;
+                        const builder = group.querySelector('[name$="[builder_level]"]');
+                        if (!wantedLevel) return !builder;
+                        if (!builder) return false;
+                        const raw = (builder.value || builder.dataset.default || '').toString().toLowerCase();
+                        return raw === wantedLevel;
+                      });
                     }""",
-                    arg=library_id,
+                    arg=[library_id, builder_level],
                     timeout=per_attempt_timeout_ms,
                 )
-                page.wait_for_timeout(200)
                 ctx = _ratings_context(page, library_id, builder_level)
                 if ctx:
                     ctx["libraryId"] = library_id
@@ -521,6 +533,20 @@ def _load_library_with_ratings(page, builder_level=None, library_type=None):
             # Context can still be missing right after the card appears; brief settle before retry.
             if attempt < LIBRARY_LOAD_RETRIES:
                 page.wait_for_timeout(250)
+    active_library = page.evaluate(
+        """(wantedType) => {
+          const card = document.querySelector('#library-form-container .library-settings-card');
+          if (!card) return null;
+          if (wantedType && (card.dataset.libraryType || '') !== wantedType) return null;
+          return card.dataset.libraryId || null;
+        }""",
+        library_type,
+    )
+    if active_library:
+        ctx = _ratings_context(page, active_library, builder_level)
+        if ctx:
+            ctx["libraryId"] = active_library
+            return ctx
     return None
 
 

--- a/tests/js/kometa/cliFlags.test.js
+++ b/tests/js/kometa/cliFlags.test.js
@@ -8,7 +8,7 @@
 // COVERAGE:
 //
 //   KOMETA_CLI_FLAGS (4):
-//     - contains all 24 documented flags
+//     - contains all documented flags
 //     - each entry has label + description
 //     - labels are non-empty strings
 //     - object is frozen (immutability guard)
@@ -44,12 +44,14 @@ import {
 // ---------------------------------------------------------------------
 
 describe('KOMETA_CLI_FLAGS', () => {
-  it('contains all 24 documented flags', () => {
+  it('contains all documented flags', () => {
     const expected = [
       '--run', '--run-libraries', '--times',
       '--operations-only', '--metadata-only', '--collections-only',
       '--playlists-only', '--overlays-only',
       '--debug', '--trace', '--log-requests',
+      '--validate', '--validate-file', '--validate-dir',
+      '--validate-level', '--validate-schema', '--schema-path',
       '--delete-collections', '--delete-labels', '--read-only-config',
       '--low-priority', '--no-report', '--no-missing', '--no-countdown',
       '--ignore-ghost', '--ignore-schedules', '--no-verify-ssl',
@@ -89,6 +91,7 @@ describe('updateFlagLabels', () => {
       <label for="opt-run-libraries">placeholder</label>
       <label for="opt-debug">placeholder</label>
       <label for="opt-operations-only">placeholder</label>
+      <label for="opt-validate">placeholder</label>
       <label for="opt-no-verify-ssl">placeholder</label>
     `
   })
@@ -148,13 +151,15 @@ describe('updateFlagLabels', () => {
     expect(() => updateFlagLabels(true)).not.toThrow()
   })
 
-  it('renders labels across all four flag groups', () => {
+  it('renders labels across all five flag groups', () => {
     // Verify that opt-run (RUN_OPTION), opt-operations-only (MODE),
-    // opt-debug (LOG), and opt-no-verify-ssl (OTHER) all get rendered.
+    // opt-debug (LOG), opt-validate (VALIDATION), and
+    // opt-no-verify-ssl (OTHER) all get rendered.
     updateFlagLabels(false)
     expect(document.querySelector('label[for="opt-run"]').textContent).toContain('Run Immediately')
     expect(document.querySelector('label[for="opt-operations-only"]').textContent).toContain('Operations Only')
     expect(document.querySelector('label[for="opt-debug"]').textContent).toContain('Debug Logging')
+    expect(document.querySelector('label[for="opt-validate"]').textContent).toContain('Validate Generated Config')
     expect(document.querySelector('label[for="opt-no-verify-ssl"]').textContent).toContain('No Verify SSL')
   })
 

--- a/tests/js/kometa/headerBadges.test.js
+++ b/tests/js/kometa/headerBadges.test.js
@@ -25,6 +25,9 @@
 //   updateModeFlagsHeaderBadge / updateLogFlagsHeaderBadge -- radio
 //                            selected vs none, various flag values
 //
+//   updateValidationFlagsHeaderBadge -- validation mode selected vs
+//                            missing dependent file/directory paths
+//
 //   updateOtherFlagsHeaderBadge -- 0/some/all core flags, extras
 //                            (timeout/divider/width) counted separately
 
@@ -37,6 +40,7 @@ import {
   updateRunOptionHeaderBadge,
   updateModeFlagsHeaderBadge,
   updateLogFlagsHeaderBadge,
+  updateValidationFlagsHeaderBadge,
   updateOtherFlagsHeaderBadge,
   updateConfigOutputHeaderBadges,
   updateRunCommandHeaderBadge,
@@ -363,6 +367,56 @@ describe('updateLogFlagsHeaderBadge', () => {
 })
 
 // ---------------------------------------------------------------------
+// updateValidationFlagsHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateValidationFlagsHeaderBadge', () => {
+  function installValidationFlagsDom (mode = '', filePath = '', dirPath = '') {
+    document.body.innerHTML = `
+      <input type="radio" name="validate-mode" value="" ${mode === '' ? 'checked' : ''}>
+      <input type="radio" name="validate-mode" value="--validate" ${mode === '--validate' ? 'checked' : ''}>
+      <input type="radio" name="validate-mode" value="--validate-file" ${mode === '--validate-file' ? 'checked' : ''}>
+      <input type="radio" name="validate-mode" value="--validate-dir" ${mode === '--validate-dir' ? 'checked' : ''}>
+      <input id="opt-validate-file-val" value="${filePath}">
+      <input id="opt-validate-dir-val" value="${dirPath}">
+    `
+    installBadge('heading-validationflags-rollup-badge')
+  }
+
+  it('shows Default when no validation mode is selected', () => {
+    installValidationFlagsDom('')
+    updateValidationFlagsHeaderBadge()
+    const badge = document.getElementById('heading-validationflags-rollup-badge')
+    expect(badge.textContent).toBe('Default')
+    expect(badge.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('shows Validate Config when config validation is selected', () => {
+    installValidationFlagsDom('--validate')
+    updateValidationFlagsHeaderBadge()
+    const badge = document.getElementById('heading-validationflags-rollup-badge')
+    expect(badge.textContent).toBe('Validate Config')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('warns when validate-file is selected without a path', () => {
+    installValidationFlagsDom('--validate-file')
+    updateValidationFlagsHeaderBadge()
+    const badge = document.getElementById('heading-validationflags-rollup-badge')
+    expect(badge.textContent).toBe('File needed')
+    expect(badge.classList.contains('qs-validation-rollup-badge--warn')).toBe(true)
+  })
+
+  it('shows Validate Directory when validate-dir has a path', () => {
+    installValidationFlagsDom('--validate-dir', '', '/data/configs')
+    updateValidationFlagsHeaderBadge()
+    const badge = document.getElementById('heading-validationflags-rollup-badge')
+    expect(badge.textContent).toBe('Validate Directory')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
 // updateOtherFlagsHeaderBadge
 // ---------------------------------------------------------------------
 
@@ -651,6 +705,7 @@ describe('syncFinalAccordionRollups', () => {
     installBadge('heading-runopt-rollup-badge')
     installBadge('heading-modeflags-rollup-badge')
     installBadge('heading-logflags-rollup-badge')
+    installBadge('heading-validationflags-rollup-badge')
     installBadge('heading-otherflags-rollup-badge')
     installBadge('config-output-lines-badge')
     installBadge('config-output-rollup-badge')
@@ -680,7 +735,7 @@ describe('syncFinalAccordionRollups', () => {
     expect(() => syncFinalAccordionRollups()).not.toThrow()
   })
 
-  it('refreshes every rollup badge on the page (touches all 10 ids)', () => {
+  it('refreshes every rollup badge on the page (touches all 11 ids)', () => {
     // Pre-mark every badge with a sentinel string. After the call,
     // every badge must have been rewritten (i.e. not equal to the
     // sentinel).
@@ -689,6 +744,7 @@ describe('syncFinalAccordionRollups', () => {
       'heading-runopt-rollup-badge',
       'heading-modeflags-rollup-badge',
       'heading-logflags-rollup-badge',
+      'heading-validationflags-rollup-badge',
       'heading-otherflags-rollup-badge',
       'config-output-lines-badge',
       'config-output-rollup-badge',

--- a/tests/js/kometa/runCommand.test.js
+++ b/tests/js/kometa/runCommand.test.js
@@ -96,6 +96,23 @@ function installRunCommandDom (opts = {}) {
     <input type="radio" name="log-flag" value="" ${logFlag === '' ? 'checked' : ''}>
     <input type="radio" name="log-flag" value="--debug" ${logFlag === '--debug' ? 'checked' : ''}>
 
+    <input type="radio" name="validate-mode" value="" checked>
+    <input type="radio" name="validate-mode" value="--validate">
+    <input type="radio" name="validate-mode" value="--validate-file">
+    <input type="radio" name="validate-mode" value="--validate-dir">
+    <select id="opt-validate-level">
+      <option value="">Default</option>
+      <option value="syntax">syntax</option>
+      <option value="structure">structure</option>
+      <option value="full">full</option>
+    </select>
+    <input type="checkbox" id="opt-validate-schema">
+    <input id="opt-validate-file-val" value="">
+    <div id="validate-file-error" class="d-none"></div>
+    <input id="opt-validate-dir-val" value="">
+    <div id="validate-dir-error" class="d-none"></div>
+    <input id="opt-schema-path" value="">
+
     <input type="checkbox" id="opt-delete-collections">
     <input type="checkbox" id="opt-delete-labels">
     <input type="checkbox" id="opt-read-only-config">
@@ -441,6 +458,73 @@ describe('buildCommand no-value checkboxes', () => {
     installRunCommandDom()
     document.getElementById('opt-tests').remove()
     expect(() => buildCommand()).not.toThrow()
+  })
+})
+
+describe('buildCommand validation modes', () => {
+  function selectValidateMode (value) {
+    document.querySelectorAll('input[name="validate-mode"]').forEach(el => {
+      el.checked = el.value === value
+    })
+  }
+
+  it('builds a generated-config validation command with level and schema options', () => {
+    installRunCommandDom()
+    selectValidateMode('--validate')
+    document.getElementById('opt-validate-level').value = 'syntax'
+    document.getElementById('opt-validate-schema').checked = true
+    document.getElementById('opt-schema-path').value = '/schemas/json-schema'
+    document.querySelector('input[name="run-option"][value="--collections-only"]').checked = true
+    document.getElementById('opt-delete-collections').checked = true
+
+    expect(buildCommand()).toBe(true)
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--validate --validate-level syntax --validate-schema --schema-path /schemas/json-schema')
+    expect(out).toContain('--config /opt/kometa/config/config.yml')
+    expect(out).not.toContain('--collections-only')
+    expect(out).not.toContain('--delete-collections')
+  })
+
+  it('builds a validate-file command and quotes paths with spaces', () => {
+    installRunCommandDom()
+    selectValidateMode('--validate-file')
+    document.getElementById('opt-validate-file-val').value = '/data/my collections.yml'
+    document.getElementById('opt-schema-path').value = '/data/json schema'
+
+    expect(buildCommand()).toBe(true)
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--validate-file "/data/my collections.yml"')
+    expect(out).toContain('--schema-path "/data/json schema"')
+    expect(out).not.toContain('--config')
+  })
+
+  it('rejects validate-file without a file path', () => {
+    installRunCommandDom()
+    selectValidateMode('--validate-file')
+
+    expect(buildCommand()).toBe(false)
+    expect(document.getElementById('validate-file-error').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-command-output').textContent).toContain('YAML file path')
+  })
+
+  it('builds a validate-dir command', () => {
+    installRunCommandDom()
+    selectValidateMode('--validate-dir')
+    document.getElementById('opt-validate-dir-val').value = '/data/configs'
+
+    expect(buildCommand()).toBe(true)
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--validate-dir /data/configs')
+    expect(out).not.toContain('--config')
+  })
+
+  it('rejects validate-dir without a directory path', () => {
+    installRunCommandDom()
+    selectValidateMode('--validate-dir')
+
+    expect(buildCommand()).toBe(false)
+    expect(document.getElementById('validate-dir-error').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-command-output').textContent).toContain('YAML directory path')
   })
 })
 

--- a/tests/js/kometa/runCommand.test.js
+++ b/tests/js/kometa/runCommand.test.js
@@ -101,9 +101,8 @@ function installRunCommandDom (opts = {}) {
     <input type="radio" name="validate-mode" value="--validate-file">
     <input type="radio" name="validate-mode" value="--validate-dir">
     <select id="opt-validate-level">
-      <option value="">Default</option>
       <option value="syntax">syntax</option>
-      <option value="structure">structure</option>
+      <option value="structure" selected>structure</option>
       <option value="full">full</option>
     </select>
     <input type="checkbox" id="opt-validate-schema">
@@ -483,6 +482,15 @@ describe('buildCommand validation modes', () => {
     expect(out).toContain('--config /opt/kometa/config/config.yml')
     expect(out).not.toContain('--collections-only')
     expect(out).not.toContain('--delete-collections')
+  })
+
+  it('uses structure as the default validate level for generated-config validation', () => {
+    installRunCommandDom()
+    selectValidateMode('--validate')
+
+    expect(buildCommand()).toBe(true)
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--validate --validate-level structure')
   })
 
   it('builds a validate-file command and quotes paths with spaces', () => {


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Adds the new Kometa validation/runtime flags to the Kometa page run-command builder and hardens the ratings artifact E2E bootstrap.

## Changes

- Added a `Validation / Schema Checks` section on the Kometa page for:
  - `--validate`
  - `--validate-level` with dropdown values `syntax`, `structure`, `full`
  - `--validate-schema`
  - `--schema-path`
  - `--validate-file`
  - `--validate-dir`
- Updated run-command generation so validation modes build validation-only commands instead of mixing with normal run flags.
- Added header badge/rollup state for validation command modes and missing file/dir path requirements.
- Added CLI flag metadata/tooltips and JS coverage for the new runtime flags.
- Hardened the ratings matrix artifact E2E helper to wait for the actual ratings overlay group and matching `builder_level`, not only the library card shell.

## Testing

- `npx standard static\local-js\modules\kometa\_runCommand.js static\local-js\modules\kometa\_cliFlags.js static\local-js\modules\kometa\_headerBadges.js`
- `npx eslint static\local-js\900-kometa.js static\local-js\modules\kometa\_runCommand.js tests\js\kometa\runCommand.test.js`
- `npx vitest run tests\js\kometa\runCommand.test.js tests\js\kometa\cliFlags.test.js tests\js\kometa\headerBadges.test.js`
- `venv\Scripts\python.exe -m py_compile tests\e2e\test_ratings_matrix_artifacts_e2e.py`
- `git diff --check`

Note: focused Playwright E2E verification was attempted, but the local browser/server run timed out in this Windows environment.
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1558 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
