### PR TITLE
Fix analytics

### DIFF
--- a/modules/database.py
+++ b/modules/database.py
@@ -267,6 +267,8 @@ def log_runs_table_create():
         quiet_period_summary TEXT,
         progress_snapshot TEXT,
         quickstart_run_marker INTEGER,
+        quickstart_version TEXT,
+        quickstart_branch TEXT,
         start_mode TEXT,
         config_line_count INTEGER,
         cache_line_count INTEGER,
@@ -300,6 +302,8 @@ def _ensure_log_runs_columns(cursor):
         "quiet_period_summary": "TEXT",
         "progress_snapshot": "TEXT",
         "quickstart_run_marker": "INTEGER",
+        "quickstart_version": "TEXT",
+        "quickstart_branch": "TEXT",
         "start_mode": "TEXT",
         "config_line_count": "INTEGER",
         "cache_line_count": "INTEGER",
@@ -342,6 +346,8 @@ def save_log_run(summary, recommendations=None):
     if isinstance(progress_snapshot, dict):
         progress_snapshot = json.dumps(progress_snapshot, ensure_ascii=True)
     quickstart_run_marker = 1 if summary.get("quickstart_run_marker") else 0
+    quickstart_version = str(summary.get("quickstart_version") or "").strip() or None
+    quickstart_branch = str(summary.get("quickstart_branch") or "").strip() or None
     start_mode = str(summary.get("start_mode") or "").strip().lower() or None
     config_line_count = summary.get("config_line_count")
     cache_line_count = summary.get("cache_line_count")
@@ -379,11 +385,13 @@ def save_log_run(summary, recommendations=None):
                     quiet_period_summary,
                     progress_snapshot,
                     quickstart_run_marker,
+                    quickstart_version,
+                    quickstart_branch,
                     start_mode,
                     config_line_count,
                     cache_line_count,
                     created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     run_key,
                     tool_name,
@@ -413,6 +421,8 @@ def save_log_run(summary, recommendations=None):
                     quiet_period_summary,
                     progress_snapshot,
                     quickstart_run_marker,
+                    quickstart_version,
+                    quickstart_branch,
                     start_mode,
                     config_line_count,
                     cache_line_count,
@@ -484,6 +494,8 @@ def _decode_log_run_row(row):
             decoded["progress_snapshot"] = None
     decoded["maintenance_had_pause"] = bool(decoded.get("maintenance_had_pause"))
     decoded["quickstart_run_marker"] = bool(decoded.get("quickstart_run_marker"))
+    decoded["quickstart_version"] = str(decoded.get("quickstart_version") or "").strip() or None
+    decoded["quickstart_branch"] = str(decoded.get("quickstart_branch") or "").strip() or None
     decoded["start_mode"] = str(decoded.get("start_mode") or "").strip().lower() or None
     decoded["tool_name"] = str(decoded.get("tool_name") or "kometa").strip().lower() or "kometa"
     return decoded
@@ -498,7 +510,7 @@ def get_log_runs(limit=100):
                                config_name, config_hash, run_command, command_signature, section_runtimes,
                                recommendations, log_mtime, log_size, debug_count, info_count, warning_count,
                                error_count, critical_count, trace_count, analysis_counts, library_counts,
-                               maintenance_summary, maintenance_had_pause, quiet_period_summary, progress_snapshot, quickstart_run_marker, start_mode,
+                               maintenance_summary, maintenance_had_pause, quiet_period_summary, progress_snapshot, quickstart_run_marker, quickstart_version, quickstart_branch, start_mode,
                                config_line_count, cache_line_count, created_at
                         FROM log_runs
                         ORDER BY created_at DESC"""
@@ -523,7 +535,7 @@ def get_log_run(run_key):
                           config_name, config_hash, run_command, command_signature, section_runtimes,
                           recommendations, log_mtime, log_size, debug_count, info_count, warning_count,
                           error_count, critical_count, trace_count, analysis_counts, library_counts,
-                          maintenance_summary, maintenance_had_pause, quiet_period_summary, progress_snapshot, quickstart_run_marker, start_mode,
+                          maintenance_summary, maintenance_had_pause, quiet_period_summary, progress_snapshot, quickstart_run_marker, quickstart_version, quickstart_branch, start_mode,
                           config_line_count, cache_line_count, created_at
                    FROM log_runs
                    WHERE run_key == ?

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -522,6 +522,8 @@ class LogscanAnalyzer:
         if summary:
             summary["analysis_counts"] = analysis_counts
             summary["quickstart_run_marker"] = bool(quickstart_marker)
+            summary["quickstart_version"] = quickstart_marker_fields.get("quickstart") or None
+            summary["quickstart_branch"] = quickstart_marker_fields.get("branch") or None
             summary["start_mode"] = quickstart_marker_fields.get("start_mode") or None
             summary["library_counts"] = library_counts
             summary["maintenance_summary"] = maintenance_summary

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -212,12 +212,22 @@ def _parse_json_object_value(value):
 # --- collection template var normalization --------------------------------
 
 
+def _sort_id_values(values):
+    def sort_key(item):
+        text = str(item).strip()
+        if text.isdigit():
+            return (0, int(text), text)
+        return (1, text.lower(), text)
+
+    return sorted(values, key=sort_key)
+
+
 def _normalize_collection_template_var_value(key, value):
     if key == "collection_section" and value in (None, ""):
         return None
     if key in {"ignore_ids", "ignore_imdb_ids"}:
         list_values = _parse_string_list(value)
-        return ",".join(list_values) if list_values else None
+        return _sort_id_values(list_values) if list_values else None
     if key in {"append_include"}:
         list_values = _parse_string_list(value)
         return list_values if list_values else None
@@ -325,9 +335,18 @@ def _expand_franchise_dynamic_child_overrides(template_vars):
 
 
 def _normalize_settings_section_value(key, value):
-    if key in {"ignore_ids", "ignore_imdb_ids"}:
+    if key == "ignore_ids":
         list_values = _parse_string_list(value)
-        return ",".join(list_values) if list_values else None
+        normalized = []
+        for item in list_values:
+            try:
+                normalized.append(int(str(item).strip()))
+            except Exception:
+                normalized.append(str(item).strip())
+        return _sort_id_values(normalized) if normalized else None
+    if key == "ignore_imdb_ids":
+        list_values = _parse_string_list(value)
+        return _sort_id_values(list_values) if list_values else None
     return value
 
 

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -213,6 +213,8 @@ def _parse_json_object_value(value):
 
 
 def _normalize_collection_template_var_value(key, value):
+    if key == "collection_section" and value in (None, ""):
+        return None
     if key in {"ignore_ids", "ignore_imdb_ids"}:
         list_values = _parse_string_list(value)
         return ",".join(list_values) if list_values else None

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -444,6 +444,8 @@ _LEGACY_REGION_KEYS = {
 
 # Template-var keys that hold delimited lists.  Empty parses drop the key.
 _LIST_KEYS = ("include", "exclude", "exclude_prefix")
+_LOOKUP_LABELS_SUFFIX = "__lookup_labels"
+_TEMPLATE_VARIABLE_COMMENTS_KEY = "__template_variable_comments"
 
 
 def _coerce_bool_like_string(value):
@@ -485,6 +487,38 @@ def _normalize_list_template_vars(template_vars):
             template_vars[list_key] = list_values
         else:
             template_vars.pop(list_key, None)
+
+
+def _parse_template_lookup_labels(value):
+    if isinstance(value, dict):
+        return {str(k).strip(): str(v).strip() for k, v in value.items() if str(k).strip() and str(v).strip()}
+    if not isinstance(value, str):
+        return {}
+    raw = value.strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k).strip(): str(v).strip() for k, v in parsed.items() if str(k).strip() and str(v).strip()}
+
+
+def _split_template_lookup_labels(children):
+    template_values = {}
+    lookup_labels = {}
+    for key, value in children.items():
+        key_text = str(key or "")
+        if key_text.endswith(_LOOKUP_LABELS_SUFFIX):
+            template_key = key_text[: -len(_LOOKUP_LABELS_SUFFIX)]
+            labels = _parse_template_lookup_labels(value)
+            if template_key and labels:
+                lookup_labels[template_key] = labels
+            continue
+        template_values[key] = value
+    return template_values, lookup_labels
 
 
 def _apply_template_var_normalizers(template_vars, raw_id):
@@ -602,10 +636,13 @@ def build_collection_files(
             )
 
         if all_children:
-            template_vars = {k: _coerce_bool_like_string(v) for k, v in all_children.items()}
+            template_values, lookup_labels = _split_template_lookup_labels(all_children)
+            template_vars = {k: _coerce_bool_like_string(v) for k, v in template_values.items()}
             _apply_template_var_normalizers(template_vars, raw_id)
             if template_vars:
                 file_entry["template_variables"] = template_vars
+                if lookup_labels:
+                    file_entry[_TEMPLATE_VARIABLE_COMMENTS_KEY] = lookup_labels
 
         collection_files.append(file_entry)
 

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -34,10 +34,11 @@ import io
 from datetime import datetime, timezone
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedSeq
 from ruamel.yaml.scalarstring import PlainScalarString
 
 from modules import database, helpers
-from modules.output_collections import _normalize_settings_section_value
+from modules.output_collections import _normalize_settings_section_value, _TEMPLATE_VARIABLE_COMMENTS_KEY
 from modules.output_headers import render_section_header
 from modules.output_values import _normalize_asset_directory_values
 
@@ -194,6 +195,53 @@ def _plainify_strings(obj):
     if isinstance(obj, str):
         return PlainScalarString(obj)
     return obj
+
+
+def _format_inline_comment(value):
+    text = " ".join(str(value or "").replace("\r", " ").replace("\n", " ").split())
+    return text.strip()
+
+
+def _apply_template_variable_comments(cleaned_data):
+    """Attach saved lookup labels as YAML end-of-line comments.
+
+    The UI persists label metadata beside template string-list fields under
+    ``__template_variable_comments``.  That key is internal to Quickstart: it
+    must be consumed before dumping so Kometa never sees it.
+    """
+    libraries = cleaned_data.get("libraries") if isinstance(cleaned_data, dict) else None
+    if not isinstance(libraries, dict):
+        return
+
+    for library_data in libraries.values():
+        if not isinstance(library_data, dict):
+            continue
+        collection_files = library_data.get("collection_files")
+        if not isinstance(collection_files, list):
+            continue
+
+        for entry in collection_files:
+            if not isinstance(entry, dict):
+                continue
+            comment_map = entry.pop(_TEMPLATE_VARIABLE_COMMENTS_KEY, None)
+            if not isinstance(comment_map, dict):
+                continue
+            template_vars = entry.get("template_variables")
+            if not isinstance(template_vars, dict):
+                continue
+
+            for template_key, labels in comment_map.items():
+                if not isinstance(labels, dict):
+                    continue
+                values = template_vars.get(template_key)
+                if not isinstance(values, list):
+                    continue
+                commented_values = CommentedSeq(values)
+                for index, item in enumerate(commented_values):
+                    comment = _format_inline_comment(labels.get(str(item).strip()))
+                    if comment:
+                        commented_values.yaml_add_eol_comment(comment, index)
+                template_vars[template_key] = commented_values
 
 
 # --- per-section post-cleaning tweaks -------------------------------------
@@ -381,6 +429,9 @@ def dump_section(title, dump_name, data, header_style, config_name):
 
     if dump_name == "settings":
         _apply_settings_normalization(cleaned_data)
+
+    if dump_name == "libraries":
+        _apply_template_variable_comments(cleaned_data)
 
     dump_yaml = _build_dump_yaml()
     with io.StringIO() as stream:

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -34,11 +34,11 @@ import io
 from datetime import datetime, timezone
 
 from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedSeq
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.scalarstring import PlainScalarString
 
 from modules import database, helpers
-from modules.output_collections import _normalize_settings_section_value, _TEMPLATE_VARIABLE_COMMENTS_KEY
+from modules.output_collections import _LOOKUP_LABELS_SUFFIX, _normalize_settings_section_value, _TEMPLATE_VARIABLE_COMMENTS_KEY, _parse_template_lookup_labels
 from modules.output_headers import render_section_header
 from modules.output_values import _normalize_asset_directory_values
 
@@ -202,6 +202,78 @@ def _format_inline_comment(value):
     return text.strip()
 
 
+def _split_comment_values(value):
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
+def _format_value_comment(value, labels):
+    values = _split_comment_values(value)
+    if len(values) == 1:
+        return _format_inline_comment(labels.get(values[0]))
+    comments = []
+    for item in values:
+        label = _format_inline_comment(labels.get(str(item).strip()))
+        if label:
+            comments.append(f"{item}: {label}")
+    return "; ".join(comments)
+
+
+def _apply_comment_map_to_template_vars(template_vars, comment_map):
+    if not isinstance(template_vars, dict) or not isinstance(comment_map, dict):
+        return template_vars
+
+    commented_template_vars = template_vars if isinstance(template_vars, CommentedMap) else CommentedMap(template_vars)
+    for template_key, labels in comment_map.items():
+        if not isinstance(labels, dict) or template_key not in commented_template_vars:
+            continue
+        values = commented_template_vars.get(template_key)
+        if isinstance(values, list):
+            commented_values = CommentedSeq(values)
+            for index, item in enumerate(commented_values):
+                comment = _format_inline_comment(labels.get(str(item).strip()))
+                if comment:
+                    commented_values.yaml_add_eol_comment(comment, index)
+            commented_template_vars[template_key] = commented_values
+            continue
+        comment = _format_value_comment(values, labels)
+        if comment:
+            commented_template_vars.yaml_add_eol_comment(comment, key=template_key)
+    return commented_template_vars
+
+
+def _pop_lookup_label_sidecars(container):
+    if not isinstance(container, dict):
+        return {}
+
+    comment_map = {}
+    for key in list(container.keys()):
+        key_text = str(key or "")
+        if not key_text.endswith(_LOOKUP_LABELS_SUFFIX):
+            continue
+        template_key = key_text[: -len(_LOOKUP_LABELS_SUFFIX)]
+        labels = _parse_template_lookup_labels(container.pop(key, None))
+        if template_key and labels:
+            comment_map[template_key] = labels
+    return comment_map
+
+
+def _apply_settings_lookup_comments(cleaned_data):
+    settings_block = cleaned_data.get("settings") if isinstance(cleaned_data, dict) else None
+    if not isinstance(settings_block, dict):
+        return
+
+    comment_map = _pop_lookup_label_sidecars(settings_block)
+    if not comment_map:
+        return
+
+    cleaned_data["settings"] = _apply_comment_map_to_template_vars(settings_block, comment_map)
+
+
 def _apply_template_variable_comments(cleaned_data):
     """Attach saved lookup labels as YAML end-of-line comments.
 
@@ -216,6 +288,10 @@ def _apply_template_variable_comments(cleaned_data):
     for library_data in libraries.values():
         if not isinstance(library_data, dict):
             continue
+        library_comment_map = library_data.pop(_TEMPLATE_VARIABLE_COMMENTS_KEY, None)
+        if isinstance(library_comment_map, dict) and isinstance(library_data.get("template_variables"), dict):
+            library_data["template_variables"] = _apply_comment_map_to_template_vars(library_data["template_variables"], library_comment_map)
+
         collection_files = library_data.get("collection_files")
         if not isinstance(collection_files, list):
             continue
@@ -230,18 +306,7 @@ def _apply_template_variable_comments(cleaned_data):
             if not isinstance(template_vars, dict):
                 continue
 
-            for template_key, labels in comment_map.items():
-                if not isinstance(labels, dict):
-                    continue
-                values = template_vars.get(template_key)
-                if not isinstance(values, list):
-                    continue
-                commented_values = CommentedSeq(values)
-                for index, item in enumerate(commented_values):
-                    comment = _format_inline_comment(labels.get(str(item).strip()))
-                    if comment:
-                        commented_values.yaml_add_eol_comment(comment, index)
-                template_vars[template_key] = commented_values
+            entry["template_variables"] = _apply_comment_map_to_template_vars(template_vars, comment_map)
 
 
 # --- per-section post-cleaning tweaks -------------------------------------
@@ -429,6 +494,7 @@ def dump_section(title, dump_name, data, header_style, config_name):
 
     if dump_name == "settings":
         _apply_settings_normalization(cleaned_data)
+        _apply_settings_lookup_comments(cleaned_data)
 
     if dump_name == "libraries":
         _apply_template_variable_comments(cleaned_data)

--- a/modules/output_libraries_section.py
+++ b/modules/output_libraries_section.py
@@ -30,6 +30,7 @@ from flask import current_app as app
 from ruamel.yaml import YAML
 
 from modules import helpers
+from modules.output_collections import _TEMPLATE_VARIABLE_COMMENTS_KEY
 from modules.output_collections import build_collection_files
 from modules.output_file_entries import _parse_metadata_file_entries
 from modules.output_library_ops import (
@@ -191,7 +192,11 @@ def build_libraries_section(
             entry["metadata_files"] = metadata_entries
 
         # Template variables
-        entry["template_variables"] = build_template_variables(templates, library_type, library_key, has_collectionless)
+        template_variables = build_template_variables(templates, library_type, library_key, has_collectionless)
+        template_variable_comments = template_variables.pop(_TEMPLATE_VARIABLE_COMMENTS_KEY, None) if isinstance(template_variables, dict) else None
+        entry["template_variables"] = template_variables
+        if template_variable_comments:
+            entry[_TEMPLATE_VARIABLE_COMMENTS_KEY] = template_variable_comments
 
         # Grouped mass update operations (mass_genre_update handled above)
         operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id))

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -25,6 +25,7 @@ import json
 from ruamel.yaml.comments import CommentedSeq
 
 from modules import helpers
+from modules.output_collections import _LOOKUP_LABELS_SUFFIX, _TEMPLATE_VARIABLE_COMMENTS_KEY, _parse_template_lookup_labels
 from modules.output_values import _coerce_bool, _normalize_asset_directory_values
 
 # Values that we treat as "no override provided" for the numeric-ish
@@ -353,14 +354,20 @@ def _discover_template_variables(template_data, library_type, template_key):
     """
     prefix = f"{library_type}-library_{template_key}"
     discovered = {}
+    lookup_labels = {}
     for key, value in template_data.items():
         if not key.startswith(prefix):
             continue
         for suffix, output_name in _TEMPLATE_VAR_SUFFIXES.items():
+            if key.endswith(f"{suffix}{_LOOKUP_LABELS_SUFFIX}"):
+                labels = _parse_template_lookup_labels(value)
+                if labels:
+                    lookup_labels[output_name] = labels
+                break
             if key.endswith(suffix):
                 discovered[output_name] = value
                 break
-    return discovered
+    return discovered, lookup_labels
 
 
 def build_template_variables(templates, library_type, library_key, has_collectionless):
@@ -386,7 +393,7 @@ def build_template_variables(templates, library_type, library_key, has_collectio
     """
     template_key = helpers.extract_library_name(library_key)
     template_data = templates.get(template_key, {})
-    discovered = _discover_template_variables(template_data, library_type, template_key)
+    discovered, lookup_labels = _discover_template_variables(template_data, library_type, template_key)
 
     sep_color = discovered.get("use_separator")
     template_vars = {"use_separator": bool(sep_color)}
@@ -414,6 +421,9 @@ def build_template_variables(templates, library_type, library_key, has_collectio
 
     if has_collectionless:
         template_vars["collection_mode"] = "hide"
+
+    if lookup_labels:
+        template_vars[_TEMPLATE_VARIABLE_COMMENTS_KEY] = lookup_labels
 
     return template_vars
 

--- a/modules/output_optimize.py
+++ b/modules/output_optimize.py
@@ -35,6 +35,9 @@ just a plain re-import.
 
 from __future__ import annotations
 
+import re
+
+from modules import helpers
 from modules.output_defaults import (
     _build_attribute_defaults,
     _build_collection_defaults,
@@ -137,6 +140,124 @@ def _reorder_ratings_template_vars(entry):
         if key not in ordered:
             ordered[key] = tv[key]
     entry["template_variables"] = ordered
+
+
+_NATURAL_SORT_RE = re.compile(r"(\d+)")
+
+
+def _natural_sort_key(value):
+    parts = _NATURAL_SORT_RE.split(str(value or ""))
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _build_collection_template_orders():
+    """Build canonical template-variable key order from quickstart_collections.json."""
+    orders = {"movie": {}, "show": {}, "all": {}}
+    try:
+        data = helpers.load_quickstart_config("quickstart_collections.json")
+    except Exception as exc:
+        helpers.ts_log(f"Failed to load quickstart_collections.json for template variable ordering: {exc}", level="ERROR")
+        return orders
+
+    for group in data or []:
+        for collection in group.get("collections", []):
+            collection_id = collection.get("id")
+            if not collection_id:
+                continue
+            default_key = collection_id.replace("collection_", "", 1)
+            exact_order = {}
+            dynamic_prefixes = []
+            exact_keys = []
+
+            for index, item in enumerate(collection.get("template_variables") or []):
+                if not isinstance(item, dict):
+                    continue
+                key = item.get("key")
+                if key:
+                    exact_order[key] = index
+                    exact_keys.append(str(key))
+                dynamic_prefix = item.get("dynamic_child_prefix")
+                if dynamic_prefix:
+                    dynamic_prefixes.append((str(dynamic_prefix), index))
+
+            child_suffixes = {key.removeprefix("use_") for key in exact_keys if key.startswith("use_") and key not in {"use_all", "use_separator"}}
+            sibling_prefixes = {}
+            for key in exact_keys:
+                for suffix in sorted(child_suffixes, key=len, reverse=True):
+                    if not suffix or not key.endswith(f"_{suffix}"):
+                        continue
+                    prefix = key[: -len(suffix)]
+                    if not prefix:
+                        continue
+                    sibling_prefixes.setdefault(prefix, []).append((key, exact_order[key], suffix))
+                    break
+
+            sortable_sibling_prefixes = [(prefix, min(index for _key, index, _suffix in members)) for prefix, members in sibling_prefixes.items() if len(members) > 1]
+
+            order_spec = {
+                "exact": exact_order,
+                "dynamic": sorted(dynamic_prefixes, key=lambda pair: (-len(pair[0]), pair[1])),
+                "siblings": sorted(sortable_sibling_prefixes, key=lambda pair: (-len(pair[0]), pair[1])),
+            }
+            media_types = [mt for mt in (collection.get("media_types") or []) if mt in ("movie", "show")]
+            if not media_types:
+                orders["all"][default_key] = order_spec
+                continue
+            for media_type in media_types:
+                orders[media_type][default_key] = order_spec
+            if len(media_types) > 1:
+                orders["all"][default_key] = order_spec
+    return orders
+
+
+def _pick_collection_template_order(collection_orders, library_type, default_name):
+    if not default_name:
+        return None
+    library_type = library_type if library_type in ("movie", "show") else None
+    if library_type:
+        order_spec = collection_orders.get(library_type, {}).get(default_name)
+        if order_spec:
+            return order_spec
+    order_spec = collection_orders.get("all", {}).get(default_name)
+    if order_spec:
+        return order_spec
+    for fallback_type in ("movie", "show"):
+        order_spec = collection_orders.get(fallback_type, {}).get(default_name)
+        if order_spec:
+            return order_spec
+    return None
+
+
+def _collection_template_sort_key(key, order_spec):
+    key_text = str(key or "")
+    exact_order = (order_spec or {}).get("exact") or {}
+    for sibling_prefix, index in (order_spec or {}).get("siblings") or []:
+        if key_text.startswith(sibling_prefix) and key_text != sibling_prefix:
+            return (0, index, _natural_sort_key(key_text[len(sibling_prefix) :]))
+
+    if key_text in exact_order:
+        return (0, exact_order[key_text], ())
+
+    for dynamic_prefix, index in (order_spec or {}).get("dynamic") or []:
+        if key_text.startswith(dynamic_prefix) and key_text != dynamic_prefix:
+            return (0, index, _natural_sort_key(key_text[len(dynamic_prefix) :]))
+
+    return (1, len(exact_order), _natural_sort_key(key_text))
+
+
+def _reorder_collection_template_vars(entry, collection_orders, library_type):
+    """Reorder collection template_variables into Quickstart's canonical order."""
+    if not isinstance(entry, dict):
+        return
+    tv = entry.get("template_variables")
+    if not isinstance(tv, dict) or not tv:
+        return
+
+    order_spec = _pick_collection_template_order(collection_orders, library_type, entry.get("default"))
+    if not order_spec:
+        return
+
+    entry["template_variables"] = {key: tv[key] for key in sorted(tv.keys(), key=lambda item: _collection_template_sort_key(item, order_spec))}
 
 
 # --- ratings offset math --------------------------------------------------
@@ -463,7 +584,7 @@ def _optimize_library_level(library_data, attribute_defaults):
         library_data.pop("template_variables", None)
 
 
-def _optimize_collection_files(library_data, collection_defaults, library_type):
+def _optimize_collection_files(library_data, collection_defaults, collection_orders, library_type):
     """Prune per-collection-file template_variables in place."""
     collection_files = library_data.get("collection_files")
     if not isinstance(collection_files, list):
@@ -484,6 +605,7 @@ def _optimize_collection_files(library_data, collection_defaults, library_type):
             pruned["data_ending"] = tv.get("data_ending")
         if pruned:
             entry["template_variables"] = pruned
+            _reorder_collection_template_vars(entry, collection_orders, library_type)
         else:
             entry.pop("template_variables", None)
 
@@ -538,6 +660,7 @@ def optimize_template_variables(config_data, library_types=None):
         return config_data
 
     collection_defaults = _build_collection_defaults()
+    collection_orders = _build_collection_template_orders()
     overlay_defaults = _build_overlay_defaults()
     attribute_defaults = _build_attribute_defaults()
 
@@ -550,7 +673,7 @@ def optimize_template_variables(config_data, library_types=None):
             library_type = library_types.get(library_name)
 
         _optimize_library_level(library_data, attribute_defaults)
-        _optimize_collection_files(library_data, collection_defaults, library_type)
+        _optimize_collection_files(library_data, collection_defaults, collection_orders, library_type)
         _optimize_overlay_files(library_data, overlay_defaults, library_type)
 
     return config_data

--- a/modules/output_optimize.py
+++ b/modules/output_optimize.py
@@ -143,11 +143,40 @@ def _reorder_ratings_template_vars(entry):
 
 
 _NATURAL_SORT_RE = re.compile(r"(\d+)")
+_ID_TOKEN_RE = re.compile(r"^(?:\d+|tt\d+)$", re.IGNORECASE)
 
 
 def _natural_sort_key(value):
     parts = _NATURAL_SORT_RE.split(str(value or ""))
     return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _id_sort_key(value):
+    text = str(value or "").strip()
+    if text.isdigit():
+        return (0, int(text), text)
+    imdb_match = re.fullmatch(r"tt(\d+)", text, flags=re.IGNORECASE)
+    if imdb_match:
+        return (1, int(imdb_match.group(1)), text.lower())
+    return (2, _natural_sort_key(text))
+
+
+def _is_sortable_id_list(value):
+    if not isinstance(value, list) or len(value) < 2:
+        return False
+    for item in value:
+        text = str(item or "").strip()
+        if not _ID_TOKEN_RE.fullmatch(text):
+            return False
+    return True
+
+
+def _sort_id_list_template_values(template_vars):
+    if not isinstance(template_vars, dict):
+        return
+    for key, value in list(template_vars.items()):
+        if _is_sortable_id_list(value):
+            template_vars[key] = sorted(value, key=_id_sort_key)
 
 
 def _build_collection_template_orders():
@@ -252,6 +281,8 @@ def _reorder_collection_template_vars(entry, collection_orders, library_type):
     tv = entry.get("template_variables")
     if not isinstance(tv, dict) or not tv:
         return
+
+    _sort_id_list_template_values(tv)
 
     order_spec = _pick_collection_template_order(collection_orders, library_type, entry.get("default"))
     if not order_spec:

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2041,20 +2041,23 @@ fieldset:disabled .btn {
 }
 
 .collection-variable-section,
-.overlay-variable-section {
+.overlay-variable-section,
+.template-toggle-group {
     position: relative;
     transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .collection-variable-section.template-variable-section-has-overrides,
-.overlay-variable-section.template-variable-section-has-overrides {
+.overlay-variable-section.template-variable-section-has-overrides,
+.template-toggle-group.template-variable-section-has-overrides {
     border-color: rgba(var(--accent-color), 0.55) !important;
     background: linear-gradient(90deg, rgba(var(--accent-color), 0.08), transparent 38%);
     padding-left: 1rem !important;
 }
 
 .collection-variable-section.template-variable-section-has-overrides::before,
-.overlay-variable-section.template-variable-section-has-overrides::before {
+.overlay-variable-section.template-variable-section-has-overrides::before,
+.template-toggle-group.template-variable-section-has-overrides::before {
     content: "";
     position: absolute;
     left: 0;
@@ -2064,6 +2067,18 @@ fieldset:disabled .btn {
     border-radius: 0 4px 4px 0;
     background: var(--theme-primary);
     box-shadow: 0 0 10px rgba(var(--accent-color), 0.35);
+}
+
+.accordion-header.template-variable-section-has-overrides {
+    border-left: 4px solid var(--theme-primary) !important;
+    padding-left: 10px !important;
+}
+
+.template-override-summary,
+.accordion-override-summary {
+    color: var(--theme-primary-hover) !important;
+    font-weight: 600;
+    white-space: nowrap;
 }
 
 /* -------------------- */

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2085,11 +2085,16 @@ fieldset:disabled .btn {
     position: relative;
     border-left: 4px solid var(--theme-primary) !important;
     box-shadow: inset 7px 0 0 rgba(var(--accent-color), 0.08);
+    background: linear-gradient(90deg, rgba(var(--accent-color), 0.08), transparent 34%);
+    padding-left: 0.45rem;
 }
 
 .input-group.template-variable-field-has-override > .input-group-text:first-child,
 .font-row.template-variable-field-has-override .input-group-text:first-child,
-.rgba-group.template-variable-field-has-override .input-group-text:first-child {
+.rgba-group.template-variable-field-has-override .input-group-text:first-child,
+[data-collection-field-wrapper].template-variable-field-has-override > .input-group-text:first-child,
+[data-template-string-list].template-variable-field-has-override .input-group-text:first-child,
+[data-template-mapping-list].template-variable-field-has-override .input-group-text:first-child {
     color: var(--theme-primary-hover);
     font-weight: 700;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2040,6 +2040,32 @@ fieldset:disabled .btn {
     transition: background-color 0.2s ease;
 }
 
+.collection-variable-section,
+.overlay-variable-section {
+    position: relative;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.collection-variable-section.template-variable-section-has-overrides,
+.overlay-variable-section.template-variable-section-has-overrides {
+    border-color: rgba(var(--accent-color), 0.55) !important;
+    background: linear-gradient(90deg, rgba(var(--accent-color), 0.08), transparent 38%);
+    padding-left: 1rem !important;
+}
+
+.collection-variable-section.template-variable-section-has-overrides::before,
+.overlay-variable-section.template-variable-section-has-overrides::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    bottom: 0.45rem;
+    width: 4px;
+    border-radius: 0 4px 4px 0;
+    background: var(--theme-primary);
+    box-shadow: 0 0 10px rgba(var(--accent-color), 0.35);
+}
+
 /* -------------------- */
 /* INPUT STYLES         */
 /* -------------------- */

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2081,6 +2081,19 @@ fieldset:disabled .btn {
     white-space: nowrap;
 }
 
+.template-variable-field-has-override {
+    position: relative;
+    border-left: 4px solid var(--theme-primary) !important;
+    box-shadow: inset 7px 0 0 rgba(var(--accent-color), 0.08);
+}
+
+.input-group.template-variable-field-has-override > .input-group-text:first-child,
+.font-row.template-variable-field-has-override .input-group-text:first-child,
+.rgba-group.template-variable-field-has-override .input-group-text:first-child {
+    color: var(--theme-primary-hover);
+    font-weight: 700;
+}
+
 /* -------------------- */
 /* INPUT STYLES         */
 /* -------------------- */

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -62946,12 +62946,21 @@
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
-            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
+            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Release Date Order</b> ",
             "default": "release",
             "options": [
-              {
-                "value": "custom",
-                "label": "Custom Order",
+                {
+                    "value": "release",
+                    "label": "Release Date Order",
+                    "media_types": [
+                        "movie",
+                        "show",
+                        "episode"
+                    ]
+                },
+                {
+                    "value": "custom",
+                    "label": "Custom Order",
                 "media_types": [
                   "movie",
                   "show",
@@ -63858,12 +63867,21 @@
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
-            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
+            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Release Date Order</b> ",
             "default": "release",
             "options": [
-              {
-                "value": "custom",
-                "label": "Custom Order",
+                {
+                    "value": "release",
+                    "label": "Release Date Order",
+                    "media_types": [
+                        "movie",
+                        "show",
+                        "episode"
+                    ]
+                },
+                {
+                    "value": "custom",
+                    "label": "Custom Order",
                 "media_types": [
                   "movie",
                   "show",

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -43,107 +43,128 @@
               "gray",
               "black",
               "red"
-            ]
+            ],
+            "section": "basics"
           },
           "use_oscars": {
             "label": "Use Oscars Best Picture",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_oscars_director": {
             "label": "Use Oscars Best Director",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_golden": {
             "label": "Use Golden Globe Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_golden_director": {
             "label": "Use Golden Globe Director",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bafta": {
             "label": "Use BAFTA Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_cannes": {
             "label": "Use Cannes Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_berlinale": {
             "label": "Use Berlinale Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_venice": {
             "label": "Use Venice Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sundance": {
             "label": "Use Sundance Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_emmys": {
             "label": "Use Emmys Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_choice": {
             "label": "Use Critic's Choice Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_spirit": {
             "label": "Use Independent Spirit Award Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_cesar": {
             "label": "Use Cesar Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_imdb": {
             "label": "Use IMDb Top 250",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_letterboxd": {
             "label": "Use Letterboxd Top 500",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rottenverified": {
             "label": "Use Rotten Tomatoes Verified Hot",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rotten": {
             "label": "Use Rotten Tomatoes Certified Fresh",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_metacritic": {
             "label": "Use Metacritic Must See",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_common": {
             "label": "Use Common Sense Selection",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_razzie": {
             "label": "Use Razzies Winner",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "horizontal_align": {
             "input_type": "select",
@@ -153,7 +174,8 @@
               "left",
               "center",
               "right"
-            ]
+            ],
+            "section": "placement"
           },
           "vertical_align": {
             "input_type": "select",
@@ -163,19 +185,50 @@
               "top",
               "center",
               "bottom"
-            ]
+            ],
+            "section": "placement"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 0,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 0,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       }
     ]
   },
@@ -217,12 +270,14 @@
           "horizontal_offset": {
             "input_type": "number",
             "default": 200,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           },
           "back_align": {
             "default": "center",
@@ -234,44 +289,80 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_episode_info",
@@ -291,81 +382,93 @@
             "input_type": "hidden",
             "key": "text",
             "label": "Text",
-            "default": "S03E15"
+            "default": "S03E15",
+            "section": "basics"
           },
           {
             "input_type": "text",
             "key": "font",
             "label": "Font",
-            "default": "Inter-Medium.ttf"
+            "default": "Inter-Medium.ttf",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "font_size",
             "label": "Font Size",
-            "default": 55
+            "default": 55,
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "font_color",
             "label": "Font Color",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "select",
@@ -378,49 +481,57 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 305
+            "default": 305,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "type": "toggle",
@@ -429,7 +540,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       },
@@ -450,74 +590,88 @@
           "last": {
             "input_type": "number",
             "default": 14,
-            "label": "Last (Days)"
+            "label": "Last (Days)",
+            "section": "basics"
           },
           "use_airing": {
             "label": "Use Airing",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_returning": {
             "label": "Use Returning",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_canceled": {
             "label": "Use Canceled",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ended": {
             "label": "Use Ended",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "text_airing": {
             "input_type": "text",
             "label": "Airing Text",
-            "default": "AIRING"
+            "default": "AIRING",
+            "section": "basics"
           },
           "text_returning": {
             "input_type": "text",
             "label": "Returning Text",
-            "default": "RETURNING"
+            "default": "RETURNING",
+            "section": "basics"
           },
           "text_canceled": {
             "input_type": "text",
             "label": "Canceled Text",
-            "default": "CANCELED"
+            "default": "CANCELED",
+            "section": "basics"
           },
           "text_ended": {
             "input_type": "text",
             "label": "Ended Text",
-            "default": "ENDED"
+            "default": "ENDED",
+            "section": "basics"
           },
           "font": {
             "input_type": "text",
             "label": "Font",
-            "default": "Inter-Medium.ttf"
+            "default": "Inter-Medium.ttf",
+            "section": "font"
           },
           "font_size": {
             "input_type": "number",
             "label": "Font Size",
-            "default": 55
+            "default": 55,
+            "section": "font"
           },
           "font_color": {
             "input_type": "text",
             "label": "Font Color",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           "stroke_width": {
             "input_type": "number",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           "stroke_color": {
             "input_type": "text",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           "back_align": {
             "default": "center",
@@ -529,74 +683,116 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_color_airing": {
             "input_type": "text",
             "default": "#016920",
-            "label": "Backdrop Color (Airing)"
+            "label": "Backdrop Color (Airing)",
+            "section": "background"
           },
           "back_color_returning": {
             "input_type": "text",
             "default": "#81007F",
-            "label": "Backdrop Color (Returning)"
+            "label": "Backdrop Color (Returning)",
+            "section": "background"
           },
           "back_color_canceled": {
             "input_type": "text",
             "default": "#B52222",
-            "label": "Backdrop Color (Canceled)"
+            "label": "Backdrop Color (Canceled)",
+            "section": "background"
           },
           "back_color_ended": {
             "input_type": "text",
             "default": "#000847",
-            "label": "Backdrop Color (Ended)"
+            "label": "Backdrop Color (Ended)",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 330,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_ratings",
@@ -1418,37 +1614,44 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           "use_g": {
             "label": "Use G",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pg": {
             "label": "Use PG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pg-13": {
             "label": "Use PG-13",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r": {
             "label": "Use R",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nc-17": {
             "label": "Use NC-17",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nr": {
             "label": "Use NR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "back_align": {
             "default": "center",
@@ -1460,54 +1663,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 270,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_content_rating_us_show",
@@ -1546,37 +1787,44 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           "use_tv-g": {
             "label": "Use TV-G",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tv-y": {
             "label": "Use TV-Y",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tv-pg": {
             "label": "Use TV-PG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tv-14": {
             "label": "Use TV-14",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tv-ma": {
             "label": "Use TV-MA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nr": {
             "label": "Use NR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -1596,7 +1844,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "default": "center",
@@ -1608,54 +1857,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 270,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_content_rating_uk",
@@ -1695,47 +1982,56 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           "use_u": {
             "label": "Use U",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pg": {
             "label": "Use PG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_12": {
             "label": "Use 12",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_12a": {
             "label": "Use 12A",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_15": {
             "label": "Use 15",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_18": {
             "label": "Use 18",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r18": {
             "label": "Use R18",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nr": {
             "label": "Use NR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -1755,7 +2051,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "default": "center",
@@ -1767,54 +2064,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 270,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_content_rating_de",
@@ -1854,42 +2189,50 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           "use_0": {
             "label": "Use 0",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_6": {
             "label": "Use 6",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_12": {
             "label": "Use 12",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_16": {
             "label": "Use 16",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_18": {
             "label": "Use 18",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bpjm": {
             "label": "Use BPjM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nr": {
             "label": "Use NR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -1909,7 +2252,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "default": "center",
@@ -1921,54 +2265,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 270,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_content_rating_au",
@@ -2008,42 +2390,50 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           "use_g": {
             "label": "Use G",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pg": {
             "label": "Use PG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_m": {
             "label": "Use M",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ma": {
             "label": "Use MA15+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r": {
             "label": "Use R18+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_x": {
             "label": "Use X18+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nr": {
             "label": "Use NR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -2063,7 +2453,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "default": "center",
@@ -2075,54 +2466,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 270,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_content_rating_nz",
@@ -2162,67 +2591,80 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           "use_g": {
             "label": "Use G",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pg": {
             "label": "Use PG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_m": {
             "label": "Use M",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r13": {
             "label": "Use R13",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rp13": {
             "label": "Use RP13",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r15": {
             "label": "Use R15",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r16": {
             "label": "Use R16",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rp16": {
             "label": "Use RP16",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_R18": {
             "label": "Use R18",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rp18": {
             "label": "Use RP18",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_r": {
             "label": "Use R",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nr": {
             "label": "Use NR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -2242,7 +2684,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "default": "center",
@@ -2254,54 +2697,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 270,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_content_rating_commonsense",
@@ -2338,19 +2819,22 @@
           {
             "input_type": "hidden",
             "key": "text",
-            "default": 17
+            "default": 17,
+            "section": "basics"
           },
           {
             "input_type": "text",
             "key": "post_text",
             "label": "Post Text",
-            "default": "+"
+            "default": "+",
+            "section": "basics"
           },
           {
             "input_type": "number",
             "key": "addon_offset",
             "label": "Addon Offset",
-            "default": 15
+            "default": 15,
+            "section": "placement"
           },
           {
             "type": "toggle",
@@ -2361,7 +2845,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2372,7 +2857,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2383,7 +2869,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2394,7 +2881,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2405,7 +2893,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2416,7 +2905,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2427,7 +2917,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2438,7 +2929,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2449,7 +2941,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2460,7 +2953,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2471,7 +2965,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2482,7 +2977,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2493,7 +2989,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2504,7 +3001,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2515,7 +3013,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2526,7 +3025,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2537,7 +3037,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2548,7 +3049,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2559,36 +3061,42 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "input_type": "hidden",
             "key": "font",
-            "default": "Inter-Medium.ttf"
+            "default": "Inter-Medium.ttf",
+            "section": "font"
           },
           {
             "input_type": "hidden",
             "key": "font_size",
-            "default": 55
+            "default": 55,
+            "section": "font"
           },
           {
             "input_type": "hidden",
             "key": "font_color",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "select",
@@ -2601,61 +3109,71 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 305
+            "default": 305,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "horizontal_offset",
             "label": "Horizontal Offset",
-            "default": 0
+            "default": 0,
+            "section": "placement"
           },
           {
             "input_type": "number",
             "key": "vertical_offset",
             "label": "Vertical Offset",
-            "default": 150
+            "default": 150,
+            "section": "placement"
           },
           {
             "type": "toggle",
@@ -2664,7 +3182,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -2673,7 +3192,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -2682,7 +3202,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       }
@@ -2719,7 +3268,8 @@
             "input_type": "hidden",
             "key": "text",
             "label": "Text",
-            "default": "1.78"
+            "default": "1.78",
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -2730,7 +3280,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2741,7 +3292,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2752,7 +3304,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2763,7 +3316,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2774,7 +3328,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2785,7 +3340,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2796,7 +3352,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -2807,39 +3364,45 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "input_type": "text",
             "key": "font",
             "label": "Font",
-            "default": "Inter-Medium.ttf"
+            "default": "Inter-Medium.ttf",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "font_size",
             "label": "Font Size",
-            "default": 55
+            "default": 55,
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "font_color",
             "label": "Font Color",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "select",
@@ -2852,61 +3415,71 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 305
+            "default": 305,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "horizontal_offset",
             "label": "Horizontal Offset",
-            "default": 0
+            "default": 0,
+            "section": "placement"
           },
           {
             "input_type": "number",
             "key": "vertical_offset",
             "label": "Vertical Offset",
-            "default": 150
+            "default": 150,
+            "section": "placement"
           },
           {
             "type": "toggle",
@@ -2915,7 +3488,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -2924,7 +3498,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -2933,7 +3508,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       },
@@ -2977,87 +3581,104 @@
             "options": [
               "compact",
               "standard"
-            ]
+            ],
+            "section": "basics"
           },
           "use_truehd_atmos": {
             "label": "Use Dolby TrueHD Atmos",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_dtsx": {
             "label": "Use DTS-X",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_plus_atmos": {
             "label": "Use Dolby Digital+ / E-AC3",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_dolby_atmos": {
             "label": "Use Dolby Atmos",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_truehd": {
             "label": "Use Dolby TrueHD",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ma": {
             "label": "Use DTS-HD-MA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_flac": {
             "label": "Use FLAC",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pcm": {
             "label": "Use PCM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hra": {
             "label": "Use DTS-HD-HRA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_plus": {
             "label": "Use Dolby Digital+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_dtses": {
             "label": "Use DTS-ES",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_dts": {
             "label": "Use DTS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_digital": {
             "label": "Use Dolby Digital",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_aac": {
             "label": "Use AAC",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mp3": {
             "label": "Use MP3",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_opus": {
             "label": "Use Opus",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -3077,7 +3698,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "input_type": "select",
@@ -3089,54 +3711,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 0,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_language_count",
@@ -3180,7 +3840,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -3191,7 +3852,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "input_type": "select",
@@ -3204,49 +3866,57 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 188
+            "default": 188,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "type": "toggle",
@@ -3255,7 +3925,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -3264,7 +3935,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -3273,7 +3945,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       },
@@ -3314,7 +4015,8 @@
             "options": [
               "small",
               "big"
-            ]
+            ],
+            "section": "basics"
           },
           "style": {
             "label": "Style",
@@ -3324,449 +4026,538 @@
               "round",
               "square",
               "half"
-            ]
+            ],
+            "section": "basics"
           },
           "use_en": {
             "label": "Use EN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_de": {
             "label": "Use DE",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fr": {
             "label": "Use FR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_es": {
             "label": "Use ES",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pt": {
             "label": "Use PT",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ja": {
             "label": "Use JA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ko": {
             "label": "Use KO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_zh": {
             "label": "Use ZH",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_da": {
             "label": "Use DA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ru": {
             "label": "Use RU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_it": {
             "label": "Use IT",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hi": {
             "label": "Use HI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_te": {
             "label": "Use TE",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fa": {
             "label": "Use FA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_th": {
             "label": "Use TH",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nl": {
             "label": "Use NL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_no": {
             "label": "Use NO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_is": {
             "label": "Use IS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sv": {
             "label": "Use SV",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tr": {
             "label": "Use TR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pl": {
             "label": "Use PL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_cs": {
             "label": "Use CS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_uk": {
             "label": "Use UK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hu": {
             "label": "Use HU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ar": {
             "label": "Use AR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bg": {
             "label": "Use BG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bn": {
             "label": "Use BN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bs": {
             "label": "Use BS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ca": {
             "label": "Use CA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_cy": {
             "label": "Use CY",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_el": {
             "label": "Use EL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_et": {
             "label": "Use ET",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_eu": {
             "label": "Use EU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fi": {
             "label": "Use FI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tl": {
             "label": "Use TL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fil": {
             "label": "Use FIL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_gl": {
             "label": "Use GL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_he": {
             "label": "Use HE",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hr": {
             "label": "Use HR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_id": {
             "label": "Use ID",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ka": {
             "label": "Use KA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_kk": {
             "label": "Use KK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_kn": {
             "label": "Use KN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_la": {
             "label": "Use LA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lt": {
             "label": "Use LT",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lv": {
             "label": "Use LV",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mk": {
             "label": "Use MK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ml": {
             "label": "Use ML",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mr": {
             "label": "Use MR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ms": {
             "label": "Use MS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nb": {
             "label": "Use NB",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nn": {
             "label": "Use NN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pa": {
             "label": "Use PA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ro": {
             "label": "Use RO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sk": {
             "label": "Use SK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sl": {
             "label": "Use SL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sq": {
             "label": "Use SQ",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sr": {
             "label": "Use SR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_so": {
             "label": "Use SO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sw": {
             "label": "Use SW",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ta": {
             "label": "Use TA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ur": {
             "label": "Use UR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_vi": {
             "label": "Use VI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bm": {
             "label": "Use BM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ln": {
             "label": "Use LN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_wo": {
             "label": "Use WO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_myn": {
             "label": "Use MYN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_iu": {
             "label": "Use IU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rom": {
             "label": "Use ROM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_am": {
             "label": "Use AM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_su": {
             "label": "Use SU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_zu": {
             "label": "Use ZU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lb": {
             "label": "Use LB",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mos": {
             "label": "Use MOS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_af": {
             "label": "Use AF",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mn": {
             "label": "Use MN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_kh": {
             "label": "Use KH",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_li": {
             "label": "Use LI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ga": {
             "label": "Use GA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ay": {
             "label": "Use AY",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lo": {
             "label": "Use LO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "font": {
             "label": "Font",
             "input_type": "text",
-            "default": "Inter-Bold.ttf"
+            "default": "Inter-Bold.ttf",
+            "section": "font"
           },
           "font_size": {
             "label": "Font Size",
             "input_type": "number",
-            "default": 50
+            "default": 50,
+            "section": "font"
           },
           "font_color": {
             "label": "Font Color",
             "input_type": "text",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           "stroke_width": {
             "label": "Stroke Width",
             "input_type": "number",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           "stroke_color": {
             "label": "Stroke Color",
             "input_type": "text",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           "hide_text": {
             "label": "Hide Text",
             "input_type": "toggle",
-            "default": false
+            "default": false,
+            "section": "basics"
           },
           "use_lowercase": {
             "label": "Use Lowercase",
             "input_type": "toggle",
-            "default": false
+            "default": false,
+            "section": "basics"
           },
           "group_alignment": {
             "label": "Group Alignment",
@@ -3775,12 +4566,14 @@
             "options": [
               "vertical",
               "horizontal"
-            ]
+            ],
+            "section": "placement"
           },
           "offset": {
             "label": "Addon Offset",
             "input_type": "number",
-            "default": 10
+            "default": 10,
+            "section": "placement"
           },
           "languages": {
             "label": "Languages",
@@ -3790,88 +4583,332 @@
             "help_text": "Leave blank to use Kometa defaults, or choose specific supported language flags.",
             "tooltip": "Quickstart limits this list to the language flags documented by Kometa for the languages overlay. Leaving it blank uses Kometa defaults.",
             "options": [
-              { "value": "en", "label": "English (en)" },
-              { "value": "de", "label": "German (de)" },
-              { "value": "fr", "label": "French (fr)" },
-              { "value": "es", "label": "Spanish (es)" },
-              { "value": "pt", "label": "Portuguese (pt)" },
-              { "value": "ja", "label": "Japanese (ja)" },
-              { "value": "ko", "label": "Korean (ko)" },
-              { "value": "zh", "label": "Chinese (zh)" },
-              { "value": "da", "label": "Danish (da)" },
-              { "value": "ru", "label": "Russian (ru)" },
-              { "value": "it", "label": "Italian (it)" },
-              { "value": "hi", "label": "Hindi (hi)" },
-              { "value": "te", "label": "Telugu (te)" },
-              { "value": "fa", "label": "Farsi (fa)" },
-              { "value": "th", "label": "Thai (th)" },
-              { "value": "nl", "label": "Dutch (nl)" },
-              { "value": "no", "label": "Norwegian (no)" },
-              { "value": "is", "label": "Icelandic (is)" },
-              { "value": "sv", "label": "Swedish (sv)" },
-              { "value": "tr", "label": "Turkish (tr)" },
-              { "value": "pl", "label": "Polish (pl)" },
-              { "value": "cs", "label": "Czech (cs)" },
-              { "value": "uk", "label": "Ukrainian (uk)" },
-              { "value": "hu", "label": "Hungarian (hu)" },
-              { "value": "ar", "label": "Arabic (ar)" },
-              { "value": "bg", "label": "Bulgarian (bg)" },
-              { "value": "bn", "label": "Bengali (bn)" },
-              { "value": "bs", "label": "Bosnian (bs)" },
-              { "value": "ca", "label": "Catalan (ca)" },
-              { "value": "cy", "label": "Welsh (cy)" },
-              { "value": "el", "label": "Greek (el)" },
-              { "value": "et", "label": "Estonian (et)" },
-              { "value": "eu", "label": "Basque (eu)" },
-              { "value": "fi", "label": "Finnish (fi)" },
-              { "value": "tl", "label": "Tagalog (tl)" },
-              { "value": "fil", "label": "Filipino (fil)" },
-              { "value": "gl", "label": "Galician (gl)" },
-              { "value": "he", "label": "Hebrew (he)" },
-              { "value": "hr", "label": "Croatian (hr)" },
-              { "value": "id", "label": "Indonesian (id)" },
-              { "value": "ka", "label": "Georgian (ka)" },
-              { "value": "kk", "label": "Kazakh (kk)" },
-              { "value": "kn", "label": "Kannada (kn)" },
-              { "value": "la", "label": "Latin (la)" },
-              { "value": "lt", "label": "Lithuanian (lt)" },
-              { "value": "lv", "label": "Latvian (lv)" },
-              { "value": "mk", "label": "Macedonian (mk)" },
-              { "value": "ml", "label": "Malayalam (ml)" },
-              { "value": "mr", "label": "Marathi (mr)" },
-              { "value": "ms", "label": "Malay (ms)" },
-              { "value": "nb", "label": "Norwegian Bokmal (nb)" },
-              { "value": "nn", "label": "Norwegian Nynorsk (nn)" },
-              { "value": "pa", "label": "Punjabi (pa)" },
-              { "value": "ro", "label": "Romanian (ro)" },
-              { "value": "sk", "label": "Slovak (sk)" },
-              { "value": "sl", "label": "Slovenian (sl)" },
-              { "value": "sq", "label": "Albanian (sq)" },
-              { "value": "sr", "label": "Serbian (sr)" },
-              { "value": "so", "label": "Somali (so)" },
-              { "value": "sw", "label": "Swahili (sw)" },
-              { "value": "ta", "label": "Tamil (ta)" },
-              { "value": "ur", "label": "Urdu (ur)" },
-              { "value": "vi", "label": "Vietnamese (vi)" },
-              { "value": "bm", "label": "Bambara (bm)" },
-              { "value": "ln", "label": "Lingala (ln)" },
-              { "value": "wo", "label": "Wolof (wo)" },
-              { "value": "myn", "label": "Mayan (myn)" },
-              { "value": "iu", "label": "Inuktitut (iu)" },
-              { "value": "rom", "label": "Romani (rom)" },
-              { "value": "am", "label": "Amharic (am)" },
-              { "value": "su", "label": "Sundanese (su)" },
-              { "value": "zu", "label": "Zulu (zu)" },
-              { "value": "lb", "label": "Luxembourgish (lb)" },
-              { "value": "mos", "label": "Mossi (mos)" },
-              { "value": "af", "label": "Afrikaans (af)" },
-              { "value": "mn", "label": "Mongolian (mn)" },
-              { "value": "kh", "label": "Khmer (kh)" },
-              { "value": "li", "label": "Limburgish (li)" },
-              { "value": "ga", "label": "Irish (ga)" },
-              { "value": "ay", "label": "Aymara (ay)" },
-              { "value": "lo", "label": "Lao (lo)" }
-            ]
+              {
+                "value": "en",
+                "label": "English (en)"
+              },
+              {
+                "value": "de",
+                "label": "German (de)"
+              },
+              {
+                "value": "fr",
+                "label": "French (fr)"
+              },
+              {
+                "value": "es",
+                "label": "Spanish (es)"
+              },
+              {
+                "value": "pt",
+                "label": "Portuguese (pt)"
+              },
+              {
+                "value": "ja",
+                "label": "Japanese (ja)"
+              },
+              {
+                "value": "ko",
+                "label": "Korean (ko)"
+              },
+              {
+                "value": "zh",
+                "label": "Chinese (zh)"
+              },
+              {
+                "value": "da",
+                "label": "Danish (da)"
+              },
+              {
+                "value": "ru",
+                "label": "Russian (ru)"
+              },
+              {
+                "value": "it",
+                "label": "Italian (it)"
+              },
+              {
+                "value": "hi",
+                "label": "Hindi (hi)"
+              },
+              {
+                "value": "te",
+                "label": "Telugu (te)"
+              },
+              {
+                "value": "fa",
+                "label": "Farsi (fa)"
+              },
+              {
+                "value": "th",
+                "label": "Thai (th)"
+              },
+              {
+                "value": "nl",
+                "label": "Dutch (nl)"
+              },
+              {
+                "value": "no",
+                "label": "Norwegian (no)"
+              },
+              {
+                "value": "is",
+                "label": "Icelandic (is)"
+              },
+              {
+                "value": "sv",
+                "label": "Swedish (sv)"
+              },
+              {
+                "value": "tr",
+                "label": "Turkish (tr)"
+              },
+              {
+                "value": "pl",
+                "label": "Polish (pl)"
+              },
+              {
+                "value": "cs",
+                "label": "Czech (cs)"
+              },
+              {
+                "value": "uk",
+                "label": "Ukrainian (uk)"
+              },
+              {
+                "value": "hu",
+                "label": "Hungarian (hu)"
+              },
+              {
+                "value": "ar",
+                "label": "Arabic (ar)"
+              },
+              {
+                "value": "bg",
+                "label": "Bulgarian (bg)"
+              },
+              {
+                "value": "bn",
+                "label": "Bengali (bn)"
+              },
+              {
+                "value": "bs",
+                "label": "Bosnian (bs)"
+              },
+              {
+                "value": "ca",
+                "label": "Catalan (ca)"
+              },
+              {
+                "value": "cy",
+                "label": "Welsh (cy)"
+              },
+              {
+                "value": "el",
+                "label": "Greek (el)"
+              },
+              {
+                "value": "et",
+                "label": "Estonian (et)"
+              },
+              {
+                "value": "eu",
+                "label": "Basque (eu)"
+              },
+              {
+                "value": "fi",
+                "label": "Finnish (fi)"
+              },
+              {
+                "value": "tl",
+                "label": "Tagalog (tl)"
+              },
+              {
+                "value": "fil",
+                "label": "Filipino (fil)"
+              },
+              {
+                "value": "gl",
+                "label": "Galician (gl)"
+              },
+              {
+                "value": "he",
+                "label": "Hebrew (he)"
+              },
+              {
+                "value": "hr",
+                "label": "Croatian (hr)"
+              },
+              {
+                "value": "id",
+                "label": "Indonesian (id)"
+              },
+              {
+                "value": "ka",
+                "label": "Georgian (ka)"
+              },
+              {
+                "value": "kk",
+                "label": "Kazakh (kk)"
+              },
+              {
+                "value": "kn",
+                "label": "Kannada (kn)"
+              },
+              {
+                "value": "la",
+                "label": "Latin (la)"
+              },
+              {
+                "value": "lt",
+                "label": "Lithuanian (lt)"
+              },
+              {
+                "value": "lv",
+                "label": "Latvian (lv)"
+              },
+              {
+                "value": "mk",
+                "label": "Macedonian (mk)"
+              },
+              {
+                "value": "ml",
+                "label": "Malayalam (ml)"
+              },
+              {
+                "value": "mr",
+                "label": "Marathi (mr)"
+              },
+              {
+                "value": "ms",
+                "label": "Malay (ms)"
+              },
+              {
+                "value": "nb",
+                "label": "Norwegian Bokmal (nb)"
+              },
+              {
+                "value": "nn",
+                "label": "Norwegian Nynorsk (nn)"
+              },
+              {
+                "value": "pa",
+                "label": "Punjabi (pa)"
+              },
+              {
+                "value": "ro",
+                "label": "Romanian (ro)"
+              },
+              {
+                "value": "sk",
+                "label": "Slovak (sk)"
+              },
+              {
+                "value": "sl",
+                "label": "Slovenian (sl)"
+              },
+              {
+                "value": "sq",
+                "label": "Albanian (sq)"
+              },
+              {
+                "value": "sr",
+                "label": "Serbian (sr)"
+              },
+              {
+                "value": "so",
+                "label": "Somali (so)"
+              },
+              {
+                "value": "sw",
+                "label": "Swahili (sw)"
+              },
+              {
+                "value": "ta",
+                "label": "Tamil (ta)"
+              },
+              {
+                "value": "ur",
+                "label": "Urdu (ur)"
+              },
+              {
+                "value": "vi",
+                "label": "Vietnamese (vi)"
+              },
+              {
+                "value": "bm",
+                "label": "Bambara (bm)"
+              },
+              {
+                "value": "ln",
+                "label": "Lingala (ln)"
+              },
+              {
+                "value": "wo",
+                "label": "Wolof (wo)"
+              },
+              {
+                "value": "myn",
+                "label": "Mayan (myn)"
+              },
+              {
+                "value": "iu",
+                "label": "Inuktitut (iu)"
+              },
+              {
+                "value": "rom",
+                "label": "Romani (rom)"
+              },
+              {
+                "value": "am",
+                "label": "Amharic (am)"
+              },
+              {
+                "value": "su",
+                "label": "Sundanese (su)"
+              },
+              {
+                "value": "zu",
+                "label": "Zulu (zu)"
+              },
+              {
+                "value": "lb",
+                "label": "Luxembourgish (lb)"
+              },
+              {
+                "value": "mos",
+                "label": "Mossi (mos)"
+              },
+              {
+                "value": "af",
+                "label": "Afrikaans (af)"
+              },
+              {
+                "value": "mn",
+                "label": "Mongolian (mn)"
+              },
+              {
+                "value": "kh",
+                "label": "Khmer (kh)"
+              },
+              {
+                "value": "li",
+                "label": "Limburgish (li)"
+              },
+              {
+                "value": "ga",
+                "label": "Irish (ga)"
+              },
+              {
+                "value": "ay",
+                "label": "Aymara (ay)"
+              },
+              {
+                "value": "lo",
+                "label": "Lao (lo)"
+              }
+            ],
+            "section": "basics"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -3891,7 +4928,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "flag_alignment": {
             "default": "left",
@@ -3900,7 +4938,8 @@
             "options": [
               "left",
               "right"
-            ]
+            ],
+            "section": "placement"
           },
           "back_align": {
             "default": "left",
@@ -3912,64 +4951,104 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 60,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 190,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 26,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 223,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           },
           "initial_horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Initial Hor. Offset"
+            "label": "Initial Hor. Offset",
+            "section": "placement"
           },
           "initial_vertical_offset": {
             "input_type": "number",
             "default": 223,
-            "label": "Initial Vert. Offset"
+            "label": "Initial Vert. Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_languages_subtitles",
@@ -4008,7 +5087,8 @@
             "options": [
               "small",
               "big"
-            ]
+            ],
+            "section": "basics"
           },
           "style": {
             "label": "Style",
@@ -4018,449 +5098,538 @@
               "round",
               "square",
               "half"
-            ]
+            ],
+            "section": "basics"
           },
           "use_en": {
             "label": "Use EN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_de": {
             "label": "Use DE",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fr": {
             "label": "Use FR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_es": {
             "label": "Use ES",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pt": {
             "label": "Use PT",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ja": {
             "label": "Use JA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ko": {
             "label": "Use KO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_zh": {
             "label": "Use ZH",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_da": {
             "label": "Use DA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ru": {
             "label": "Use RU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_it": {
             "label": "Use IT",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hi": {
             "label": "Use HI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_te": {
             "label": "Use TE",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fa": {
             "label": "Use FA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_th": {
             "label": "Use TH",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nl": {
             "label": "Use NL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_no": {
             "label": "Use NO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_is": {
             "label": "Use IS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sv": {
             "label": "Use SV",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tr": {
             "label": "Use TR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pl": {
             "label": "Use PL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_cs": {
             "label": "Use CS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_uk": {
             "label": "Use UK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hu": {
             "label": "Use HU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ar": {
             "label": "Use AR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bg": {
             "label": "Use BG",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bn": {
             "label": "Use BN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bs": {
             "label": "Use BS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ca": {
             "label": "Use CA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_cy": {
             "label": "Use CY",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_el": {
             "label": "Use EL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_et": {
             "label": "Use ET",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_eu": {
             "label": "Use EU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fi": {
             "label": "Use FI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tl": {
             "label": "Use TL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_fil": {
             "label": "Use FIL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_gl": {
             "label": "Use GL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_he": {
             "label": "Use HE",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hr": {
             "label": "Use HR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_id": {
             "label": "Use ID",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ka": {
             "label": "Use KA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_kk": {
             "label": "Use KK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_kn": {
             "label": "Use KN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_la": {
             "label": "Use LA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lt": {
             "label": "Use LT",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lv": {
             "label": "Use LV",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mk": {
             "label": "Use MK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ml": {
             "label": "Use ML",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mr": {
             "label": "Use MR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ms": {
             "label": "Use MS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nb": {
             "label": "Use NB",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_nn": {
             "label": "Use NN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_pa": {
             "label": "Use PA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ro": {
             "label": "Use RO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sk": {
             "label": "Use SK",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sl": {
             "label": "Use SL",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sq": {
             "label": "Use SQ",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sr": {
             "label": "Use SR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_so": {
             "label": "Use SO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_sw": {
             "label": "Use SW",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ta": {
             "label": "Use TA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ur": {
             "label": "Use UR",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_vi": {
             "label": "Use VI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bm": {
             "label": "Use BM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ln": {
             "label": "Use LN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_wo": {
             "label": "Use WO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_myn": {
             "label": "Use MYN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_iu": {
             "label": "Use IU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_rom": {
             "label": "Use ROM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_am": {
             "label": "Use AM",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_su": {
             "label": "Use SU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_zu": {
             "label": "Use ZU",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lb": {
             "label": "Use LB",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mos": {
             "label": "Use MOS",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_af": {
             "label": "Use AF",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_mn": {
             "label": "Use MN",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_kh": {
             "label": "Use KH",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_li": {
             "label": "Use LI",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ga": {
             "label": "Use GA",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_ay": {
             "label": "Use AY",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_lo": {
             "label": "Use LO",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "font": {
             "label": "Font",
             "input_type": "text",
-            "default": "Inter-Bold.ttf"
+            "default": "Inter-Bold.ttf",
+            "section": "font"
           },
           "font_size": {
             "label": "Font Size",
             "input_type": "number",
-            "default": 50
+            "default": 50,
+            "section": "font"
           },
           "font_color": {
             "label": "Font Color",
             "input_type": "text",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           "stroke_width": {
             "label": "Stroke Width",
             "input_type": "number",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           "stroke_color": {
             "label": "Stroke Color",
             "input_type": "text",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           "hide_text": {
             "label": "Hide Text",
             "input_type": "toggle",
-            "default": false
+            "default": false,
+            "section": "basics"
           },
           "use_lowercase": {
             "label": "Use Lowercase",
             "input_type": "toggle",
-            "default": false
+            "default": false,
+            "section": "basics"
           },
           "group_alignment": {
             "label": "Group Alignment",
@@ -4469,12 +5638,14 @@
             "options": [
               "vertical",
               "horizontal"
-            ]
+            ],
+            "section": "placement"
           },
           "offset": {
             "label": "Addon Offset",
             "input_type": "number",
-            "default": 10
+            "default": 10,
+            "section": "placement"
           },
           "languages": {
             "label": "Languages",
@@ -4484,92 +5655,337 @@
             "help_text": "Leave blank to use Kometa defaults, or choose specific supported subtitle language flags.",
             "tooltip": "Quickstart limits this list to the language flags documented by Kometa for the languages overlay. Leaving it blank uses Kometa defaults.",
             "options": [
-              { "value": "en", "label": "English (en)" },
-              { "value": "de", "label": "German (de)" },
-              { "value": "fr", "label": "French (fr)" },
-              { "value": "es", "label": "Spanish (es)" },
-              { "value": "pt", "label": "Portuguese (pt)" },
-              { "value": "ja", "label": "Japanese (ja)" },
-              { "value": "ko", "label": "Korean (ko)" },
-              { "value": "zh", "label": "Chinese (zh)" },
-              { "value": "da", "label": "Danish (da)" },
-              { "value": "ru", "label": "Russian (ru)" },
-              { "value": "it", "label": "Italian (it)" },
-              { "value": "hi", "label": "Hindi (hi)" },
-              { "value": "te", "label": "Telugu (te)" },
-              { "value": "fa", "label": "Farsi (fa)" },
-              { "value": "th", "label": "Thai (th)" },
-              { "value": "nl", "label": "Dutch (nl)" },
-              { "value": "no", "label": "Norwegian (no)" },
-              { "value": "is", "label": "Icelandic (is)" },
-              { "value": "sv", "label": "Swedish (sv)" },
-              { "value": "tr", "label": "Turkish (tr)" },
-              { "value": "pl", "label": "Polish (pl)" },
-              { "value": "cs", "label": "Czech (cs)" },
-              { "value": "uk", "label": "Ukrainian (uk)" },
-              { "value": "hu", "label": "Hungarian (hu)" },
-              { "value": "ar", "label": "Arabic (ar)" },
-              { "value": "bg", "label": "Bulgarian (bg)" },
-              { "value": "bn", "label": "Bengali (bn)" },
-              { "value": "bs", "label": "Bosnian (bs)" },
-              { "value": "ca", "label": "Catalan (ca)" },
-              { "value": "cy", "label": "Welsh (cy)" },
-              { "value": "el", "label": "Greek (el)" },
-              { "value": "et", "label": "Estonian (et)" },
-              { "value": "eu", "label": "Basque (eu)" },
-              { "value": "fi", "label": "Finnish (fi)" },
-              { "value": "tl", "label": "Tagalog (tl)" },
-              { "value": "fil", "label": "Filipino (fil)" },
-              { "value": "gl", "label": "Galician (gl)" },
-              { "value": "he", "label": "Hebrew (he)" },
-              { "value": "hr", "label": "Croatian (hr)" },
-              { "value": "id", "label": "Indonesian (id)" },
-              { "value": "ka", "label": "Georgian (ka)" },
-              { "value": "kk", "label": "Kazakh (kk)" },
-              { "value": "kn", "label": "Kannada (kn)" },
-              { "value": "la", "label": "Latin (la)" },
-              { "value": "lt", "label": "Lithuanian (lt)" },
-              { "value": "lv", "label": "Latvian (lv)" },
-              { "value": "mk", "label": "Macedonian (mk)" },
-              { "value": "ml", "label": "Malayalam (ml)" },
-              { "value": "mr", "label": "Marathi (mr)" },
-              { "value": "ms", "label": "Malay (ms)" },
-              { "value": "nb", "label": "Norwegian Bokmal (nb)" },
-              { "value": "nn", "label": "Norwegian Nynorsk (nn)" },
-              { "value": "pa", "label": "Punjabi (pa)" },
-              { "value": "ro", "label": "Romanian (ro)" },
-              { "value": "sk", "label": "Slovak (sk)" },
-              { "value": "sl", "label": "Slovenian (sl)" },
-              { "value": "sq", "label": "Albanian (sq)" },
-              { "value": "sr", "label": "Serbian (sr)" },
-              { "value": "so", "label": "Somali (so)" },
-              { "value": "sw", "label": "Swahili (sw)" },
-              { "value": "ta", "label": "Tamil (ta)" },
-              { "value": "ur", "label": "Urdu (ur)" },
-              { "value": "vi", "label": "Vietnamese (vi)" },
-              { "value": "bm", "label": "Bambara (bm)" },
-              { "value": "ln", "label": "Lingala (ln)" },
-              { "value": "wo", "label": "Wolof (wo)" },
-              { "value": "myn", "label": "Mayan (myn)" },
-              { "value": "iu", "label": "Inuktitut (iu)" },
-              { "value": "rom", "label": "Romani (rom)" },
-              { "value": "am", "label": "Amharic (am)" },
-              { "value": "su", "label": "Sundanese (su)" },
-              { "value": "zu", "label": "Zulu (zu)" },
-              { "value": "lb", "label": "Luxembourgish (lb)" },
-              { "value": "mos", "label": "Mossi (mos)" },
-              { "value": "af", "label": "Afrikaans (af)" },
-              { "value": "mn", "label": "Mongolian (mn)" },
-              { "value": "kh", "label": "Khmer (kh)" },
-              { "value": "li", "label": "Limburgish (li)" },
-              { "value": "ga", "label": "Irish (ga)" },
-              { "value": "ay", "label": "Aymara (ay)" },
-              { "value": "lo", "label": "Lao (lo)" }
-            ]
+              {
+                "value": "en",
+                "label": "English (en)"
+              },
+              {
+                "value": "de",
+                "label": "German (de)"
+              },
+              {
+                "value": "fr",
+                "label": "French (fr)"
+              },
+              {
+                "value": "es",
+                "label": "Spanish (es)"
+              },
+              {
+                "value": "pt",
+                "label": "Portuguese (pt)"
+              },
+              {
+                "value": "ja",
+                "label": "Japanese (ja)"
+              },
+              {
+                "value": "ko",
+                "label": "Korean (ko)"
+              },
+              {
+                "value": "zh",
+                "label": "Chinese (zh)"
+              },
+              {
+                "value": "da",
+                "label": "Danish (da)"
+              },
+              {
+                "value": "ru",
+                "label": "Russian (ru)"
+              },
+              {
+                "value": "it",
+                "label": "Italian (it)"
+              },
+              {
+                "value": "hi",
+                "label": "Hindi (hi)"
+              },
+              {
+                "value": "te",
+                "label": "Telugu (te)"
+              },
+              {
+                "value": "fa",
+                "label": "Farsi (fa)"
+              },
+              {
+                "value": "th",
+                "label": "Thai (th)"
+              },
+              {
+                "value": "nl",
+                "label": "Dutch (nl)"
+              },
+              {
+                "value": "no",
+                "label": "Norwegian (no)"
+              },
+              {
+                "value": "is",
+                "label": "Icelandic (is)"
+              },
+              {
+                "value": "sv",
+                "label": "Swedish (sv)"
+              },
+              {
+                "value": "tr",
+                "label": "Turkish (tr)"
+              },
+              {
+                "value": "pl",
+                "label": "Polish (pl)"
+              },
+              {
+                "value": "cs",
+                "label": "Czech (cs)"
+              },
+              {
+                "value": "uk",
+                "label": "Ukrainian (uk)"
+              },
+              {
+                "value": "hu",
+                "label": "Hungarian (hu)"
+              },
+              {
+                "value": "ar",
+                "label": "Arabic (ar)"
+              },
+              {
+                "value": "bg",
+                "label": "Bulgarian (bg)"
+              },
+              {
+                "value": "bn",
+                "label": "Bengali (bn)"
+              },
+              {
+                "value": "bs",
+                "label": "Bosnian (bs)"
+              },
+              {
+                "value": "ca",
+                "label": "Catalan (ca)"
+              },
+              {
+                "value": "cy",
+                "label": "Welsh (cy)"
+              },
+              {
+                "value": "el",
+                "label": "Greek (el)"
+              },
+              {
+                "value": "et",
+                "label": "Estonian (et)"
+              },
+              {
+                "value": "eu",
+                "label": "Basque (eu)"
+              },
+              {
+                "value": "fi",
+                "label": "Finnish (fi)"
+              },
+              {
+                "value": "tl",
+                "label": "Tagalog (tl)"
+              },
+              {
+                "value": "fil",
+                "label": "Filipino (fil)"
+              },
+              {
+                "value": "gl",
+                "label": "Galician (gl)"
+              },
+              {
+                "value": "he",
+                "label": "Hebrew (he)"
+              },
+              {
+                "value": "hr",
+                "label": "Croatian (hr)"
+              },
+              {
+                "value": "id",
+                "label": "Indonesian (id)"
+              },
+              {
+                "value": "ka",
+                "label": "Georgian (ka)"
+              },
+              {
+                "value": "kk",
+                "label": "Kazakh (kk)"
+              },
+              {
+                "value": "kn",
+                "label": "Kannada (kn)"
+              },
+              {
+                "value": "la",
+                "label": "Latin (la)"
+              },
+              {
+                "value": "lt",
+                "label": "Lithuanian (lt)"
+              },
+              {
+                "value": "lv",
+                "label": "Latvian (lv)"
+              },
+              {
+                "value": "mk",
+                "label": "Macedonian (mk)"
+              },
+              {
+                "value": "ml",
+                "label": "Malayalam (ml)"
+              },
+              {
+                "value": "mr",
+                "label": "Marathi (mr)"
+              },
+              {
+                "value": "ms",
+                "label": "Malay (ms)"
+              },
+              {
+                "value": "nb",
+                "label": "Norwegian Bokmal (nb)"
+              },
+              {
+                "value": "nn",
+                "label": "Norwegian Nynorsk (nn)"
+              },
+              {
+                "value": "pa",
+                "label": "Punjabi (pa)"
+              },
+              {
+                "value": "ro",
+                "label": "Romanian (ro)"
+              },
+              {
+                "value": "sk",
+                "label": "Slovak (sk)"
+              },
+              {
+                "value": "sl",
+                "label": "Slovenian (sl)"
+              },
+              {
+                "value": "sq",
+                "label": "Albanian (sq)"
+              },
+              {
+                "value": "sr",
+                "label": "Serbian (sr)"
+              },
+              {
+                "value": "so",
+                "label": "Somali (so)"
+              },
+              {
+                "value": "sw",
+                "label": "Swahili (sw)"
+              },
+              {
+                "value": "ta",
+                "label": "Tamil (ta)"
+              },
+              {
+                "value": "ur",
+                "label": "Urdu (ur)"
+              },
+              {
+                "value": "vi",
+                "label": "Vietnamese (vi)"
+              },
+              {
+                "value": "bm",
+                "label": "Bambara (bm)"
+              },
+              {
+                "value": "ln",
+                "label": "Lingala (ln)"
+              },
+              {
+                "value": "wo",
+                "label": "Wolof (wo)"
+              },
+              {
+                "value": "myn",
+                "label": "Mayan (myn)"
+              },
+              {
+                "value": "iu",
+                "label": "Inuktitut (iu)"
+              },
+              {
+                "value": "rom",
+                "label": "Romani (rom)"
+              },
+              {
+                "value": "am",
+                "label": "Amharic (am)"
+              },
+              {
+                "value": "su",
+                "label": "Sundanese (su)"
+              },
+              {
+                "value": "zu",
+                "label": "Zulu (zu)"
+              },
+              {
+                "value": "lb",
+                "label": "Luxembourgish (lb)"
+              },
+              {
+                "value": "mos",
+                "label": "Mossi (mos)"
+              },
+              {
+                "value": "af",
+                "label": "Afrikaans (af)"
+              },
+              {
+                "value": "mn",
+                "label": "Mongolian (mn)"
+              },
+              {
+                "value": "kh",
+                "label": "Khmer (kh)"
+              },
+              {
+                "value": "li",
+                "label": "Limburgish (li)"
+              },
+              {
+                "value": "ga",
+                "label": "Irish (ga)"
+              },
+              {
+                "value": "ay",
+                "label": "Aymara (ay)"
+              },
+              {
+                "value": "lo",
+                "label": "Lao (lo)"
+              }
+            ],
+            "section": "basics"
           },
           "use_subtitles": {
             "input_type": "hidden",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -4589,7 +6005,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "flag_alignment": {
             "default": "right",
@@ -4598,7 +6015,8 @@
             "options": [
               "left",
               "right"
-            ]
+            ],
+            "section": "placement"
           },
           "back_align": {
             "default": "right",
@@ -4610,64 +6028,104 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 60,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 190,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 26,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 223,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           },
           "initial_horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Initial Hor. Offset"
+            "label": "Initial Hor. Offset",
+            "section": "placement"
           },
           "initial_vertical_offset": {
             "input_type": "number",
             "default": 223,
-            "label": "Initial Vert. Offset"
+            "label": "Initial Vert. Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_resolution",
@@ -4716,7 +6174,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -4727,7 +6186,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4738,7 +6198,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4749,7 +6210,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4760,7 +6222,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4771,7 +6234,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4782,7 +6246,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4793,7 +6258,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4804,7 +6270,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4815,7 +6282,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4826,7 +6294,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4837,7 +6306,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4848,7 +6318,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4859,7 +6330,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4870,7 +6342,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4881,7 +6354,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4892,7 +6366,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4903,7 +6378,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4914,7 +6390,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4925,7 +6402,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4936,7 +6414,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4947,7 +6426,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4958,7 +6438,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4969,7 +6450,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4980,7 +6462,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -4991,7 +6474,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5002,7 +6486,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5013,7 +6498,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5024,7 +6510,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5035,7 +6522,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5046,7 +6534,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5057,7 +6546,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5068,7 +6558,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5079,7 +6570,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5090,7 +6582,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5101,7 +6594,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5112,7 +6606,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5123,7 +6618,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5134,7 +6630,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5145,7 +6642,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5156,7 +6654,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5167,7 +6666,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5178,7 +6678,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5189,7 +6690,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5200,7 +6702,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5211,7 +6714,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5222,7 +6726,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5233,7 +6738,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5244,7 +6750,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5255,7 +6762,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5266,7 +6774,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5277,7 +6786,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5288,7 +6798,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5299,7 +6810,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5310,7 +6822,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5321,7 +6834,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5332,7 +6846,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5343,7 +6858,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5354,7 +6870,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5365,7 +6882,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5376,7 +6894,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5387,7 +6906,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5398,7 +6918,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5409,7 +6930,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5420,7 +6942,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5431,7 +6954,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "input_type": "select",
@@ -5444,61 +6968,71 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 305
+            "default": 305,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "horizontal_offset",
             "label": "Horizontal Offset",
-            "default": 15
+            "default": 15,
+            "section": "placement"
           },
           {
             "input_type": "number",
             "key": "vertical_offset",
             "label": "Vertical Offset",
-            "default": 15
+            "default": 15,
+            "section": "placement"
           },
           {
             "type": "toggle",
@@ -5507,7 +7041,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5516,7 +7051,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5525,7 +7061,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       },
@@ -5549,45 +7114,52 @@
             "input_type": "text",
             "key": "text",
             "label": "Prefix Text",
-            "default": "Runtime: "
+            "default": "Runtime: ",
+            "section": "basics"
           },
           {
             "input_type": "text",
             "key": "format",
             "label": "Format",
-            "default": "<<runtimeH>>h <<runtimeM>>m"
+            "default": "<<runtimeH>>h <<runtimeM>>m",
+            "section": "basics"
           },
           {
             "input_type": "text",
             "key": "font",
             "label": "Font",
-            "default": "Inter-Medium.ttf"
+            "default": "Inter-Medium.ttf",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "font_size",
             "label": "Font Size",
-            "default": 55
+            "default": 55,
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "font_color",
             "label": "Font Color",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "select",
@@ -5600,49 +7172,57 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 600
+            "default": 600,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "type": "toggle",
@@ -5651,7 +7231,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5660,7 +7241,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       },
@@ -5728,49 +7338,57 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "type": "toggle",
@@ -5779,7 +7397,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5788,7 +7407,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5797,7 +7417,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       },
@@ -5825,7 +7474,8 @@
             "input_type": "hidden",
             "key": "text",
             "label": "Text",
-            "default": "HDTV"
+            "default": "HDTV",
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -5836,7 +7486,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5847,7 +7498,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5858,7 +7510,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5869,7 +7522,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5880,7 +7534,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5891,7 +7546,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5902,7 +7558,8 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "type": "toggle",
@@ -5913,39 +7570,45 @@
             "options": [
               "true",
               "false"
-            ]
+            ],
+            "section": "included_items"
           },
           {
             "input_type": "text",
             "key": "font",
             "label": "Font",
-            "default": "Inter-Medium.ttf"
+            "default": "Inter-Medium.ttf",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "font_size",
             "label": "Font Size",
-            "default": 55
+            "default": 55,
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "font_color",
             "label": "Font Color",
-            "default": "#FFFFFFFF"
+            "default": "#FFFFFFFF",
+            "section": "font"
           },
           {
             "input_type": "number",
             "key": "stroke_width",
             "label": "Stroke Width",
             "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0.",
+            "section": "font"
           },
           {
             "input_type": "text",
             "key": "stroke_color",
             "label": "Stroke Color",
             "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA.",
+            "section": "font"
           },
           {
             "input_type": "select",
@@ -5958,49 +7621,57 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 105
+            "default": 105,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 305
+            "default": 305,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "type": "toggle",
@@ -6009,7 +7680,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -6018,7 +7690,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -6027,7 +7700,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       }
@@ -6077,14 +7779,16 @@
             "options": [
               "color",
               "white"
-            ]
+            ],
+            "section": "basics"
           },
           "originals_only": {
             "label": "Originals Only",
             "input_type": "toggle",
             "default": false,
             "tooltip": "Switches supported services from \"currently streaming on this service\" to that service's original productions. This cannot be combined with Region and only works for select services such as Amazon, Apple TV, Disney, Max, Hulu, Netflix, Paramount, Peacock.",
-            "mutually_exclusive_with": "region"
+            "mutually_exclusive_with": "region",
+            "section": "basics"
           },
           "region": {
             "label": "Region",
@@ -6094,117 +7798,140 @@
             "options_source": "iso_3166_1_regions",
             "include_blank_option": true,
             "blank_option_label": "Default Region (Kometa default: US)",
-            "mutually_exclusive_with": "originals_only"
+            "mutually_exclusive_with": "originals_only",
+            "section": "basics"
           },
           "use_netflix": {
             "label": "Use Netflix",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_amazon": {
             "label": "Use Prime Video",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_disney": {
             "label": "Use Disney+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hbomax": {
             "label": "Use HBO Max",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_crunchyroll": {
             "label": "Use Crunchyroll",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_movistar": {
             "label": "Use Movistar Plus+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_atresplayer": {
             "label": "Use Atres Player",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_youtube": {
             "label": "Use YouTube",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hulu": {
             "label": "Use Hulu",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_paramount": {
             "label": "Use Paramount+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_amc": {
             "label": "Use AMC+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_appletv": {
             "label": "Use AppleTV",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_peacock": {
             "label": "Use Peacock",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_discovery": {
             "label": "Use discovery+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_crave": {
             "label": "Use Crave",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_now": {
             "label": "Use NOW",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_channel4": {
             "label": "Use Channel 4",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_itvx": {
             "label": "Use ITVX",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_bet": {
             "label": "Use BET+",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_hayu": {
             "label": "Use hayu",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_tubi": {
             "label": "Use tubi",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "use_filmin": {
             "label": "Use filmin",
             "input_type": "toggle",
-            "default": true
+            "default": true,
+            "section": "included_items"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -6224,7 +7951,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "input_type": "select",
@@ -6236,54 +7964,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 390,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_studio",
@@ -6323,7 +8089,8 @@
             "options": [
               "standard",
               "bigger"
-            ]
+            ],
+            "section": "basics"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -6343,7 +8110,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "input_type": "select",
@@ -6355,54 +8123,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 150,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       },
       {
         "id": "overlay_network",
@@ -6441,7 +8247,8 @@
             "options": [
               "color",
               "white"
-            ]
+            ],
+            "section": "basics"
           },
           "builder_level": {
             "input_type": "toggle",
@@ -6461,7 +8268,8 @@
                 "label": "Apply to Episode",
                 "value": "episode"
               }
-            ]
+            ],
+            "section": "basics"
           },
           "back_align": {
             "input_type": "select",
@@ -6473,54 +8281,92 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           "back_color": {
             "input_type": "text",
             "default": "#00000099",
-            "label": "Backdrop Color"
+            "label": "Backdrop Color",
+            "section": "background"
           },
           "back_height": {
             "input_type": "number",
             "default": 105,
-            "label": "Backdrop Height"
+            "label": "Backdrop Height",
+            "section": "background"
           },
           "back_width": {
             "input_type": "number",
             "default": 305,
-            "label": "Backdrop Width"
+            "label": "Backdrop Width",
+            "section": "background"
           },
           "back_line_color": {
             "input_type": "text",
             "default": "#00000000",
-            "label": "Backdrop Line Color"
+            "label": "Backdrop Line Color",
+            "section": "background"
           },
           "back_line_width": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Line Width"
+            "label": "Backdrop Line Width",
+            "section": "background"
           },
           "back_padding": {
             "input_type": "number",
             "default": 1,
-            "label": "Backdrop Padding"
+            "label": "Backdrop Padding",
+            "section": "background"
           },
           "back_radius": {
             "input_type": "number",
             "default": 30,
-            "label": "Backdrop Radius"
+            "label": "Backdrop Radius",
+            "section": "background"
           },
           "horizontal_offset": {
             "input_type": "number",
             "default": 15,
-            "label": "Horizontal Offset"
+            "label": "Horizontal Offset",
+            "section": "placement"
           },
           "vertical_offset": {
             "input_type": "number",
             "default": 510,
-            "label": "Vertical Offset"
+            "label": "Vertical Offset",
+            "section": "placement"
           }
-        }
+        },
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
+          }
+        ]
       }
     ]
   },
@@ -6573,49 +8419,57 @@
               "right",
               "top",
               "bottom"
-            ]
+            ],
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_color",
             "label": "Backdrop Color",
-            "default": "#00000099"
+            "default": "#00000099",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_height",
             "label": "Backdrop Height",
-            "default": 170
+            "default": 170,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_width",
             "label": "Backdrop Width",
-            "default": 305
+            "default": 305,
+            "section": "background"
           },
           {
             "input_type": "text",
             "key": "back_line_color",
             "label": "Backdrop Line Color",
-            "default": "#00000000"
+            "default": "#00000000",
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_line_width",
             "label": "Backdrop Line Width",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_padding",
             "label": "Backdrop Padding",
-            "default": 1
+            "default": 1,
+            "section": "background"
           },
           {
             "input_type": "number",
             "key": "back_radius",
             "label": "Backdrop Radius",
-            "default": 30
+            "default": 30,
+            "section": "background"
           },
           {
             "type": "toggle",
@@ -6624,7 +8478,8 @@
             "value": "show",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -6633,7 +8488,8 @@
             "value": "season",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "type": "toggle",
@@ -6642,7 +8498,36 @@
             "value": "episode",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "basics"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core overlay behavior and style.",
+            "default_open": true
+          },
+          {
+            "id": "included_items",
+            "label": "Included Items",
+            "summary": "Choose which generated overlay items are active."
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Text font, size, color, and stroke."
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding."
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment and offsets."
           }
         ]
       }

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -206,27 +206,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       }
@@ -340,27 +344,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -549,27 +557,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -770,27 +782,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -1726,27 +1742,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -1920,27 +1940,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -2127,27 +2151,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -2328,27 +2356,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -2529,27 +2561,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -2760,27 +2796,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -3211,27 +3251,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       }
@@ -3517,27 +3561,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -3774,27 +3822,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -3954,27 +4006,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -5026,27 +5082,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -6103,27 +6163,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -7070,27 +7134,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -7250,27 +7318,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -7426,27 +7498,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -7709,27 +7785,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       }
@@ -8027,27 +8107,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -8186,27 +8270,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       },
@@ -8344,27 +8432,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       }
@@ -8507,27 +8599,31 @@
             "id": "basics",
             "label": "Basics",
             "summary": "Core overlay behavior and style.",
-            "default_open": true
+            "default_open": false
           },
           {
             "id": "included_items",
             "label": "Included Items",
-            "summary": "Choose which generated overlay items are active."
+            "summary": "Choose which generated overlay items are active.",
+            "default_open": false
           },
           {
             "id": "font",
             "label": "Font",
-            "summary": "Text font, size, color, and stroke."
+            "summary": "Text font, size, color, and stroke.",
+            "default_open": false
           },
           {
             "id": "background",
             "label": "Background",
-            "summary": "Background fill, outline, dimensions, and padding."
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
           },
           {
             "id": "placement",
             "label": "Placement",
-            "summary": "Overlay alignment and offsets."
+            "summary": "Overlay alignment and offsets.",
+            "default_open": false
           }
         ]
       }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -7516,6 +7516,37 @@ function setOverrideSummaryBadge (badge, count) {
   badge.classList.toggle('d-none', count <= 0)
 }
 
+function findTemplateVariableFieldRow (field) {
+  if (!field || field.type === 'hidden') return null
+  return field.closest(
+    '[data-template-string-list], ' +
+    '[data-template-mapping-list], ' +
+    '[data-overlay-language-weight-builder], ' +
+    '.rgba-group, ' +
+    '.font-row, ' +
+    '.input-group, ' +
+    '.form-check'
+  )
+}
+
+function updateTemplateVariableFieldOverrideStates (body, fieldsByName) {
+  if (!body) return
+  body.querySelectorAll('.template-variable-field-has-override').forEach(row => {
+    row.classList.remove('template-variable-field-has-override')
+    row.removeAttribute('data-template-variable-field-override')
+  })
+
+  fieldsByName.forEach(fields => {
+    if (!isCollectionSectionFieldConfigured(fields)) return
+    fields.forEach(field => {
+      const row = findTemplateVariableFieldRow(field)
+      if (!row) return
+      row.classList.add('template-variable-field-has-override')
+      row.dataset.templateVariableFieldOverride = 'true'
+    })
+  })
+}
+
 function getOrCreateTemplateOverrideBadge (group) {
   if (!group) return null
   let badge = group.querySelector('[data-template-group-override-summary]')
@@ -7600,6 +7631,8 @@ function updateCollectionVariableSectionSummary (section) {
     if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
   })
 
+  updateTemplateVariableFieldOverrideStates(body, fieldsByName)
+
   summary.textContent = configuredCount === 0
     ? 'Defaults'
     : configuredCount === 1
@@ -7629,6 +7662,8 @@ function updateOverlayVariableSectionSummary (section) {
   fieldsByName.forEach(fields => {
     if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
   })
+
+  updateTemplateVariableFieldOverrideStates(body, fieldsByName)
 
   summary.textContent = configuredCount === 0
     ? 'Defaults'

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -36,6 +36,64 @@ const copyModal = copyModalEl ? new bootstrap.Modal(copyModalEl) : null
 let activeLibraryId = null
 let loadRequestId = 0
 let allowNextStepNavigation = false
+
+function setLibrariesButtonBusy (button, busy, label = 'Working...') {
+  if (!button) return
+  if (!button.dataset.librariesBusyOriginalHtml) {
+    button.dataset.librariesBusyOriginalHtml = button.innerHTML
+  }
+  if (!button.dataset.librariesBusyOriginalWidth) {
+    const width = button.getBoundingClientRect ? button.getBoundingClientRect().width : 0
+    if (width > 0) {
+      button.dataset.librariesBusyOriginalWidth = `${Math.ceil(width)}px`
+      button.style.minWidth = button.dataset.librariesBusyOriginalWidth
+    }
+  }
+  button.disabled = !!busy
+  button.setAttribute('aria-busy', busy ? 'true' : 'false')
+  if (busy) {
+    button.innerHTML = `<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>${label}`
+  } else {
+    button.innerHTML = button.dataset.librariesBusyOriginalHtml || button.innerHTML
+    button.removeAttribute('aria-busy')
+  }
+}
+
+function shouldShowLibrariesButtonSpinner (button) {
+  if (!button || button.disabled || button.getAttribute('aria-busy') === 'true') return false
+  if (!button.classList.contains('btn')) return false
+  if (button.classList.contains('accordion-button') || button.classList.contains('btn-close')) return false
+  if (button.matches('[data-bs-dismiss], [data-bs-toggle="collapse"], [data-bs-toggle="dropdown"], [data-bs-toggle="modal"]')) return false
+  if (button.matches('[data-toggle-secret-visibility], [data-collection-section-move], [data-section-id]')) return false
+  if (button.matches('.style-preview-card, .font-picker-card, .overlay-details-toggle')) return false
+  if (button.closest('.btn-group') && button.querySelector('.bi-chevron-up, .bi-chevron-down')) return false
+  return true
+}
+
+function showLibrariesButtonClickSpinner (button, label = 'Working...') {
+  if (!shouldShowLibrariesButtonSpinner(button)) return
+  const token = String(Date.now())
+  button.dataset.librariesClickBusyToken = token
+  setLibrariesButtonBusy(button, true, label)
+  window.setTimeout(() => {
+    if (button.dataset.librariesClickBusyToken !== token) return
+    delete button.dataset.librariesClickBusyToken
+    setLibrariesButtonBusy(button, false)
+  }, 450)
+}
+
+function setLibrariesButtonPersistentBusy (button, busy, label = 'Working...') {
+  if (busy && button?.dataset?.librariesClickBusyToken) {
+    delete button.dataset.librariesClickBusyToken
+  }
+  setLibrariesButtonBusy(button, busy, label)
+}
+
+document.addEventListener('click', event => {
+  const button = event.target.closest('button')
+  if (!button || !document.body.contains(button)) return
+  showLibrariesButtonClickSpinner(button)
+}, true)
 const dependencyHintConfigs = {
   tautulli: {
     stepKey: '030-tautulli',
@@ -5726,11 +5784,12 @@ function getCollectionSectionEntries (libraryId) {
       inputId: input.id,
       defaultValue: String(input.dataset.default || '').trim(),
       currentValue: String(input.value || '').trim(),
+      effectiveValue: String(input.value || input.dataset.default || '').trim(),
       domIndex: index
     })
   })
   entries.sort((left, right) => {
-    const byValue = compareCollectionSectionValues(left.currentValue, right.currentValue)
+    const byValue = compareCollectionSectionValues(left.effectiveValue, right.effectiveValue)
     if (byValue !== 0) return byValue
     return left.domIndex - right.domIndex
   })
@@ -5761,8 +5820,8 @@ function buildCollectionSectionListItem (entry, position) {
       </div>
     </div>
     <div class="text-end">
-      <div class="small text-muted">Current</div>
-      <span class="badge bg-secondary" data-collection-section-current>${entry.currentValue || 'blank'}</span>
+      <div class="small text-muted">${entry.currentValue ? 'Current' : 'Default'}</div>
+      <span class="badge bg-secondary" data-collection-section-current>${entry.currentValue || entry.defaultValue || 'blank'}</span>
       <div class="small text-muted mt-1">New: <span data-collection-section-next>${String(position * 10).padStart(3, '0')}</span></div>
     </div>
   `
@@ -5775,6 +5834,17 @@ function refreshCollectionSectionPreviewNumbers (list) {
     const next = item.querySelector('[data-collection-section-next]')
     if (next) next.textContent = String((index + 1) * 10).padStart(3, '0')
   })
+}
+
+function setCollectionSectionActionBusy (button, busy) {
+  setLibrariesButtonPersistentBusy(button, busy)
+}
+
+function markCollectionSectionModalCustomOrder (modalEl) {
+  if (!modalEl) return
+  modalEl.dataset.collectionSectionResetMode = 'false'
+  const status = modalEl.querySelector('[data-collection-section-modal-status]')
+  if (status) status.textContent = 'Custom order pending. Save Order will write collection_section overrides.'
 }
 
 function ensureCollectionSectionModalRoot (modalEl) {
@@ -5848,6 +5918,7 @@ function renderCollectionSectionModalList (modalEl) {
     return entries
   }
   entries.forEach((entry, index) => list.appendChild(buildCollectionSectionListItem(entry, index + 1)))
+  modalEl.dataset.collectionSectionResetMode = 'false'
   if (status) status.textContent = `${entries.length} enabled collection default${entries.length === 1 ? '' : 's'} ready to reorder.`
   if (saveButton) saveButton.disabled = false
   refreshCollectionSectionPreviewNumbers(list)
@@ -5861,6 +5932,7 @@ function renderCollectionSectionModalList (modalEl) {
     delay: 180,
     touchStartThreshold: 6,
     onSort: function () {
+      markCollectionSectionModalCustomOrder(modalEl)
       refreshCollectionSectionPreviewNumbers(list)
     }
   })
@@ -5870,43 +5942,62 @@ function renderCollectionSectionModalList (modalEl) {
 function saveCollectionSectionModalOrder (modalEl) {
   if (!modalEl) return
   modalEl = prepareCollectionSectionModal(modalEl)
+  const saveButton = modalEl.querySelector('[data-collection-section-save]')
+  setCollectionSectionActionBusy(saveButton, true)
   const list = modalEl.querySelector('[data-collection-section-sortable]')
   const items = Array.from(list ? list.children : [])
-  if (!items.length) return
-  items.forEach((item, index) => {
-    const inputId = item.dataset.inputId
-    const input = inputId ? document.getElementById(inputId) : null
-    if (!input) return
-    const nextValue = String((index + 1) * 10).padStart(3, '0')
-    input.value = nextValue
-    input.dispatchEvent(new Event('input', { bubbles: true }))
-    input.dispatchEvent(new Event('change', { bubbles: true }))
-    const current = item.querySelector('[data-collection-section-current]')
-    if (current) current.textContent = nextValue
-  })
-  if (typeof showToast === 'function') {
-    showToast('success', 'Collection section order updated.')
-  }
-  refreshCollectionSectionPreviewNumbers(list)
-  const modal = typeof bootstrap !== 'undefined' && bootstrap.Modal ? bootstrap.Modal.getOrCreateInstance(modalEl) : null
-  if (modal) modal.hide()
+  const resetMode = modalEl.dataset.collectionSectionResetMode === 'true'
+  window.setTimeout(() => {
+    if (!items.length) {
+      setCollectionSectionActionBusy(saveButton, false)
+      return
+    }
+    if (!resetMode) {
+      items.forEach((item, index) => {
+        const inputId = item.dataset.inputId
+        const input = inputId ? document.getElementById(inputId) : null
+        if (!input) return
+        const nextValue = String((index + 1) * 10).padStart(3, '0')
+        input.value = nextValue
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+        input.dispatchEvent(new Event('change', { bubbles: true }))
+        const current = item.querySelector('[data-collection-section-current]')
+        if (current) current.textContent = nextValue
+      })
+    }
+    if (typeof showToast === 'function') {
+      showToast(resetMode ? 'info' : 'success', resetMode ? 'Collection section overrides cleared. JSON defaults will be used.' : 'Collection section order updated.')
+    }
+    refreshCollectionSectionPreviewNumbers(list)
+    const modal = typeof bootstrap !== 'undefined' && bootstrap.Modal ? bootstrap.Modal.getOrCreateInstance(modalEl) : null
+    if (modal) modal.hide()
+    setCollectionSectionActionBusy(saveButton, false)
+  }, 120)
 }
 
 function resetCollectionSectionModalOrder (modalEl) {
   if (!modalEl) return
   modalEl = prepareCollectionSectionModal(modalEl)
+  const resetButton = modalEl.querySelector('[data-collection-section-reset]')
+  setCollectionSectionActionBusy(resetButton, true)
   const entries = getCollectionSectionEntries(modalEl.dataset.libraryId)
-  entries.forEach(entry => {
-    const input = entry.inputId ? document.getElementById(entry.inputId) : null
-    if (!input) return
-    input.value = entry.defaultValue
-    input.dispatchEvent(new Event('input', { bubbles: true }))
-    input.dispatchEvent(new Event('change', { bubbles: true }))
-  })
-  renderCollectionSectionModalList(modalEl)
-  if (typeof showToast === 'function') {
-    showToast('info', 'Collection section order reset to defaults.')
-  }
+  window.setTimeout(() => {
+    entries.forEach(entry => {
+      const input = entry.inputId ? document.getElementById(entry.inputId) : null
+      if (!input) return
+      input.value = ''
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    renderCollectionSectionModalList(modalEl)
+    modalEl.dataset.collectionSectionResetMode = 'true'
+    const status = modalEl.querySelector('[data-collection-section-modal-status]')
+    if (status) status.textContent = 'Defaults pending. Save Order will clear collection_section overrides and use JSON defaults.'
+    if (typeof showToast === 'function') {
+      showToast('info', 'Collection section overrides cleared. Save Order to use JSON defaults.')
+    }
+    setCollectionSectionActionBusy(resetButton, false)
+  }, 120)
 }
 
 document.addEventListener('click', (event) => {
@@ -5946,6 +6037,7 @@ document.addEventListener('click', (event) => {
     } else if (direction === 'down' && item.nextElementSibling) {
       list.insertBefore(item.nextElementSibling, item)
     }
+    markCollectionSectionModalCustomOrder(moveButton.closest('[data-collection-section-modal]'))
     refreshCollectionSectionPreviewNumbers(list)
   }
 })
@@ -6258,9 +6350,7 @@ async function runCollectionGroupReset (btn, group) {
   const idleLabel = btn.dataset.resetIdleLabel || btn.textContent.trim() || 'Reset to Defaults'
   btn.dataset.resetIdleLabel = idleLabel
   btn.dataset.resetBusy = 'true'
-  btn.disabled = true
-  btn.setAttribute('aria-busy', 'true')
-  btn.textContent = 'Resetting...'
+  setLibrariesButtonPersistentBusy(btn, true, 'Resetting...')
 
   const pauseForPaint = async () => {
     await new Promise(resolve => requestAnimationFrame(() => resolve()))
@@ -6405,10 +6495,8 @@ async function runCollectionGroupReset (btn, group) {
     finalizeToast(changes)
   } finally {
     delete group.dataset.resetting
-    btn.disabled = false
-    btn.removeAttribute('aria-busy')
     btn.dataset.resetBusy = 'false'
-    btn.textContent = idleLabel
+    setLibrariesButtonPersistentBusy(btn, false)
   }
 }
 
@@ -6427,13 +6515,18 @@ function wireOffsetReset (scope) {
         })
         return
       }
-      if (group) {
-        group.dataset.resetting = 'true'
+      setLibrariesButtonPersistentBusy(btn, true, 'Resetting...')
+      const finishOverlayReset = () => {
+        setLibrariesButtonPersistentBusy(btn, false)
       }
-      const changes = []
-      const touched = new Set()
-      const isRatingsOverlay = group?.dataset?.overlayId === 'overlay_ratings'
-      const escapeHtml = (value) => String(value ?? '')
+      try {
+        if (group) {
+          group.dataset.resetting = 'true'
+        }
+        const changes = []
+        const touched = new Set()
+        const isRatingsOverlay = group?.dataset?.overlayId === 'overlay_ratings'
+        const escapeHtml = (value) => String(value ?? '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -6619,24 +6712,34 @@ function wireOffsetReset (scope) {
         }
       }
 
-      if (isRatingsOverlay && group) {
-        group.dataset.ratingFontForce = 'true'
-        const ratingImageInputs = group.querySelectorAll('[name$="[rating1_image]"], [name$="[rating2_image]"], [name$="[rating3_image]"]')
-        ratingImageInputs.forEach(input => {
-          input.dispatchEvent(new Event('change', { bubbles: true }))
-        })
-        window.setTimeout(() => {
-          ratingFontInputs.forEach(input => {
-            const from = ratingFontBefore.get(input) || ''
-            const to = getDisplayValue(input)
-            if (from !== to) {
-              changes.push({ label: getInputLabel(input), from, to })
-            }
+        if (isRatingsOverlay && group) {
+          group.dataset.ratingFontForce = 'true'
+          const ratingImageInputs = group.querySelectorAll('[name$="[rating1_image]"], [name$="[rating2_image]"], [name$="[rating3_image]"]')
+          ratingImageInputs.forEach(input => {
+            input.dispatchEvent(new Event('change', { bubbles: true }))
           })
+          window.setTimeout(() => {
+            ratingFontInputs.forEach(input => {
+              const from = ratingFontBefore.get(input) || ''
+              const to = getDisplayValue(input)
+              if (from !== to) {
+                changes.push({ label: getInputLabel(input), from, to })
+              }
+            })
+            finalizeToast()
+            finishOverlayReset()
+          }, 0)
+        } else {
           finalizeToast()
-        }, 0)
-      } else {
-        finalizeToast()
+          finishOverlayReset()
+        }
+      } catch (error) {
+        console.error('[overlay reset failed]', error)
+        if (group) delete group.dataset.resetting
+        if (typeof showToast === 'function') {
+          showToast('error', 'Reset to defaults failed.')
+        }
+        finishOverlayReset()
       }
     })
     btn.dataset.listenerAdded = 'true'

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3773,7 +3773,7 @@ function setupTemplateStringListHandlers (scope) {
     }
   }
 
-  function applyLookupState (target, presetConfig, presetName, value, context = {}) {
+function applyLookupState (target, presetConfig, presetName, value, context = {}, onResolvedLabel = null) {
     if (!target || !presetConfig?.lookupService || !value) return
 
     if (presetConfig.lookupService === 'tmdb') {
@@ -3793,8 +3793,11 @@ function setupTemplateStringListHandlers (scope) {
       })
       lookupTemplateStringValue(presetName, value, context).then(result => {
         if (!target.isConnected) return
-        if (result.valid && result.verified && result.label) {
-          const successMessage = result.message || `TMDb: ${result.label}`
+      if (result.valid && result.verified && result.label) {
+        if (typeof onResolvedLabel === 'function') {
+          onResolvedLabel(value, result.label)
+        }
+        const successMessage = result.message || `TMDb: ${result.label}`
           setLookupState(target, {
             valid: true,
             verified: true,
@@ -3837,8 +3840,11 @@ function setupTemplateStringListHandlers (scope) {
       })
       lookupTemplateStringValue(presetName, value, context).then(result => {
         if (!target.isConnected) return
-        if (result.valid && result.verified && result.label) {
-          const successMessage = result.message || `Plex: ${result.label}`
+      if (result.valid && result.verified && result.label) {
+        if (typeof onResolvedLabel === 'function') {
+          onResolvedLabel(value, result.label)
+        }
+        const successMessage = result.message || `Plex: ${result.label}`
           setLookupState(target, {
             valid: true,
             verified: true,
@@ -3899,6 +3905,7 @@ function setupTemplateStringListHandlers (scope) {
     if (wrapper.dataset.listenerAdded) return
     const hiddenId = wrapper.dataset.hiddenInput
     const hidden = hiddenId ? document.getElementById(hiddenId) : wrapper.querySelector('input[type="hidden"]')
+    const lookupLabelsHidden = hiddenId ? document.getElementById(`${hiddenId}__lookup_labels`) : null
     const input = wrapper.querySelector('[data-template-string-input]')
     const addBtn = wrapper.querySelector('[data-template-string-add]')
     const list = wrapper.querySelector('[data-template-string-items]')
@@ -3930,6 +3937,60 @@ function setupTemplateStringListHandlers (scope) {
         // fall through to treat as single value
       }
       return [raw]
+    }
+
+    function parseLookupLabels () {
+      if (!lookupLabelsHidden) return {}
+      const raw = String(lookupLabelsHidden.value || '').trim()
+      if (!raw) return {}
+      try {
+        const parsed = JSON.parse(raw)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          return Object.fromEntries(
+            Object.entries(parsed)
+              .map(([key, value]) => [String(key || '').trim(), String(value || '').trim()])
+              .filter(([key, value]) => key && value)
+          )
+        }
+      } catch {
+        return {}
+      }
+      return {}
+    }
+
+    function writeLookupLabels (labels) {
+      if (!lookupLabelsHidden) return
+      const cleanLabels = Object.fromEntries(
+        Object.entries(labels || {})
+          .map(([key, value]) => [String(key || '').trim(), String(value || '').trim()])
+          .filter(([key, value]) => key && value)
+      )
+      lookupLabelsHidden.value = JSON.stringify(cleanLabels)
+      lookupLabelsHidden.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    function pruneLookupLabels (values) {
+      if (!lookupLabelsHidden) return
+      const allowed = new Set((values || []).map(value => String(value || '').trim()).filter(Boolean))
+      const labels = parseLookupLabels()
+      let changed = false
+      Object.keys(labels).forEach(key => {
+        if (!allowed.has(key)) {
+          delete labels[key]
+          changed = true
+        }
+      })
+      if (changed) writeLookupLabels(labels)
+    }
+
+    function storeLookupLabel (value, label) {
+      if (!lookupLabelsHidden || !value || !label) return
+      const labels = parseLookupLabels()
+      const key = String(value).trim()
+      const normalizedLabel = String(label).trim()
+      if (!key || !normalizedLabel || labels[key] === normalizedLabel) return
+      labels[key] = normalizedLabel
+      writeLookupLabels(labels)
     }
 
     function getCounterpartHiddenId () {
@@ -4061,7 +4122,7 @@ function setupTemplateStringListHandlers (scope) {
         })
 
         if (item.valid && presetConfig.lookupService) {
-          applyLookupState(lookupMeta, presetConfig, presetName, item.value, { libraryName, mediaType })
+          applyLookupState(lookupMeta, presetConfig, presetName, item.value, { libraryName, mediaType }, storeLookupLabel)
         }
       })
     }
@@ -4083,6 +4144,7 @@ function setupTemplateStringListHandlers (scope) {
       }
 
       hidden.value = JSON.stringify(normalizedValues)
+      pruneLookupLabels(normalizedValues)
       renderList(analyzed)
 
       const invalidItems = analyzed.filter(item => !item.valid)

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5724,6 +5724,7 @@ function getCollectionSectionEntries (libraryId) {
       collectionId,
       label,
       inputId: input.id,
+      defaultValue: String(input.dataset.default || '').trim(),
       currentValue: String(input.value || '').trim(),
       domIndex: index
     })
@@ -5868,6 +5869,7 @@ function renderCollectionSectionModalList (modalEl) {
 
 function saveCollectionSectionModalOrder (modalEl) {
   if (!modalEl) return
+  modalEl = prepareCollectionSectionModal(modalEl)
   const list = modalEl.querySelector('[data-collection-section-sortable]')
   const items = Array.from(list ? list.children : [])
   if (!items.length) return
@@ -5886,8 +5888,25 @@ function saveCollectionSectionModalOrder (modalEl) {
     showToast('success', 'Collection section order updated.')
   }
   refreshCollectionSectionPreviewNumbers(list)
-  const modal = bootstrap && bootstrap.Modal ? bootstrap.Modal.getInstance(modalEl) : null
+  const modal = typeof bootstrap !== 'undefined' && bootstrap.Modal ? bootstrap.Modal.getOrCreateInstance(modalEl) : null
   if (modal) modal.hide()
+}
+
+function resetCollectionSectionModalOrder (modalEl) {
+  if (!modalEl) return
+  modalEl = prepareCollectionSectionModal(modalEl)
+  const entries = getCollectionSectionEntries(modalEl.dataset.libraryId)
+  entries.forEach(entry => {
+    const input = entry.inputId ? document.getElementById(entry.inputId) : null
+    if (!input) return
+    input.value = entry.defaultValue
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+  })
+  renderCollectionSectionModalList(modalEl)
+  if (typeof showToast === 'function') {
+    showToast('info', 'Collection section order reset to defaults.')
+  }
 }
 
 document.addEventListener('click', (event) => {
@@ -5905,7 +5924,7 @@ document.addEventListener('click', (event) => {
   const resetButton = event.target.closest('[data-collection-section-reset]')
   if (resetButton) {
     const modalEl = resetButton.closest('[data-collection-section-modal]')
-    renderCollectionSectionModalList(modalEl)
+    resetCollectionSectionModalOrder(modalEl)
     return
   }
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6504,7 +6504,23 @@ function wireOffsetReset (scope) {
   const root = scope || document
   root.querySelectorAll('.reset-offset-btn').forEach(btn => {
     if (btn.dataset.listenerAdded) return
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', async () => {
+      if (btn.dataset.collectionVariableSectionReset === 'true') {
+        const section = btn.closest('[data-collection-variable-section="true"]')
+        const sectionBody = section?.querySelector('.collection-variable-section-body') || section
+        if (sectionBody) {
+          runCollectionGroupReset(btn, sectionBody).then(() => {
+            updateCollectionVariableSectionSummary(section)
+          }).catch(error => {
+            console.error('[collection section reset failed]', error)
+            if (typeof showToast === 'function') {
+              showToast('error', 'Section reset to defaults failed.')
+            }
+          })
+          return
+        }
+      }
+
       const group = btn.closest('.template-toggle-group')
       if (group?.dataset?.collectionId) {
         runCollectionGroupReset(btn, group).catch(error => {
@@ -6516,6 +6532,8 @@ function wireOffsetReset (scope) {
         return
       }
       setLibrariesButtonPersistentBusy(btn, true, 'Resetting...')
+      await new Promise(resolve => requestAnimationFrame(() => resolve()))
+      await new Promise(resolve => window.setTimeout(resolve, 0))
       const finishOverlayReset = () => {
         setLibrariesButtonPersistentBusy(btn, false)
       }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -36,6 +36,7 @@ const copyModal = copyModalEl ? new bootstrap.Modal(copyModalEl) : null
 let activeLibraryId = null
 let loadRequestId = 0
 let allowNextStepNavigation = false
+let lookupLabelAutosaveTimer = null
 
 function setLibrariesButtonBusy (button, busy, label = 'Working...') {
   if (!button) return
@@ -3991,6 +3992,7 @@ function applyLookupState (target, presetConfig, presetName, value, context = {}
       if (!key || !normalizedLabel || labels[key] === normalizedLabel) return
       labels[key] = normalizedLabel
       writeLookupLabels(labels)
+      scheduleLookupLabelAutosave()
     }
 
     function getCounterpartHiddenId () {
@@ -5435,10 +5437,26 @@ function initLibraryAssetDirectoryInputs (card) {
   })
 }
 
-function autosaveActiveLibrary () {
+function scheduleLookupLabelAutosave (delayMs = 900) {
+  if (lookupLabelAutosaveTimer) {
+    clearTimeout(lookupLabelAutosaveTimer)
+    lookupLabelAutosaveTimer = null
+  }
+  lookupLabelAutosaveTimer = setTimeout(() => {
+    lookupLabelAutosaveTimer = null
+    if (!activeLibraryId || window.QS_SWITCHING_CONFIG) return
+    autosaveActiveLibrary({ quiet: true })
+      .catch(err => {
+        console.warn('[Autosave] Failed to persist lookup labels', err)
+      })
+  }, Math.max(0, Number(delayMs) || 0))
+}
+
+function autosaveActiveLibrary (options = {}) {
   const card = libraryContainer.firstElementChild
   if (!activeLibraryId || !card) return Promise.resolve()
   if (window.QS_SWITCHING_CONFIG) return Promise.resolve()
+  const quiet = Boolean(options && options.quiet)
 
   if (typeof PathValidation !== 'undefined' && PathValidation.validateAll) {
     const pathValid = PathValidation.validateAll(card)
@@ -5446,7 +5464,7 @@ function autosaveActiveLibrary () {
       if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.focusFirstInvalidField === 'function') {
         ValidationHandler.focusFirstInvalidField(card)
       }
-      if (typeof showToast === 'function') {
+      if (!quiet && typeof showToast === 'function') {
         showToast('error', 'Please fix invalid path fields before saving.')
       }
       return Promise.reject(new Error('Invalid path fields'))
@@ -5459,7 +5477,7 @@ function autosaveActiveLibrary () {
       if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.focusFirstInvalidField === 'function') {
         ValidationHandler.focusFirstInvalidField(card)
       }
-      if (typeof showToast === 'function') {
+      if (!quiet && typeof showToast === 'function') {
         showToast('error', 'Please fix invalid URL fields before saving.')
       }
       return Promise.reject(new Error('Invalid URL fields'))
@@ -5498,7 +5516,7 @@ function autosaveActiveLibrary () {
       return res.json().catch(() => ({}))
     })
     .then(data => {
-      if (data && data.success && typeof showToast === 'function') {
+      if (data && data.success && !quiet && typeof showToast === 'function') {
         showToast('success', `Autosaved ${friendlyName}.`)
       }
       if (data && data.success) {
@@ -5509,7 +5527,7 @@ function autosaveActiveLibrary () {
     })
     .catch(err => {
       console.error('[Autosave] Failed to save library', activeLibraryId, err)
-      if (typeof showToast === 'function') {
+      if (!quiet && typeof showToast === 'function') {
         showToast('error', err.message || `Autosave failed for ${friendlyName}.`)
       }
       throw err

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5217,6 +5217,7 @@ function mountCard (card, libraryId) {
   setupMappingListHandlers('genre_mapper', card)
   setupMappingListHandlers('content_rating_mapper', card)
   wireOverlayDetailToggles(card)
+  wireOverlayVariableSectionToggles(card)
   wireCollectionDetailToggles(card)
   wireCollectionVariableSectionToggles(card)
   setupParentChildToggleVisibility(card)
@@ -5226,6 +5227,7 @@ function mountCard (card, libraryId) {
   setupAddMissingDependencies(card)
   wireOverlayTemplateSections(card)
   wireCollectionTemplateSections(card)
+  wireOverlayVariableSections(card)
   wireCollectionVariableSections(card)
   if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
     OverlayHandler.initializeOverlayBoards(card)
@@ -5736,10 +5738,12 @@ document.querySelectorAll('.overlay-template-section').forEach((el) => {
 })
 
 wireOverlayDetailToggles()
+wireOverlayVariableSectionToggles()
 wireCollectionDetailToggles()
 wireCollectionVariableSectionToggles()
 wireOverlayTemplateSections()
 wireCollectionTemplateSections()
+wireOverlayVariableSections()
 wireCollectionVariableSections()
 wireRatingsOffsetSync()
 
@@ -6195,6 +6199,9 @@ function toggleOverlayTemplateSection (checkbox) {
       }
     }
   }
+  groupContainer?.querySelectorAll('[data-overlay-variable-section="true"]').forEach(section => {
+    updateOverlayVariableSectionSummary(section)
+  })
 }
 
 function toggleCollectionTemplateSection (parentToggle) {
@@ -6515,6 +6522,22 @@ function wireOffsetReset (scope) {
             console.error('[collection section reset failed]', error)
             if (typeof showToast === 'function') {
               showToast('error', 'Section reset to defaults failed.')
+            }
+          })
+          return
+        }
+      }
+
+      if (btn.dataset.overlayVariableSectionReset === 'true') {
+        const section = btn.closest('[data-overlay-variable-section="true"]')
+        const sectionBody = section?.querySelector('.overlay-variable-section-body') || section
+        if (sectionBody) {
+          runCollectionGroupReset(btn, sectionBody).then(() => {
+            updateOverlayVariableSectionSummary(section)
+          }).catch(error => {
+            console.error('[overlay section reset failed]', error)
+            if (typeof showToast === 'function') {
+              showToast('error', 'Overlay section reset to defaults failed.')
             }
           })
           return
@@ -7400,6 +7423,10 @@ function wireOverlayDetailToggles (scope) {
   wireDetailToggles('.overlay-details-toggle', scope)
 }
 
+function wireOverlayVariableSectionToggles (scope) {
+  wireDetailToggles('.overlay-variable-section-toggle', scope)
+}
+
 function wireCollectionDetailToggles (scope) {
   wireDetailToggles('.collection-details-toggle', scope)
 }
@@ -7504,6 +7531,47 @@ function updateCollectionVariableSectionSummary (section) {
     : configuredCount === 1
       ? '1 override'
       : `${configuredCount} overrides`
+}
+
+function updateOverlayVariableSectionSummary (section) {
+  if (!section) return
+  const summary = section.querySelector('[data-overlay-section-summary]')
+  const body = section.querySelector('.overlay-variable-section-body')
+  if (!summary || !body) return
+
+  const fieldsByName = new Map()
+  body.querySelectorAll('[name]').forEach(field => {
+    if (!field || field.disabled) return
+    const name = String(field.name || '').trim()
+    if (!name) return
+    if (!fieldsByName.has(name)) fieldsByName.set(name, [])
+    fieldsByName.get(name).push(field)
+  })
+
+  let configuredCount = 0
+  fieldsByName.forEach(fields => {
+    if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
+  })
+
+  summary.textContent = configuredCount === 0
+    ? 'Defaults'
+    : configuredCount === 1
+      ? '1 override'
+      : `${configuredCount} overrides`
+}
+
+function wireOverlayVariableSections (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-overlay-variable-section="true"]').forEach(section => {
+    if (section.dataset.summaryBound === 'true') return
+
+    const refresh = () => updateOverlayVariableSectionSummary(section)
+    section.addEventListener('input', refresh)
+    section.addEventListener('change', refresh)
+    refresh()
+
+    section.dataset.summaryBound = 'true'
+  })
 }
 
 function wireCollectionVariableSections (scope) {

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -7551,8 +7551,16 @@ function parseCollectionSectionStoredMapping (rawValue) {
   return {}
 }
 
+function isInternalTemplateMetadataField (field) {
+  if (!field) return false
+  const name = String(field.name || '').trim()
+  return field.dataset?.skipOverrideCount === 'true' ||
+    field.dataset?.templateMetadata === 'lookup-labels' ||
+    name.endsWith('__lookup_labels')
+}
+
 function isCollectionSectionFieldConfigured (fields) {
-  const enabledFields = Array.from(fields || []).filter(field => field && !field.disabled)
+  const enabledFields = Array.from(fields || []).filter(field => field && !field.disabled && !isInternalTemplateMetadataField(field))
   if (!enabledFields.length) return false
 
   const visibleFields = enabledFields.filter(field => field.type !== 'hidden')
@@ -7628,6 +7636,7 @@ function updateTemplateVariableFieldOverrideStates (body, fieldsByName) {
   fieldsByName.forEach(fields => {
     if (!isCollectionSectionFieldConfigured(fields)) return
     fields.forEach(field => {
+      if (isInternalTemplateMetadataField(field)) return
       const row = findTemplateVariableFieldRow(field)
       if (!row) return
       row.classList.add('template-variable-field-has-override')
@@ -7719,6 +7728,7 @@ function updateCollectionVariableSectionSummary (section) {
   const fieldsByName = new Map()
   body.querySelectorAll('[name]').forEach(field => {
     if (!field || field.disabled) return
+    if (isInternalTemplateMetadataField(field)) return
     const name = String(field.name || '').trim()
     if (!name) return
     if (!fieldsByName.has(name)) fieldsByName.set(name, [])
@@ -7751,6 +7761,7 @@ function updateOverlayVariableSectionSummary (section) {
   const fieldsByName = new Map()
   body.querySelectorAll('[name]').forEach(field => {
     if (!field || field.disabled) return
+    if (isInternalTemplateMetadataField(field)) return
     const name = String(field.name || '').trim()
     if (!name) return
     if (!fieldsByName.has(name)) fieldsByName.set(name, [])

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3461,6 +3461,14 @@ const templateStringListPresetConfigs = {
       ? { valid: true }
       : { valid: false, message: 'Enter a numeric ID like 603 or 1399.' }
   },
+  imdb_id_tmdb: {
+    duplicateInsensitive: true,
+    normalize: value => value.toLowerCase(),
+    lookupService: 'tmdb',
+    validate: value => /^tt\d{7,8}$/i.test(value)
+      ? { valid: true }
+      : { valid: false, message: 'Enter an IMDb ID like tt1234567 or tt12345678.' }
+  },
   imdb_id_plex: {
     duplicateInsensitive: true,
     normalize: value => value.toLowerCase(),
@@ -3902,6 +3910,85 @@ function applyLookupState (target, presetConfig, presetName, value, context = {}
   }
 
   const root = scope || document
+  root.querySelectorAll('[data-template-scalar-lookup="true"]').forEach(input => {
+    if (input.dataset.templateScalarLookupBound === 'true') return
+
+    const presetName = String(input.dataset.validationPreset || '').trim()
+    const presetConfig = templateStringListPresetConfigs[presetName]
+    if (!presetConfig?.lookupService) return
+
+    const lookupLabelsHidden = input.id ? document.getElementById(`${input.id}__lookup_labels`) : null
+    const libraryName = String(input.dataset.libraryName || '').trim()
+    const mediaType = String(input.dataset.mediaType || '').trim()
+    const lookupMeta = document.createElement('div')
+    lookupMeta.className = 'small mt-1 d-none'
+
+    const wrapper = input.closest('[data-collection-field-wrapper="true"], .input-group') || input
+    wrapper.insertAdjacentElement('afterend', lookupMeta)
+
+    function writeLookupLabels (labels) {
+      if (!lookupLabelsHidden) return
+      const cleanLabels = Object.fromEntries(
+        Object.entries(labels || {})
+          .map(([key, value]) => [String(key || '').trim(), String(value || '').trim()])
+          .filter(([key, value]) => key && value)
+      )
+      lookupLabelsHidden.value = JSON.stringify(cleanLabels)
+      lookupLabelsHidden.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    function validateScalarValue () {
+      const rawValue = String(input.value || '').trim()
+      const normalized = presetConfig.normalize ? presetConfig.normalize(rawValue) : rawValue
+      const result = presetConfig.validate ? presetConfig.validate(normalized) : { valid: Boolean(normalized) }
+      return {
+        value: normalized,
+        valid: Boolean(result.valid),
+        message: result.message || 'Enter a valid value.'
+      }
+    }
+
+    function storeLookupLabel (value, label) {
+      if (!lookupLabelsHidden || !value || !label) return
+      const key = String(value).trim()
+      const normalizedLabel = String(label).trim()
+      if (!key || !normalizedLabel) return
+      writeLookupLabels({ [key]: normalizedLabel })
+      scheduleLookupLabelAutosave()
+    }
+
+    function runLookup () {
+      const checked = validateScalarValue()
+      if (!checked.value) {
+        setLookupState(lookupMeta, { message: '' })
+        writeLookupLabels({})
+        return
+      }
+      if (!checked.valid) {
+        setLookupState(lookupMeta, {
+          valid: false,
+          verified: true,
+          message: checked.message
+        })
+        writeLookupLabels({})
+        return
+      }
+      if (input.value !== checked.value) {
+        input.value = checked.value
+      }
+      applyLookupState(lookupMeta, presetConfig, presetName, checked.value, { libraryName, mediaType }, storeLookupLabel)
+    }
+
+    input.addEventListener('input', () => {
+      writeLookupLabels({})
+      setLookupState(lookupMeta, { message: '' })
+    })
+    input.addEventListener('change', runLookup)
+    input.addEventListener('blur', runLookup)
+    runLookup()
+    input.dataset.templateScalarLookupBound = 'true'
+  })
+
   root.querySelectorAll('[data-template-string-list]').forEach(wrapper => {
     if (wrapper.dataset.listenerAdded) return
     const hiddenId = wrapper.dataset.hiddenInput

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6495,6 +6495,7 @@ async function runCollectionGroupReset (btn, group) {
       trigger.dispatchEvent(new Event('change', { bubbles: true }))
     }
 
+    refreshTemplateOverrideState(group.closest('.template-toggle-group') || group)
     updateAccordionHighlights()
     if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
       ValidationHandler.updateValidationState()
@@ -6517,7 +6518,7 @@ function wireOffsetReset (scope) {
         const sectionBody = section?.querySelector('.collection-variable-section-body') || section
         if (sectionBody) {
           runCollectionGroupReset(btn, sectionBody).then(() => {
-            updateCollectionVariableSectionSummary(section)
+            refreshTemplateOverrideState(section.closest('.template-toggle-group') || section)
           }).catch(error => {
             console.error('[collection section reset failed]', error)
             if (typeof showToast === 'function') {
@@ -6533,7 +6534,7 @@ function wireOffsetReset (scope) {
         const sectionBody = section?.querySelector('.overlay-variable-section-body') || section
         if (sectionBody) {
           runCollectionGroupReset(btn, sectionBody).then(() => {
-            updateOverlayVariableSectionSummary(section)
+            refreshTemplateOverrideState(section.closest('.template-toggle-group') || section)
           }).catch(error => {
             console.error('[overlay section reset failed]', error)
             if (typeof showToast === 'function') {
@@ -6558,6 +6559,13 @@ function wireOffsetReset (scope) {
       await new Promise(resolve => requestAnimationFrame(() => resolve()))
       await new Promise(resolve => window.setTimeout(resolve, 0))
       const finishOverlayReset = () => {
+        if (group) {
+          refreshTemplateOverrideState(group)
+          updateAccordionHighlights()
+          if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
+            ValidationHandler.updateValidationState()
+          }
+        }
         setLibrariesButtonPersistentBusy(btn, false)
       }
       try {
@@ -7517,11 +7525,12 @@ function setOverrideSummaryBadge (badge, count) {
 }
 
 function findTemplateVariableFieldRow (field) {
-  if (!field || field.type === 'hidden') return null
+  if (!field) return null
   return field.closest(
     '[data-template-string-list], ' +
     '[data-template-mapping-list], ' +
     '[data-overlay-language-weight-builder], ' +
+    '[data-collection-field-wrapper], ' +
     '.rgba-group, ' +
     '.font-row, ' +
     '.input-group, ' +
@@ -7609,6 +7618,16 @@ function updateTemplateGroupOverrideSummary (section) {
   group.classList.toggle('template-variable-section-has-overrides', count > 0)
   setOverrideSummaryBadge(getOrCreateTemplateOverrideBadge(group), count)
   updateAncestorOverrideSummaries(group)
+}
+
+function refreshTemplateOverrideState (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-collection-variable-section="true"]').forEach(section => {
+    updateCollectionVariableSectionSummary(section)
+  })
+  root.querySelectorAll('[data-overlay-variable-section="true"]').forEach(section => {
+    updateOverlayVariableSectionSummary(section)
+  })
 }
 
 function updateCollectionVariableSectionSummary (section) {

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -7531,6 +7531,7 @@ function updateCollectionVariableSectionSummary (section) {
     : configuredCount === 1
       ? '1 override'
       : `${configuredCount} overrides`
+  section.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
 }
 
 function updateOverlayVariableSectionSummary (section) {
@@ -7558,6 +7559,7 @@ function updateOverlayVariableSectionSummary (section) {
     : configuredCount === 1
       ? '1 override'
       : `${configuredCount} overrides`
+  section.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
 }
 
 function wireOverlayVariableSections (scope) {

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -7506,6 +7506,80 @@ function isCollectionSectionFieldConfigured (fields) {
   return defaultValue ? value !== defaultValue : true
 }
 
+function formatTemplateOverrideCount (count) {
+  return count === 1 ? '1 override' : `${count} overrides`
+}
+
+function setOverrideSummaryBadge (badge, count) {
+  if (!badge) return
+  badge.textContent = count > 0 ? formatTemplateOverrideCount(count) : ''
+  badge.classList.toggle('d-none', count <= 0)
+}
+
+function getOrCreateTemplateOverrideBadge (group) {
+  if (!group) return null
+  let badge = group.querySelector('[data-template-group-override-summary]')
+  if (badge) return badge
+
+  badge = document.createElement('span')
+  badge.className = 'small template-override-summary ms-2 d-none'
+  badge.dataset.templateGroupOverrideSummary = 'true'
+
+  const target = group.querySelector('.overlay-toggle-row') || group.querySelector('.form-check > .d-flex') || group.querySelector('.form-check')
+  target?.appendChild(badge)
+  return badge
+}
+
+function getOrCreateAccordionOverrideBadge (header) {
+  if (!header) return null
+  let badge = header.querySelector('[data-accordion-override-summary]')
+  if (badge) return badge
+
+  const button = header.querySelector('.accordion-button')
+  if (!button) return null
+
+  badge = document.createElement('span')
+  badge.className = 'small accordion-override-summary ms-3 d-none'
+  badge.dataset.accordionOverrideSummary = 'true'
+  button.appendChild(badge)
+  return badge
+}
+
+function updateAncestorOverrideSummaries (element) {
+  let collapse = element?.closest('.accordion-collapse')
+  const seen = new Set()
+
+  while (collapse && !seen.has(collapse)) {
+    seen.add(collapse)
+    const accordionItem = collapse.closest('.accordion-item')
+    const header = accordionItem?.querySelector('.accordion-header')
+    const count = Array.from(collapse.querySelectorAll('.template-toggle-group')).reduce((total, group) => {
+      return total + (Number(group.dataset.overrideCount || '0') || 0)
+    }, 0)
+
+    accordionItem?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    header?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
+
+    collapse = accordionItem?.parentElement?.closest('.accordion-collapse')
+  }
+}
+
+function updateTemplateGroupOverrideSummary (section) {
+  const group = section?.closest('.template-toggle-group')
+  if (!group) return
+
+  const sections = group.querySelectorAll('[data-collection-variable-section="true"], [data-overlay-variable-section="true"]')
+  const count = Array.from(sections).reduce((total, item) => {
+    return total + (Number(item.dataset.overrideCount || '0') || 0)
+  }, 0)
+
+  group.dataset.overrideCount = String(count)
+  group.classList.toggle('template-variable-section-has-overrides', count > 0)
+  setOverrideSummaryBadge(getOrCreateTemplateOverrideBadge(group), count)
+  updateAncestorOverrideSummaries(group)
+}
+
 function updateCollectionVariableSectionSummary (section) {
   if (!section) return
   const summary = section.querySelector('[data-collection-section-summary]')
@@ -7532,6 +7606,8 @@ function updateCollectionVariableSectionSummary (section) {
       ? '1 override'
       : `${configuredCount} overrides`
   section.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
+  section.dataset.overrideCount = String(configuredCount)
+  updateTemplateGroupOverrideSummary(section)
 }
 
 function updateOverlayVariableSectionSummary (section) {
@@ -7560,6 +7636,8 @@ function updateOverlayVariableSectionSummary (section) {
       ? '1 override'
       : `${configuredCount} overrides`
   section.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
+  section.dataset.overrideCount = String(configuredCount)
+  updateTemplateGroupOverrideSummary(section)
 }
 
 function wireOverlayVariableSections (scope) {

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -1,3 +1,4 @@
+/* global bootstrap */
 import { elementGroup } from './modules/elementGroup.js'
 
 const tableBody = document.querySelector('#logscan-trends-table tbody')
@@ -41,6 +42,8 @@ const limit = elementGroup('#logscan-trends-limit', '#logscan-trends-limit-botto
 const configFilter = elementGroup('#logscan-trends-config-filter', '#logscan-trends-config-filter-bottom')
 const toolFilter = elementGroup('#logscan-trends-tool-filter', '#logscan-trends-tool-filter-bottom')
 const timeRange = elementGroup('#logscan-trends-time-range', '#logscan-trends-time-range-bottom')
+const toolVersionFilter = elementGroup('#logscan-trends-tool-version-filter', '#logscan-trends-tool-version-filter-bottom')
+const quickstartVersionFilter = elementGroup('#logscan-trends-quickstart-version-filter', '#logscan-trends-quickstart-version-filter-bottom')
 const commandFilter = elementGroup('#logscan-trends-command-filter', '#logscan-trends-command-filter-bottom')
 const resetFilters = elementGroup('#logscan-trends-reset-filters', '#logscan-trends-reset-filters-bottom')
 const dateStart = elementGroup('#logscan-trends-date-start', '#logscan-trends-date-start-bottom')
@@ -333,6 +336,14 @@ function getRunCommandValue (run) {
   return ''
 }
 
+function getRunToolVersionValue (run) {
+  return String(run && run.kometa_version ? run.kometa_version : '').trim()
+}
+
+function getRunQuickstartVersionValue (run) {
+  return String(run && run.quickstart_version ? run.quickstart_version : '').trim()
+}
+
 function getRunToolName (run) {
   if (!run) return 'kometa'
   return String(run.tool_name || 'kometa').trim().toLowerCase() || 'kometa'
@@ -377,6 +388,23 @@ function renderKometaStartModeBadge (run) {
   const label = getKometaStartModeLabel(run)
   if (!label) return ''
   return `<span class="badge text-bg-secondary ms-2">Start: ${escapeHtml(label)}</span>`
+}
+
+function renderRunVersionCell (run) {
+  let toolDisplay = run && run.kometa_version ? run.kometa_version : 'n/a'
+  if (run && run.kometa_version && run.kometa_newest_version && run.kometa_version !== run.kometa_newest_version) {
+    toolDisplay = `${run.kometa_version} -> ${run.kometa_newest_version}`
+  }
+  const quickstartVersion = run && run.quickstart_version ? String(run.quickstart_version).trim() : ''
+  const quickstartBranch = run && run.quickstart_branch ? String(run.quickstart_branch).trim() : ''
+  const quickstartDisplay = quickstartVersion
+    ? `${quickstartVersion}${quickstartBranch ? ` (${quickstartBranch})` : ''}`
+    : ''
+  if (!quickstartDisplay) return escapeHtml(toolDisplay)
+  return `
+    <div><span class="text-muted">Tool:</span> ${escapeHtml(toolDisplay)}</div>
+    <div><span class="text-muted">QS:</span> ${escapeHtml(quickstartDisplay)}</div>
+  `
 }
 
 function getImagemaidMode (run) {
@@ -1192,7 +1220,7 @@ function getSelectedCountSeries () {
 }
 
 function renderCountsSeriesSelector () {
-  if (!countsSeries.length) return
+  if (!countsSeries) return
   const html = LOG_LEVEL_SERIES.map(series => {
     const active = Boolean(countsSeriesSelection && countsSeriesSelection[series.key])
     return `
@@ -1639,7 +1667,7 @@ function renderImagemaidModeMix (runs) {
 }
 
 function renderArchiveStorageSummary (storage) {
-  if (!tablePolicy.length) return
+  if (!tablePolicy) return
   const kometaKeepLimit = storage && Number.isFinite(storage.kometa_keep_limit)
     ? storage.kometa_keep_limit
     : (parseInt((window.QS_AppConfig && window.QS_AppConfig.QS_KOMETA_LOG_KEEP) || '0', 10) || 0)
@@ -1673,7 +1701,7 @@ function renderDaily (runs) {
   const days = Object.keys(buckets).sort().slice(-14)
   if (!days.length) {
     daily.textContent = 'No daily totals yet.'
-    if (dailyRuntime.length) {
+    if (dailyRuntime) {
       dailyRuntime.textContent = 'No runtime averages yet.'
     }
     return
@@ -1759,7 +1787,7 @@ function renderDaily (runs) {
 }
 
 function renderDailyRuntimeAverages (runs, days) {
-  if (!dailyRuntime.length) return
+  if (!dailyRuntime) return
   const buckets = {}
   runs.forEach(run => {
     const key = getRunDateKey(run)
@@ -1840,7 +1868,7 @@ function pruneSelectedRunKeys () {
 }
 
 function updateSelectionSummary () {
-  if (!tableSelectionSummary.length) return
+  if (!tableSelectionSummary) return
   const selectedCount = selectedRunKeys.size
   const visibleSelectable = getSelectableRuns(currentTableRuns).length
   const visibleCompleteSelectable = getSelectableRunsByCompletion(currentTableRuns, false).length
@@ -1851,23 +1879,23 @@ function updateSelectionSummary () {
   } else {
     tableSelectionSummary.textContent = `${selectedCount} selected. ${selectedCompressibleCount} compressible. ${visibleSelectable} deletable in current view.`
   }
-  if (tableCompressSelected.length) {
+  if (tableCompressSelected) {
     tableCompressSelected.disabled = selectedCompressibleCount === 0
   }
-  if (tableDeleteSelected.length) {
+  if (tableDeleteSelected) {
     tableDeleteSelected.disabled = selectedCount === 0
   }
-  if (tableClearSelection.length) {
+  if (tableClearSelection) {
     tableClearSelection.disabled = selectedCount === 0
   }
-  if (tableSelectAll.length) {
+  if (tableSelectAll) {
     tableSelectAll.disabled = visibleSelectable === 0
   }
-  if (tableSelectComplete.length) {
+  if (tableSelectComplete) {
     tableSelectComplete.disabled = visibleCompleteSelectable === 0
     tableSelectComplete.classList.toggle('is-active', tableStatusFilter === 'complete')
   }
-  if (tableSelectIncomplete.length) {
+  if (tableSelectIncomplete) {
     tableSelectIncomplete.disabled = visibleIncompleteSelectable === 0
     tableSelectIncomplete.classList.toggle('is-active', tableStatusFilter === 'incomplete')
   }
@@ -1889,21 +1917,21 @@ function updateTableSummary (total, pageSize, pageCount) {
   const totalIncomplete = Number.isFinite(allIncompleteRunsTotal) ? allIncompleteRunsTotal : allIncompleteRuns.length
   const loaded = allTableRuns.length
   const grandTotal = totalComplete + totalIncomplete
-  if (tableSummary.length) {
+  if (tableSummary) {
     if (!total) {
       tableSummary.textContent = 'No runs match the current filters.'
     } else {
       tableSummary.textContent = `Ingested: ${totalComplete}. Incomplete: ${totalIncomplete}. Showing: ${total}. Page size: ${pageSize}.`
     }
   }
-  if (tableFilterCount.length) {
+  if (tableFilterCount) {
     let filterText = `Filtered: ${total} of ${loaded} loaded`
     if (grandTotal > loaded) {
       filterText += ` (${grandTotal} total)`
     }
     tableFilterCount.textContent = filterText
   }
-  if (!tablePageInfo.length) return
+  if (!tablePageInfo) return
   if (!total) {
     tablePageInfo.textContent = 'No rows'
     updateSelectionSummary()
@@ -1970,10 +1998,7 @@ function renderTable (runs) {
     const progressHelpText = getRunToolName(run) === 'imagemaid'
       ? 'Stored ImageMaid operation matrix for this run, including observed scan/action timings, item counts, and outcomes.'
       : 'Inline final progress snapshot for this run, including preparation, maintenance context, and per-library phase status.'
-    let kometaDisplay = run.kometa_version || 'n/a'
-    if (run.kometa_version && run.kometa_newest_version && run.kometa_version !== run.kometa_newest_version) {
-      kometaDisplay = `${run.kometa_version} -> ${run.kometa_newest_version}`
-    }
+    const versionDisplay = renderRunVersionCell(run)
     const runKey = run.run_key || rowKey
     const isProgressExpanded = expandedProgressRunKeys.has(runKey)
     const isSelectable = isRunSelectable(run)
@@ -2048,7 +2073,7 @@ function renderTable (runs) {
         ${isImageMaidRun ? '' : renderRunCardCell('Config lines', 'Non-comment lines captured from the redacted config output.', escapeHtml(String(configLineCount)))}
         ${renderRunCardCell('Command', 'Sanitized command line captured for the run.', `<span class="logscan-command" title="${escapeHtml(commandTitle)}">${escapeHtml(command)}</span>`)}
         ${renderRunCardCell('Counts', 'Kometa: C cache, D debug, I info, W warnings, E errors, Cr critical, T tracebacks, plus M movies, S shows, Ep episodes, and Items total. ImageMaid: C D I W E Cr T plus Items total.', `<span class="logscan-count-chip-row">${countChips}</span>`)}
-        ${renderRunCardCell('Version', 'Detected tool version for the run, plus newest version when different.', escapeHtml(kometaDisplay))}
+        ${renderRunCardCell('Version', 'Detected tool version and Quickstart version from the run marker when available.', versionDisplay)}
         ${renderRunCardCell('Maintenance', 'Quickstart maintenance pauses recorded in meta.log for this run.', renderMaintenanceSummaryCell(run))}
         ${renderRunCardCell('Quiet periods', 'Emphasizes the longest unexplained delay between timestamped run log lines, with maintenance-related gaps available in the details view.', renderQuietPeriodCell(run))}
         ${renderRunCardCell(progressLabel, progressHelpText, renderProgressSnapshotCell(run, runKey), 'class="logscan-progress-cell"')}
@@ -2547,6 +2572,8 @@ function getSortValue (run, key) {
       return getDisplayedItemsTotal(run)
     case 'kometa_version':
       return run.kometa_version || ''
+    case 'quickstart_version':
+      return `${run.quickstart_version || ''} ${run.quickstart_branch || ''}`.trim()
     case 'maintenance':
       return getMaintenanceSortValue(run)
     case 'quiet_periods':
@@ -2735,6 +2762,8 @@ function getFilterState () {
   return {
     config: configFilter.value || '',
     tool: toolFilter.value || '',
+    toolVersion: toolVersionFilter.value || '',
+    quickstartVersion: quickstartVersionFilter.value || '',
     timeRange: timeRange.value || 'all',
     command: commandFilter.value || '',
     library: libraryFilter.value || '',
@@ -2757,6 +2786,8 @@ function filterRuns (runs, state) {
   return runs.filter(run => {
     if (state.config && normalizeConfigName(run.config_name) !== state.config) return false
     if (state.tool && getRunToolName(run) !== state.tool) return false
+    if (state.toolVersion && getRunToolVersionValue(run) !== state.toolVersion) return false
+    if (state.quickstartVersion && getRunQuickstartVersionValue(run) !== state.quickstartVersion) return false
     if (state.command && getRunCommandValue(run) !== state.command) return false
     if (rangeStart || rangeEnd) {
       const dateKey = getRunDateKey(run)
@@ -2770,6 +2801,8 @@ function updateFilterOptions (state) {
   let changed = false
   changed = updateConfigFilter(filterRuns(allTableRuns, { ...state, config: '' })) || changed
   changed = updateToolFilter(filterRuns(allTableRuns, { ...state, tool: '' })) || changed
+  changed = updateToolVersionFilter(filterRuns(allTableRuns, { ...state, toolVersion: '' })) || changed
+  changed = updateQuickstartVersionFilter(filterRuns(allTableRuns, { ...state, quickstartVersion: '' })) || changed
   changed = updateCommandFilter(filterRuns(allTableRuns, { ...state, command: '' })) || changed
   changed = updateDateRangeInputs(filterRuns(allTableRuns, { ...state, start: '', end: '', timeRange: 'all' }), state) || changed
   changed = updateLibraryFilter(filterRuns(allRuns, { ...state, library: '' })) || changed
@@ -2788,6 +2821,46 @@ function updateToolFilter (runs) {
   toolFilter.setHTML(options.join(''))
   const nextValue = selected && tools.includes(selected) ? selected : getDefaultToolFilterValue(tools)
   toolFilter.setValue(nextValue)
+  return nextValue !== selected
+}
+
+function updateToolVersionFilter (runs) {
+  if (!toolVersionFilter.length) return false
+  const selected = toolVersionFilter.value || ''
+  const counts = new Map()
+  runs.forEach(run => {
+    const version = getRunToolVersionValue(run)
+    if (!version) return
+    counts.set(version, (counts.get(version) || 0) + 1)
+  })
+  const versions = Array.from(counts.keys()).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+  const options = ['<option value="">All tool versions</option>']
+  versions.forEach(version => {
+    options.push(`<option value="${escapeHtml(version)}">${escapeHtml(version)}</option>`)
+  })
+  toolVersionFilter.setHTML(options.join(''))
+  const nextValue = selected && counts.has(selected) ? selected : ''
+  toolVersionFilter.setValue(nextValue)
+  return nextValue !== selected
+}
+
+function updateQuickstartVersionFilter (runs) {
+  if (!quickstartVersionFilter.length) return false
+  const selected = quickstartVersionFilter.value || ''
+  const counts = new Map()
+  runs.forEach(run => {
+    const version = getRunQuickstartVersionValue(run)
+    if (!version) return
+    counts.set(version, (counts.get(version) || 0) + 1)
+  })
+  const versions = Array.from(counts.keys()).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+  const options = ['<option value="">All QS versions</option>']
+  versions.forEach(version => {
+    options.push(`<option value="${escapeHtml(version)}">${escapeHtml(version)}</option>`)
+  })
+  quickstartVersionFilter.setHTML(options.join(''))
+  const nextValue = selected && counts.has(selected) ? selected : ''
+  quickstartVersionFilter.setValue(nextValue)
   return nextValue !== selected
 }
 
@@ -3460,7 +3533,7 @@ function fetchRuns (options = {}) {
       if (!suppressStatus) updateStatus('Failed to load trends.')
       summaryEl.textContent = 'Unable to load summary.'
       daily.textContent = 'Unable to load daily totals.'
-      if (dailyRuntime.length) {
+      if (dailyRuntime) {
         dailyRuntime.textContent = 'Unable to load runtime averages.'
       }
       runtimeEl.textContent = 'Unable to load runtime distribution.'
@@ -3790,6 +3863,16 @@ toolFilter.on('change', function () {
   clearDateFilters()
   applyFiltersAndRender()
 })
+toolVersionFilter.on('change', function () {
+  syncMirroredControlValue(toolVersionFilter, this)
+  tablePage = 1
+  applyFiltersAndRender()
+})
+quickstartVersionFilter.on('change', function () {
+  syncMirroredControlValue(quickstartVersionFilter, this)
+  tablePage = 1
+  applyFiltersAndRender()
+})
 timeRange.on('change', function () {
   syncMirroredControlValue(timeRange, this)
   tablePage = 1
@@ -3833,6 +3916,8 @@ resetFilters.on('click', function () {
   tableStatusFilter = 'all'
   configFilter.setValue('')
   toolFilter.setValue('')
+  toolVersionFilter.setValue('')
+  quickstartVersionFilter.setValue('')
   timeRange.setValue('all')
   commandFilter.setValue('')
   libraryFilter.setValue('')

--- a/static/local-js/templateStringList.js
+++ b/static/local-js/templateStringList.js
@@ -252,6 +252,7 @@
       if (wrapper.dataset.listenerAdded) return
       const hiddenId = wrapper.dataset.hiddenInput
       const hidden = hiddenId ? document.getElementById(hiddenId) : wrapper.querySelector('input[type="hidden"]')
+      const lookupLabelsHidden = hiddenId ? document.getElementById(`${hiddenId}__lookup_labels`) : null
       const input = wrapper.querySelector('input[type="text"]')
       const addBtn = wrapper.querySelector('[data-template-string-add]')
       const list = wrapper.querySelector('[data-template-string-items]')
@@ -280,6 +281,60 @@
         }
         if (raw.toLowerCase() === 'none') return []
         return raw.split(',').map(item => item.trim()).filter(Boolean)
+      }
+
+      function parseLookupLabels () {
+        if (!lookupLabelsHidden) return {}
+        const raw = String(lookupLabelsHidden.value || '').trim()
+        if (!raw) return {}
+        try {
+          const parsed = JSON.parse(raw)
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return Object.fromEntries(
+              Object.entries(parsed)
+                .map(([key, value]) => [String(key || '').trim(), String(value || '').trim()])
+                .filter(([key, value]) => key && value)
+            )
+          }
+        } catch {
+          return {}
+        }
+        return {}
+      }
+
+      function writeLookupLabels (labels) {
+        if (!lookupLabelsHidden) return
+        const cleanLabels = Object.fromEntries(
+          Object.entries(labels || {})
+            .map(([key, value]) => [String(key || '').trim(), String(value || '').trim()])
+            .filter(([key, value]) => key && value)
+        )
+        lookupLabelsHidden.value = JSON.stringify(cleanLabels)
+        lookupLabelsHidden.dispatchEvent(new Event('change', { bubbles: true }))
+      }
+
+      function pruneLookupLabels (values) {
+        if (!lookupLabelsHidden) return
+        const allowed = new Set((values || []).map(value => String(value || '').trim()).filter(Boolean))
+        const labels = parseLookupLabels()
+        let changed = false
+        Object.keys(labels).forEach(key => {
+          if (!allowed.has(key)) {
+            delete labels[key]
+            changed = true
+          }
+        })
+        if (changed) writeLookupLabels(labels)
+      }
+
+      function storeLookupLabel (value, label) {
+        if (!lookupLabelsHidden || !value || !label) return
+        const labels = parseLookupLabels()
+        const key = String(value).trim()
+        const normalizedLabel = String(label).trim()
+        if (!key || !normalizedLabel || labels[key] === normalizedLabel) return
+        labels[key] = normalizedLabel
+        writeLookupLabels(labels)
       }
 
       function getCounterpartHiddenId () {
@@ -441,6 +496,7 @@
               lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
                 if (!lookupMeta.isConnected) return
                 if (result.valid && result.verified && result.label) {
+                  storeLookupLabel(item.value, result.label)
                   const successMessage = result.message || `TMDb: ${result.label}`
                   setLookupState(lookupMeta, {
                     valid: true,
@@ -480,6 +536,7 @@
               lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
                 if (!lookupMeta.isConnected) return
                 if (result.valid && result.verified && result.label) {
+                  storeLookupLabel(item.value, result.label)
                   const successMessage = result.message || `Plex: ${result.label}`
                   setLookupState(lookupMeta, {
                     valid: true,
@@ -517,6 +574,7 @@
         }
 
         hidden.value = JSON.stringify(normalizedValues)
+        pruneLookupLabels(normalizedValues)
         renderList(analyzed)
 
         const invalidItems = analyzed.filter(item => !item.valid)

--- a/templates/150-settings.html
+++ b/templates/150-settings.html
@@ -816,6 +816,9 @@
                 <div class="invalid-feedback d-none" data-template-string-feedback></div>
                 <ul class="list-group mt-2" data-template-string-items></ul>
                 <input type="hidden" id="ignore_ids" name="ignore_ids" value="{{ ignore_ids_json }}">
+                <input type="hidden" id="ignore_ids__lookup_labels" name="ignore_ids__lookup_labels"
+                  value="{{ data['settings'].get('ignore_ids__lookup_labels', '{}') | default('{}', true) }}"
+                  data-template-metadata="lookup-labels" data-skip-override-count="true">
               </div>
             </div>
 
@@ -853,6 +856,9 @@
                 <div class="invalid-feedback d-none" data-template-string-feedback></div>
                 <ul class="list-group mt-2" data-template-string-items></ul>
                 <input type="hidden" id="ignore_imdb_ids" name="ignore_imdb_ids" value="{{ ignore_imdb_ids_json }}">
+                <input type="hidden" id="ignore_imdb_ids__lookup_labels" name="ignore_imdb_ids__lookup_labels"
+                  value="{{ data['settings'].get('ignore_imdb_ids__lookup_labels', '{}') | default('{}', true) }}"
+                  data-template-metadata="lookup-labels" data-skip-override-count="true">
               </div>
             </div>
           </div>

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -75,6 +75,14 @@
           <div id="logscan-trends-date-hint" class="small text-muted logscan-date-hint"></div>
         </div>
         <div class="logscan-filter-row logscan-filter-row-secondary">
+          <select id="logscan-trends-tool-version-filter" class="form-select form-select-sm w-auto logscan-control-field"
+            title="Filter visuals by Kometa or ImageMaid version. Pair with App to isolate one tool.">
+            <option value="">All tool versions</option>
+          </select>
+          <select id="logscan-trends-quickstart-version-filter" class="form-select form-select-sm w-auto logscan-control-field"
+            title="Filter visuals by Quickstart version from the run marker.">
+            <option value="">All QS versions</option>
+          </select>
           <select id="logscan-trends-command-filter" class="form-select form-select-sm w-auto logscan-control-field"
             title="Filter visuals by run command.">
             <option value="">All commands</option>
@@ -266,6 +274,14 @@
           <div id="logscan-trends-date-hint-bottom" class="small text-muted logscan-date-hint"></div>
         </div>
         <div class="logscan-filter-row logscan-filter-row-secondary">
+          <select id="logscan-trends-tool-version-filter-bottom" class="form-select form-select-sm w-auto logscan-control-field"
+            title="Filter visuals by Kometa or ImageMaid version. Pair with App to isolate one tool.">
+            <option value="">All tool versions</option>
+          </select>
+          <select id="logscan-trends-quickstart-version-filter-bottom" class="form-select form-select-sm w-auto logscan-control-field"
+            title="Filter visuals by Quickstart version from the run marker.">
+            <option value="">All QS versions</option>
+          </select>
           <select id="logscan-trends-command-filter-bottom" class="form-select form-select-sm w-auto logscan-control-field"
             title="Filter visuals by run command.">
             <option value="">All commands</option>
@@ -322,7 +338,8 @@
             <option value="status">Status</option>
             <option value="tool_name">Tool</option>
             <option value="trace_count">Tracebacks</option>
-            <option value="kometa_version">Version</option>
+            <option value="kometa_version">Tool version</option>
+            <option value="quickstart_version">Quickstart version</option>
             <option value="warning_count">Warnings</option>
           </select>
         <select id="logscan-table-sort-dir" class="form-select form-select-sm w-auto" aria-label="Sort direction">
@@ -434,7 +451,7 @@
               </th>
               <th>
                 <button type="button" class="logscan-sort-button" data-sort="kometa_version"
-                  title="Sort by detected version" aria-label="Sort by detected version">
+                  title="Sort by detected tool version" aria-label="Sort by detected tool version">
                   Version
                   <span class="logscan-sort-icons" aria-hidden="true">
                     <span class="logscan-sort-up"></span>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -2078,8 +2078,103 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                 {% else %}
                                                 {% set tv_items = raw_tv_items %}
                                                 {% endif %}
+                                                {% set overlay_sections = overlay.template_variable_sections if overlay.template_variable_sections is defined else [] %}
+                                                {% set overlay_render_groups = [] %}
+                                                {% if overlay_sections and overlay.id != 'overlay_ratings' %}
+                                                {% set grouped_vars = [] %}
+                                                {% for section_def in overlay_sections %}
+                                                    {% set section_items = [] %}
+                                                    {% for tv_item in tv_items %}
+                                                        {% if is_mapping %}
+                                                            {% set tv_var_name = tv_item[0] %}
+                                                            {% set tv_var_details = tv_item[1] %}
+                                                        {% else %}
+                                                            {% set tv_var_details = tv_item %}
+                                                            {% set tv_var_name = tv_var_details.key or ('var' ~ loop.index0) %}
+                                                        {% endif %}
+                                                        {% set tv_section = tv_var_details.section if tv_var_details.section is defined else 'basics' %}
+                                                        {% if tv_section == section_def.id %}
+                                                            {% set _ = section_items.append(tv_item) %}
+                                                            {% set _ = grouped_vars.append(tv_var_name) %}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                    {% if section_items %}
+                                                        {% set _ = overlay_render_groups.append({
+                                                            'id': section_def.id,
+                                                            'label': section_def.label,
+                                                            'summary': section_def.summary if section_def.summary is defined else '',
+                                                            'default_open': section_def.default_open if section_def.default_open is defined else false,
+                                                            'fields': section_items,
+                                                            'flat': false
+                                                        }) %}
+                                                    {% endif %}
+                                                {% endfor %}
+                                                {% set ungrouped_items = [] %}
+                                                {% for tv_item in tv_items %}
+                                                    {% if is_mapping %}
+                                                        {% set tv_var_name = tv_item[0] %}
+                                                    {% else %}
+                                                        {% set tv_var_details = tv_item %}
+                                                        {% set tv_var_name = tv_var_details.key or ('var' ~ loop.index0) %}
+                                                    {% endif %}
+                                                    {% if tv_var_name not in grouped_vars %}
+                                                        {% set _ = ungrouped_items.append(tv_item) %}
+                                                    {% endif %}
+                                                {% endfor %}
+                                                {% if ungrouped_items %}
+                                                    {% set _ = overlay_render_groups.append({
+                                                        'id': 'other',
+                                                        'label': 'Other',
+                                                        'summary': 'Additional overlay settings.',
+                                                        'default_open': false,
+                                                        'fields': ungrouped_items,
+                                                        'flat': false
+                                                    }) %}
+                                                {% endif %}
+                                                {% endif %}
+                                                {% if not overlay_render_groups %}
+                                                    {% set _ = overlay_render_groups.append({
+                                                        'id': 'all',
+                                                        'label': 'Details',
+                                                        'summary': '',
+                                                        'default_open': true,
+                                                        'fields': tv_items,
+                                                        'flat': true
+                                                    }) %}
+                                                {% endif %}
                                                 {% set seen_vars = [] %}
-                                                {% for item in tv_items %}
+                                                {% for render_group in overlay_render_groups %}
+                                                {% if not render_group.flat %}
+                                                {% set render_group_body_id = template_name ~ '-' ~ render_group.id ~ '-section-body' %}
+                                                <div class="collection-variable-section overlay-variable-section mb-3"
+                                                    data-overlay-variable-section="true"
+                                                    data-overlay-variable-section-id="{{ render_group.id }}">
+                                                    <button type="button"
+                                                        class="btn btn-outline-secondary btn-sm w-100 d-flex align-items-center justify-content-between collection-variable-section-toggle overlay-variable-section-toggle"
+                                                        data-section-id="{{ render_group_body_id }}"
+                                                        data-show-label="Show {{ render_group.label }}"
+                                                        data-hide-label="Hide {{ render_group.label }}"
+                                                        aria-expanded="{{ 'true' if render_group.default_open else 'false' }}">
+                                                        <span class="fw-semibold">{{ render_group.label }}</span>
+                                                        <span class="small text-muted ms-auto me-2" data-overlay-section-summary>Defaults</span>
+                                                    </button>
+                                                    {% if render_group.summary %}
+                                                    <div class="form-text mt-1">{{ render_group.summary }}</div>
+                                                    {% endif %}
+                                                    <div class="overlay-variable-section-body mt-2"
+                                                        id="{{ render_group_body_id }}"
+                                                        data-detail-section="true"
+                                                        data-default-open="{{ 'true' if render_group.default_open else 'false' }}"
+                                                        style="display: {{ 'block' if render_group.default_open else 'none' }};">
+                                                        <div class="d-flex justify-content-end mb-2">
+                                                            <button type="button"
+                                                                class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn"
+                                                                data-overlay-variable-section-reset="true">
+                                                                Reset {{ render_group.label }}
+                                                            </button>
+                                                        </div>
+                                                {% endif %}
+                                                {% for item in render_group.fields %}
                                                 {% if is_mapping %}
                                                 {% set var_name = item[0] %}
                                                 {% set var_details = item[1] %}
@@ -2426,6 +2521,11 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                     {% endif %}
                                                     {% endif %}
                                                     {% endfor %}
+                                                {% if not render_group.flat %}
+                                                    </div>
+                                                </div>
+                                                {% endif %}
+                                                {% endfor %}
 
                                                 {% if not ns.has_offsets and effective_offsets is mapping %}
                                                 {% set h_default = effective_offsets.get('horizontal', 0) %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1516,6 +1516,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         <ul class="list-group mt-2" data-template-string-items></ul>
                         <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}"
                             data-default='{{ list_default_json }}'>
+                        <input type="hidden" id="{{ input_name }}__lookup_labels" name="{{ input_name }}__lookup_labels"
+                            value="{{ data['libraries'].get(input_name ~ '__lookup_labels', '{}') | default('{}', true) }}">
                         </div>
                         {% elif item.type == 'mapping_list' %}
                         {% set stored_map = data['libraries'].get(input_name) %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -400,6 +400,10 @@ prefix if yml_location == "top_level" else
                 value="{{ imdb_data | default('', true) }}"
                 data-default=""
                 data-separator-placeholder-input="imdb"
+                data-template-scalar-lookup="true"
+                data-validation-preset="imdb_id_tmdb"
+                data-library-name="{{ library.name }}"
+                data-media-type="{{ library_media_type }}"
                 aria-describedby="{{ imdb_id }}_text"
                 placeholder="tt1234567"
                 pattern="tt\d{7,8}"
@@ -407,6 +411,9 @@ prefix if yml_location == "top_level" else
                 inputmode="text"
                 autocapitalize="off">
         </div>
+        <input type="hidden" id="{{ imdb_id }}__lookup_labels" name="{{ imdb_name }}__lookup_labels"
+            value="{{ data['libraries'].get(imdb_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
+            data-template-metadata="lookup-labels" data-skip-override-count="true">
         {% if library_media_type == 'movie' %}
         <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tmdb_movie">
             <span class="input-group-text" id="{{ tmdb_id }}_text">
@@ -417,6 +424,10 @@ prefix if yml_location == "top_level" else
                 value="{{ tmdb_data | default('', true) }}"
                 data-default=""
                 data-separator-placeholder-input="tmdb_movie"
+                data-template-scalar-lookup="true"
+                data-validation-preset="numeric_id"
+                data-library-name="{{ library.name }}"
+                data-media-type="{{ library_media_type }}"
                 aria-describedby="{{ tmdb_id }}_text"
                 placeholder="603"
                 pattern="\d+"
@@ -424,6 +435,9 @@ prefix if yml_location == "top_level" else
                 inputmode="numeric"
                 data-numeric-only="true">
         </div>
+        <input type="hidden" id="{{ tmdb_id }}__lookup_labels" name="{{ tmdb_name }}__lookup_labels"
+            value="{{ data['libraries'].get(tmdb_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
+            data-template-metadata="lookup-labels" data-skip-override-count="true">
         {% else %}
         <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tvdb_show">
             <span class="input-group-text" id="{{ tvdb_id }}_text">
@@ -1781,6 +1795,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}"
                                 data-default="{{ item.default | default('', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
+                                {% if item.validation_preset %}data-template-scalar-lookup="true" data-library-name="{{ library.name }}" data-media-type="{{ library.type }}"{% endif %}
                                 {% if field_requires_plex_pass %}data-requires-plex-pass="true" data-plex-pass-available="{{ 'true' if has_plex_pass else 'false' }}"{% endif %}
                                 {% if item.requires_any_of_template_keys is defined and item.requires_any_of_template_keys %}data-requires-any-of-template-keys="{{ item.requires_any_of_template_keys | join(',') }}" data-requirement-hint="{{ item.requirement_hint | default('', true) }}"{% endif %}
                                 {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
@@ -1799,6 +1814,11 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 {% endif %}
                                 {% if field_disabled %}disabled{% endif %}>
                         </div>
+                        {% if item.validation_preset %}
+                        <input type="hidden" id="{{ input_name }}__lookup_labels" name="{{ input_name }}__lookup_labels"
+                            value="{{ data['libraries'].get(input_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
+                            data-template-metadata="lookup-labels" data-skip-override-count="true">
+                        {% endif %}
                         {% if field_requires_plex_pass and not has_plex_pass %}
                         <input type="hidden" name="{{ input_name }}" value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}">
                         <div class="form-text text-warning mb-2">Requires Plex Pass. Validate Plex first if this should be available.</div>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1517,7 +1517,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}"
                             data-default='{{ list_default_json }}'>
                         <input type="hidden" id="{{ input_name }}__lookup_labels" name="{{ input_name }}__lookup_labels"
-                            value="{{ data['libraries'].get(input_name ~ '__lookup_labels', '{}') | default('{}', true) }}">
+                            value="{{ data['libraries'].get(input_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
+                            data-template-metadata="lookup-labels" data-skip-override-count="true">
                         </div>
                         {% elif item.type == 'mapping_list' %}
                         {% set stored_map = data['libraries'].get(input_name) %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -2146,22 +2146,27 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                 {% for render_group in overlay_render_groups %}
                                                 {% if not render_group.flat %}
                                                 {% set render_group_body_id = template_name ~ '-' ~ render_group.id ~ '-section-body' %}
-                                                <div class="collection-variable-section overlay-variable-section mb-3"
+                                                <div class="border rounded p-2 mb-3 collection-variable-section overlay-variable-section"
                                                     data-overlay-variable-section="true"
                                                     data-overlay-variable-section-id="{{ render_group.id }}">
-                                                    <button type="button"
-                                                        class="btn btn-outline-secondary btn-sm w-100 d-flex align-items-center justify-content-between collection-variable-section-toggle overlay-variable-section-toggle"
-                                                        data-section-id="{{ render_group_body_id }}"
-                                                        data-show-label="Show {{ render_group.label }}"
-                                                        data-hide-label="Hide {{ render_group.label }}"
-                                                        aria-expanded="{{ 'true' if render_group.default_open else 'false' }}">
-                                                        <span class="fw-semibold">{{ render_group.label }}</span>
-                                                        <span class="small text-muted ms-auto me-2" data-overlay-section-summary>Defaults</span>
-                                                    </button>
+                                                    <div class="d-flex align-items-center justify-content-between gap-2 flex-wrap mb-2">
+                                                        <div class="fw-semibold">{{ render_group.label }}</div>
+                                                        <div class="d-flex align-items-center gap-2">
+                                                            <span class="small text-muted" data-overlay-section-summary>Defaults</span>
+                                                            <button type="button"
+                                                                class="btn btn-sm btn-outline-secondary btn-overlay overlay-variable-section-toggle"
+                                                                data-section-id="{{ render_group_body_id }}"
+                                                                data-show-label="Show"
+                                                                data-hide-label="Hide"
+                                                                aria-expanded="{{ 'true' if render_group.default_open else 'false' }}">
+                                                                {{ 'Hide' if render_group.default_open else 'Show' }}
+                                                            </button>
+                                                        </div>
+                                                    </div>
                                                     {% if render_group.summary %}
-                                                    <div class="form-text mt-1">{{ render_group.summary }}</div>
+                                                    <div class="form-text mb-2">{{ render_group.summary }}</div>
                                                     {% endif %}
-                                                    <div class="overlay-variable-section-body mt-2"
+                                                    <div class="overlay-variable-section-body"
                                                         id="{{ render_group_body_id }}"
                                                         data-detail-section="true"
                                                         data-default-open="{{ 'true' if render_group.default_open else 'false' }}"

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1323,6 +1323,13 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 data-detail-section="true"
                                 data-default-open="{{ 'true' if render_group.default_open else 'false' }}"
                                 style="display: {{ 'block' if render_group.default_open else 'none' }};">
+                                <div class="d-flex justify-content-end mb-2">
+                                    <button type="button"
+                                        class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn"
+                                        data-collection-variable-section-reset="true">
+                                        Reset {{ render_group.label }}
+                                    </button>
+                                </div>
                         {% endif %}
                         {% set season = namespace(open=false) %}
                         {% for item in render_group.fields %}

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -37,6 +37,8 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "section.dataset.defaultOpen === 'true'" in script
     assert "template-variable-section-has-overrides" in script
     assert "configuredCount > 0" in script
+    assert "updateTemplateGroupOverrideSummary(section)" in script
+    assert "updateAncestorOverrideSummaries(group)" in script
 
 
 def test_overlay_macros_render_collapsible_variable_sections():
@@ -64,6 +66,8 @@ def test_libraries_script_wires_overlay_variable_sections():
     assert "btn.dataset.overlayVariableSectionReset === 'true'" in script
     assert "template-variable-section-has-overrides" in script
     assert "configuredCount > 0" in script
+    assert "data-template-group-override-summary" in script
+    assert "data-accordion-override-summary" in script
 
 
 def test_template_variable_sections_show_override_rail():
@@ -71,6 +75,8 @@ def test_template_variable_sections_show_override_rail():
 
     assert ".collection-variable-section.template-variable-section-has-overrides" in styles
     assert ".overlay-variable-section.template-variable-section-has-overrides" in styles
+    assert ".template-toggle-group.template-variable-section-has-overrides" in styles
+    assert ".accordion-header.template-variable-section-has-overrides" in styles
     assert "background: var(--theme-primary);" in styles
 
 
@@ -88,6 +94,7 @@ def test_common_overlay_template_variables_have_sections_except_ratings():
             continue
 
         assert {section["id"] for section in overlay["template_variable_sections"]} == section_ids
+        assert all(section.get("default_open") is False for section in overlay["template_variable_sections"])
         values = template_variables.values() if isinstance(template_variables, dict) else [item for item in template_variables if isinstance(item, dict)]
         for details in values:
             assert details.get("section") in section_ids

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -39,8 +39,11 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "configuredCount > 0" in script
     assert "updateTemplateGroupOverrideSummary(section)" in script
     assert "updateAncestorOverrideSummaries(group)" in script
+    assert "function refreshTemplateOverrideState" in script
+    assert "refreshTemplateOverrideState(group.closest('.template-toggle-group') || group)" in script
     assert "function updateTemplateVariableFieldOverrideStates" in script
     assert "data-template-variable-field-override" in script
+    assert "[data-collection-field-wrapper]" in script
 
 
 def test_overlay_macros_render_collapsible_variable_sections():
@@ -71,6 +74,7 @@ def test_libraries_script_wires_overlay_variable_sections():
     assert "data-template-group-override-summary" in script
     assert "data-accordion-override-summary" in script
     assert "findTemplateVariableFieldRow(field)" in script
+    assert "refreshTemplateOverrideState(group)" in script
 
 
 def test_template_variable_sections_show_override_rail():
@@ -81,6 +85,8 @@ def test_template_variable_sections_show_override_rail():
     assert ".template-toggle-group.template-variable-section-has-overrides" in styles
     assert ".accordion-header.template-variable-section-has-overrides" in styles
     assert ".template-variable-field-has-override" in styles
+    assert "[data-template-string-list].template-variable-field-has-override" in styles
+    assert "background: linear-gradient(90deg, rgba(var(--accent-color), 0.08), transparent 34%);" in styles
     assert "background: var(--theme-primary);" in styles
 
 

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -1,9 +1,11 @@
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MACROS_PATH = ROOT / "templates" / "partials" / "_macros.html"
 LIBRARIES_JS_PATH = ROOT / "static" / "local-js" / "025-libraries.js"
 VALIDATION_JS_PATH = ROOT / "static" / "local-js" / "validationHandler.js"
+OVERLAYS_PATH = ROOT / "static" / "json" / "quickstart_overlays.json"
 
 
 def test_collection_macros_render_collapsible_detail_section():
@@ -32,6 +34,47 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "wireCollectionVariableSectionToggles(card)" in script
     assert "wireCollectionVariableSections(card)" in script
     assert "section.dataset.defaultOpen === 'true'" in script
+
+
+def test_overlay_macros_render_collapsible_variable_sections():
+    macros = MACROS_PATH.read_text(encoding="utf-8")
+
+    assert 'data-overlay-variable-section="true"' in macros
+    assert "overlay-variable-section-toggle" in macros
+    assert "data-overlay-section-summary" in macros
+    assert 'data-overlay-variable-section-reset="true"' in macros
+    assert "Reset {{ render_group.label }}" in macros
+    assert "overlay.id != 'overlay_ratings'" in macros
+
+
+def test_libraries_script_wires_overlay_variable_sections():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "function wireOverlayVariableSectionToggles" in script
+    assert "function wireOverlayVariableSections" in script
+    assert "function updateOverlayVariableSectionSummary" in script
+    assert "wireOverlayVariableSectionToggles(card)" in script
+    assert "wireOverlayVariableSections(card)" in script
+    assert "btn.dataset.overlayVariableSectionReset === 'true'" in script
+
+
+def test_common_overlay_template_variables_have_sections_except_ratings():
+    overlay_config = json.loads(OVERLAYS_PATH.read_text(encoding="utf-8"))
+    overlays = [overlay for group in overlay_config for overlay in group.get("overlays", [])]
+    section_ids = {"basics", "included_items", "font", "background", "placement"}
+
+    for overlay in overlays:
+        template_variables = overlay.get("template_variables")
+        if not template_variables:
+            continue
+        if overlay.get("id") == "overlay_ratings":
+            assert "template_variable_sections" not in overlay
+            continue
+
+        assert {section["id"] for section in overlay["template_variable_sections"]} == section_ids
+        values = template_variables.values() if isinstance(template_variables, dict) else [item for item in template_variables if isinstance(item, dict)]
+        for details in values:
+            assert details.get("section") in section_ids
 
 
 def test_validation_handler_opens_hidden_detail_sections():

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MACROS_PATH = ROOT / "templates" / "partials" / "_macros.html"
+STYLES_PATH = ROOT / "static" / "css" / "styles.css"
 LIBRARIES_JS_PATH = ROOT / "static" / "local-js" / "025-libraries.js"
 VALIDATION_JS_PATH = ROOT / "static" / "local-js" / "validationHandler.js"
 OVERLAYS_PATH = ROOT / "static" / "json" / "quickstart_overlays.json"
@@ -34,6 +35,8 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "wireCollectionVariableSectionToggles(card)" in script
     assert "wireCollectionVariableSections(card)" in script
     assert "section.dataset.defaultOpen === 'true'" in script
+    assert "template-variable-section-has-overrides" in script
+    assert "configuredCount > 0" in script
 
 
 def test_overlay_macros_render_collapsible_variable_sections():
@@ -59,6 +62,16 @@ def test_libraries_script_wires_overlay_variable_sections():
     assert "wireOverlayVariableSectionToggles(card)" in script
     assert "wireOverlayVariableSections(card)" in script
     assert "btn.dataset.overlayVariableSectionReset === 'true'" in script
+    assert "template-variable-section-has-overrides" in script
+    assert "configuredCount > 0" in script
+
+
+def test_template_variable_sections_show_override_rail():
+    styles = STYLES_PATH.read_text(encoding="utf-8")
+
+    assert ".collection-variable-section.template-variable-section-has-overrides" in styles
+    assert ".overlay-variable-section.template-variable-section-has-overrides" in styles
+    assert "background: var(--theme-primary);" in styles
 
 
 def test_common_overlay_template_variables_have_sections_except_ratings():

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -39,9 +39,12 @@ def test_libraries_script_wires_collection_detail_toggles():
 def test_overlay_macros_render_collapsible_variable_sections():
     macros = MACROS_PATH.read_text(encoding="utf-8")
 
+    assert 'class="border rounded p-2 mb-3 collection-variable-section overlay-variable-section"' in macros
     assert 'data-overlay-variable-section="true"' in macros
     assert "overlay-variable-section-toggle" in macros
     assert "data-overlay-section-summary" in macros
+    assert 'data-show-label="Show"' in macros
+    assert 'data-hide-label="Hide"' in macros
     assert 'data-overlay-variable-section-reset="true"' in macros
     assert "Reset {{ render_group.label }}" in macros
     assert "overlay.id != 'overlay_ratings'" in macros

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -39,6 +39,8 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "configuredCount > 0" in script
     assert "updateTemplateGroupOverrideSummary(section)" in script
     assert "updateAncestorOverrideSummaries(group)" in script
+    assert "function updateTemplateVariableFieldOverrideStates" in script
+    assert "data-template-variable-field-override" in script
 
 
 def test_overlay_macros_render_collapsible_variable_sections():
@@ -68,6 +70,7 @@ def test_libraries_script_wires_overlay_variable_sections():
     assert "configuredCount > 0" in script
     assert "data-template-group-override-summary" in script
     assert "data-accordion-override-summary" in script
+    assert "findTemplateVariableFieldRow(field)" in script
 
 
 def test_template_variable_sections_show_override_rail():
@@ -77,6 +80,7 @@ def test_template_variable_sections_show_override_rail():
     assert ".overlay-variable-section.template-variable-section-has-overrides" in styles
     assert ".template-toggle-group.template-variable-section-has-overrides" in styles
     assert ".accordion-header.template-variable-section-has-overrides" in styles
+    assert ".template-variable-field-has-override" in styles
     assert "background: var(--theme-primary);" in styles
 
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3080,6 +3080,40 @@ def test_collection_section_blank_normalizes_to_none():
     assert output._normalize_collection_template_var_value("collection_section", None) is None
 
 
+def test_collection_template_variable_sibling_groups_emit_in_stable_sorted_order(app):
+    from modules.output_optimize import optimize_template_variables
+
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "seasonal",
+                        "template_variables": {
+                            "schedule_women": "daily",
+                            "schedule_black_history": "daily",
+                            "schedule_aapi": "daily",
+                            "schedule_valentine": "daily",
+                            "schedule_years": "daily",
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    optimized = optimize_template_variables(config_data, {"Movies": "movie"})
+    template_variables = optimized["libraries"]["Movies"]["collection_files"][0]["template_variables"]
+
+    assert list(template_variables) == [
+        "schedule_aapi",
+        "schedule_black_history",
+        "schedule_valentine",
+        "schedule_women",
+        "schedule_years",
+    ]
+
+
 def test_collapse_collection_data_template_vars_removes_flat_data_keys_from_all_collection_entries():
     from modules import output
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3073,6 +3073,13 @@ def test_collapse_collection_data_template_vars_handles_actor_style_data_blocks(
     }
 
 
+def test_collection_section_blank_normalizes_to_none():
+    from modules import output
+
+    assert output._normalize_collection_template_var_value("collection_section", "") is None
+    assert output._normalize_collection_template_var_value("collection_section", None) is None
+
+
 def test_collapse_collection_data_template_vars_removes_flat_data_keys_from_all_collection_entries():
     from modules import output
 

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -2048,6 +2048,30 @@ def test_logscan_trends_returns_kometa_start_mode(client, isolated_config_dir, m
     assert payload["runs"][0]["start_mode"] == "recovery"
 
 
+def test_logscan_trends_returns_quickstart_version_fields(client, isolated_config_dir, qs_module):
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-quickstart-version-1",
+            "tool_name": "kometa",
+            "finished_at": "2026-05-05T20:17:00Z",
+            "config_name": "demo",
+            "created_at": "2026-05-05T20:17:00Z",
+            "quickstart_run_marker": True,
+            "quickstart_version": "0.10.4-build302",
+            "quickstart_branch": "develop",
+            "kometa_version": "2.3.1",
+        }
+    )
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["runs"]
+    assert payload["runs"][0]["quickstart_run_marker"] is True
+    assert payload["runs"][0]["quickstart_version"] == "0.10.4-build302"
+    assert payload["runs"][0]["quickstart_branch"] == "develop"
+
+
 def test_logscan_startup_migration_defers_without_logs(isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)

--- a/tests/test_logscan_maintenance.py
+++ b/tests/test_logscan_maintenance.py
@@ -88,6 +88,12 @@ class TestExtractQuickstartMarkerFields:
         assert fields["mode"] == "analyze"
         assert fields["foo"] == "bar"
 
+    def test_extracts_quickstart_version_fields(self):
+        content = "[Quickstart] Run marker: quickstart=0.10.4-build302 branch=develop start_mode=current"
+        fields = extract_quickstart_marker_fields(content)
+        assert fields["quickstart"] == "0.10.4-build302"
+        assert fields["branch"] == "develop"
+
     def test_valid_start_mode_kept(self):
         for mode in ("current", "recovery", "logged"):
             content = f"[Quickstart] Run marker: start_mode={mode}"

--- a/tests/test_output_id_list_annotations.py
+++ b/tests/test_output_id_list_annotations.py
@@ -40,3 +40,78 @@ def test_collection_id_lists_sort_and_emit_saved_lookup_comments(app):
     assert re.search(r"- '230161'\s+# Beta Franchise", yaml_content)
     assert re.search(r"- '893731'\s+# Zeta Franchise", yaml_content)
     assert "__template_variable_comments" not in yaml_content
+
+
+def test_collection_ignore_ids_emit_as_commented_sorted_rows(app):
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "franchise",
+                        "template_variables": {
+                            "ignore_ids": ["893731", "230161", "125574"],
+                        },
+                        "__template_variable_comments": {
+                            "ignore_ids": {
+                                "893731": "Zeta Franchise",
+                                "230161": "Beta Franchise",
+                                "125574": "Alpha Franchise",
+                            }
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    with app.app_context():
+        transformed = apply_final_transformations(config_data, {"Movies": "movie"})
+        yaml_content = dump_section("", "libraries", transformed["libraries"], "none", None)
+
+    assert yaml_content.index("- '125574'") < yaml_content.index("- '230161'") < yaml_content.index("- '893731'")
+    assert re.search(r"- '125574'\s+# Alpha Franchise", yaml_content)
+    assert re.search(r"- '230161'\s+# Beta Franchise", yaml_content)
+    assert re.search(r"- '893731'\s+# Zeta Franchise", yaml_content)
+
+
+def test_settings_ignore_ids_emit_as_commented_sorted_rows(app):
+    settings = {
+        "settings": {
+            "ignore_ids": '["893731", "230161", "125574"]',
+            "ignore_ids__lookup_labels": '{"893731":"Zeta Franchise","230161":"Beta Franchise","125574":"Alpha Franchise"}',
+        }
+    }
+
+    with app.app_context():
+        yaml_content = dump_section("", "settings", settings, "none", None)
+
+    assert yaml_content.index("- 125574") < yaml_content.index("- 230161") < yaml_content.index("- 893731")
+    assert re.search(r"- 125574\s+# Alpha Franchise", yaml_content)
+    assert re.search(r"- 230161\s+# Beta Franchise", yaml_content)
+    assert re.search(r"- 893731\s+# Zeta Franchise", yaml_content)
+    assert "__lookup_labels" not in yaml_content
+
+
+def test_library_placeholder_id_emits_saved_lookup_comment(app):
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "template_variables": {
+                    "use_separator": True,
+                    "placeholder_imdb_id": "tt0108052",
+                },
+                "__template_variable_comments": {
+                    "placeholder_imdb_id": {
+                        "tt0108052": "Schindler's List",
+                    }
+                },
+            }
+        }
+    }
+
+    with app.app_context():
+        yaml_content = dump_section("", "libraries", config_data["libraries"], "none", None)
+
+    assert re.search(r"placeholder_imdb_id: tt0108052\s+# Schindler's List", yaml_content)
+    assert "__template_variable_comments" not in yaml_content

--- a/tests/test_output_id_list_annotations.py
+++ b/tests/test_output_id_list_annotations.py
@@ -1,0 +1,42 @@
+import re
+
+from modules.output_dump import dump_section
+from modules.output_render import apply_final_transformations
+
+
+def test_collection_id_lists_sort_and_emit_saved_lookup_comments(app):
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "franchise",
+                        "template_variables": {
+                            "exclude": ["893731", "230161", "125574"],
+                        },
+                        "__template_variable_comments": {
+                            "exclude": {
+                                "893731": "Zeta Franchise",
+                                "230161": "Beta Franchise",
+                                "125574": "Alpha Franchise",
+                            }
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    with app.app_context():
+        transformed = apply_final_transformations(config_data, {"Movies": "movie"})
+        yaml_content = dump_section("", "libraries", transformed["libraries"], "none", None)
+
+    alpha_index = yaml_content.index("- '125574'")
+    beta_index = yaml_content.index("- '230161'")
+    zeta_index = yaml_content.index("- '893731'")
+
+    assert alpha_index < beta_index < zeta_index
+    assert re.search(r"- '125574'\s+# Alpha Franchise", yaml_content)
+    assert re.search(r"- '230161'\s+# Beta Franchise", yaml_content)
+    assert re.search(r"- '893731'\s+# Zeta Franchise", yaml_content)
+    assert "__template_variable_comments" not in yaml_content


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Yes, those should be in the PR description too. Use this fuller version:

### Summary
Improves Libraries page usability and export consistency across analytics, reset flows, overlay organization, and ID-based template variables.

### Changes
- Organized overlay template variables into logical detail groups, excluding ratings overlays for a separate follow-up because their slot model is structurally different.
- Added grouped override indicators for overlay/collection sections so users can see where non-default values exist at parent, group, and field levels.
- Added logical section reset controls for grouped collection/overlay fields.
- Added busy spinners/status behavior for Libraries page buttons, including reset/default/order actions.
- Fixed collection section reorder/reset behavior so reset clears `collection_section` overrides instead of writing extra default values.
- Improved analytics/recent-runs behavior and added Quickstart version support alongside Kometa/ImageMaid version metadata.
- Added stable sorting for collection template variables based on Quickstart JSON ordering to reduce noisy config diffs.
- Fixed franchise collection order metadata to reflect release order defaults.
- Added lookup-label sidecars and YAML comments for ID-based fields like `exclude`, `ignore_ids`, `ignore_imdb_ids`, and placeholder IDs.
- Updated `ignore_ids` / `ignore_imdb_ids` export to sorted YAML lists so each ID can carry its own readable inline comment.

### Validation
- `venv\Scripts\python.exe -m pytest tests/test_output_id_list_annotations.py tests/test_collection_ignore_imdb_ids_contract.py tests/test_core_backend.py::test_build_libraries_section_includes_separator_placeholder_imdb_id -q`
- `node --check static\local-js\025-libraries.js`
- `venv\Scripts\python.exe -m py_compile modules\output_collections.py modules\output_dump.py modules\output_library_ops.py modules\output_libraries_section.py`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
