### PR TITLE
logical groupings for overlays with ratings part 1

### DIFF
--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -841,6 +841,38 @@
           "movie",
           "show"
         ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core ratings overlay behavior.",
+            "default_open": false
+          },
+          {
+            "id": "rating_slots",
+            "label": "Rating Slots",
+            "summary": "Choose rating sources and icon images for each slot.",
+            "default_open": false
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Per-slot font, color, and stroke settings.",
+            "default_open": false
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment, slot offsets, and position controls.",
+            "default_open": false
+          }
+        ],
         "template_variables": {
           "rating1": {
             "input_type": "select",
@@ -1311,6 +1343,38 @@
         },
         "media_types": [
           "episode"
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core ratings overlay behavior.",
+            "default_open": false
+          },
+          {
+            "id": "rating_slots",
+            "label": "Rating Slots",
+            "summary": "Choose rating sources and icon images for each slot.",
+            "default_open": false
+          },
+          {
+            "id": "font",
+            "label": "Font",
+            "summary": "Per-slot font, color, and stroke settings.",
+            "default_open": false
+          },
+          {
+            "id": "background",
+            "label": "Background",
+            "summary": "Background fill, outline, dimensions, and padding.",
+            "default_open": false
+          },
+          {
+            "id": "placement",
+            "label": "Placement",
+            "summary": "Overlay alignment, slot offsets, and position controls.",
+            "default_open": false
+          }
         ],
         "template_variables": {
           "rating1": {

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -2102,8 +2102,17 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                 {% set tv_items = raw_tv_items %}
                                                 {% endif %}
                                                 {% set overlay_sections = overlay.template_variable_sections if overlay.template_variable_sections is defined else [] %}
+                                                {% if overlay.id == 'overlay_ratings' and not overlay_sections %}
+                                                {% set overlay_sections = [
+                                                    {'id': 'basics', 'label': 'Basics', 'summary': 'Core ratings overlay behavior.', 'default_open': false},
+                                                    {'id': 'rating_slots', 'label': 'Rating Slots', 'summary': 'Choose rating sources and icon images for each slot.', 'default_open': false},
+                                                    {'id': 'font', 'label': 'Font', 'summary': 'Per-slot font, color, and stroke settings.', 'default_open': false},
+                                                    {'id': 'background', 'label': 'Background', 'summary': 'Background fill, outline, dimensions, and padding.', 'default_open': false},
+                                                    {'id': 'placement', 'label': 'Placement', 'summary': 'Overlay alignment, slot offsets, and position controls.', 'default_open': false}
+                                                ] %}
+                                                {% endif %}
                                                 {% set overlay_render_groups = [] %}
-                                                {% if overlay_sections and overlay.id != 'overlay_ratings' %}
+                                                {% if overlay_sections %}
                                                 {% set grouped_vars = [] %}
                                                 {% for section_def in overlay_sections %}
                                                     {% set section_items = [] %}
@@ -2115,8 +2124,21 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                             {% set tv_var_details = tv_item %}
                                                             {% set tv_var_name = tv_var_details.key or ('var' ~ loop.index0) %}
                                                         {% endif %}
-                                                        {% set tv_section = tv_var_details.section if tv_var_details.section is defined else 'basics' %}
-                                                        {% if tv_section == section_def.id %}
+                                                        {% set tv_section = namespace(value=(tv_var_details.section if tv_var_details.section is defined else 'basics')) %}
+                                                        {% if overlay.id == 'overlay_ratings' %}
+                                                            {% if tv_var_name in ['rating1', 'rating1_image', 'rating2', 'rating2_image', 'rating3', 'rating3_image'] %}
+                                                                {% set tv_section.value = 'rating_slots' %}
+                                                            {% elif tv_var_name.endswith('_font') or tv_var_name.endswith('_font_size') or tv_var_name.endswith('_font_color') or tv_var_name.endswith('_stroke_width') or tv_var_name.endswith('_stroke_color') %}
+                                                                {% set tv_section.value = 'font' %}
+                                                            {% elif tv_var_name.startswith('back_') or tv_var_name.startswith('addon_') %}
+                                                                {% set tv_section.value = 'background' %}
+                                                            {% elif tv_var_name in ['horizontal_position', 'vertical_position', 'rating_alignment', 'horizontal_offset', 'vertical_offset'] or tv_var_name.endswith('_horizontal_offset') or tv_var_name.endswith('_vertical_offset') %}
+                                                                {% set tv_section.value = 'placement' %}
+                                                            {% else %}
+                                                                {% set tv_section.value = 'basics' %}
+                                                            {% endif %}
+                                                        {% endif %}
+                                                        {% if tv_section.value == section_def.id %}
                                                             {% set _ = section_items.append(tv_item) %}
                                                             {% set _ = grouped_vars.append(tv_var_name) %}
                                                         {% endif %}

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -57,7 +57,8 @@ def test_overlay_macros_render_collapsible_variable_sections():
     assert 'data-hide-label="Hide"' in macros
     assert 'data-overlay-variable-section-reset="true"' in macros
     assert "Reset {{ render_group.label }}" in macros
-    assert "overlay.id != 'overlay_ratings'" in macros
+    assert "overlay.id == 'overlay_ratings'" in macros
+    assert "'rating_slots'" in macros
 
 
 def test_libraries_script_wires_overlay_variable_sections():
@@ -90,17 +91,19 @@ def test_template_variable_sections_show_override_rail():
     assert "background: var(--theme-primary);" in styles
 
 
-def test_common_overlay_template_variables_have_sections_except_ratings():
+def test_common_overlay_template_variables_have_sections():
     overlay_config = json.loads(OVERLAYS_PATH.read_text(encoding="utf-8"))
     overlays = [overlay for group in overlay_config for overlay in group.get("overlays", [])]
     section_ids = {"basics", "included_items", "font", "background", "placement"}
+    rating_section_ids = {"basics", "rating_slots", "font", "background", "placement"}
 
     for overlay in overlays:
         template_variables = overlay.get("template_variables")
         if not template_variables:
             continue
         if overlay.get("id") == "overlay_ratings":
-            assert "template_variable_sections" not in overlay
+            assert {section["id"] for section in overlay["template_variable_sections"]} == rating_section_ids
+            assert all(section.get("default_open") is False for section in overlay["template_variable_sections"])
             continue
 
         assert {section["id"] for section in overlay["template_variable_sections"]} == section_ids


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

- Aligns `overlay_ratings` with the logical overlay grouping UI used by the other overlay sections.
- Adds explicit Ratings sections for movie/show and episode overlays: Basics, Rating Slots, Font, Background, and Placement.
- Keeps existing ratings-specific behavior intact while routing fields into the correct collapsible groups.
- Updates the overlay detail contract tests so ratings are now expected to use grouped sections instead of the old flat details fallback.

## Testing

- `venv\Scripts\python.exe -m pytest tests\test_collection_details_contract.py -q`
- `venv\Scripts\python.exe -m pytest tests\test_ratings_yaml_contract.py -q`
- `venv\Scripts\python.exe -m pytest tests\test_ratings_matrix_contract.py -q`
- `node --check static\local-js\025-libraries.js`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
