### PR TITLE
fixes

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -1279,6 +1279,7 @@ logscan_reingest_state = {
     "status": "idle",
     "job_id": None,
 }
+LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL = 10
 
 # Bump this integer when a release needs a one-time Analytics reset + log reingest
 # on startup. Quickstart persists the highest successful level to config/.env so
@@ -4278,6 +4279,39 @@ def logscan_progress():
 
 @app.route("/logscan/trends", methods=["GET"])
 def logscan_trends():
+    snapshot = _logscan_reingest_snapshot()
+    if logscan_ingest_lock.locked() or snapshot.get("status") == "running":
+        total_runs = database.get_log_runs_count()
+        running_health = {
+            "source": "running",
+            "status": snapshot.get("status") or "running",
+            "job_id": snapshot.get("job_id"),
+            "trigger": snapshot.get("trigger"),
+            "migration_level": snapshot.get("migration_level"),
+            "total": snapshot.get("total", 0),
+            "scanned": snapshot.get("scanned", 0),
+            "ingested": snapshot.get("ingested", 0),
+            "duplicates": snapshot.get("duplicates", 0),
+            "skipped_incomplete": snapshot.get("skipped_incomplete", 0),
+            "skipped_invalid": snapshot.get("skipped_invalid", 0),
+            "errors": snapshot.get("errors", 0),
+            "current_file": snapshot.get("current_file"),
+            "needs_reingest": True,
+            "pending_active": True,
+        }
+        return jsonify(
+            {
+                "runs": [],
+                "incomplete_runs": [],
+                "total_runs": total_runs,
+                "total_incomplete_runs": 0,
+                "ingest_health": running_health,
+                "archive_storage": None,
+                "reingest_running": True,
+                "reingest": snapshot,
+            }
+        )
+
     try:
         _ingest_completed_live_logs("imagemaid")
         _archive_finished_live_meta_log_if_idle()
@@ -4292,20 +4326,73 @@ def logscan_trends():
         except Exception:
             limit = 50
         limit = max(1, min(limit, 500))
+    include_ingest_health = str(request.args.get("include_ingest_health", "1")).strip().lower() not in {"0", "false", "no", "off"}
+    include_archive_storage = str(request.args.get("include_archive_storage", "1")).strip().lower() not in {"0", "false", "no", "off"}
+    include_incomplete = str(request.args.get("include_incomplete", "1")).strip().lower() not in {"0", "false", "no", "off"}
     total_runs = database.get_log_runs_count()
-    ingest_health = _logscan_ingest_health()
     resolution_context = _build_logscan_resolution_context()
     runs = _annotate_logscan_runs(database.get_log_runs(limit=limit), context=resolution_context)
-    incomplete_runs = _annotate_logscan_runs(_get_logscan_incomplete_runs(limit=limit), context=resolution_context)
-    all_runs = database.get_log_runs(limit=None) if total_runs else []
+    incomplete_runs = []
+    all_incomplete_runs = []
+    if include_incomplete:
+        incomplete_runs = _annotate_logscan_runs(_get_logscan_incomplete_runs(limit=limit), context=resolution_context)
+        all_incomplete_runs = _get_logscan_incomplete_runs(limit=None)
+    payload = {
+        "runs": runs,
+        "incomplete_runs": incomplete_runs,
+        "total_runs": total_runs,
+        "total_incomplete_runs": len(all_incomplete_runs),
+        "ingest_health": _logscan_ingest_health() if include_ingest_health else None,
+        "archive_storage": None,
+        "reingest_running": False,
+    }
+    if include_archive_storage:
+        all_runs = database.get_log_runs(limit=None) if total_runs else []
+        payload["archive_storage"] = _get_logscan_archive_storage_summary(
+            all_runs=all_runs,
+            incomplete_runs=all_incomplete_runs,
+            context=resolution_context,
+        )
+    return jsonify(payload)
+
+
+@app.route("/logscan/trends/ingest-health", methods=["GET"])
+def logscan_trends_ingest_health():
+    snapshot = _logscan_reingest_snapshot()
+    if logscan_ingest_lock.locked() or snapshot.get("status") == "running":
+        return jsonify(
+            {
+                "source": "running",
+                "status": snapshot.get("status") or "running",
+                "job_id": snapshot.get("job_id"),
+                "trigger": snapshot.get("trigger"),
+                "migration_level": snapshot.get("migration_level"),
+                "total": snapshot.get("total", 0),
+                "scanned": snapshot.get("scanned", 0),
+                "ingested": snapshot.get("ingested", 0),
+                "duplicates": snapshot.get("duplicates", 0),
+                "skipped_incomplete": snapshot.get("skipped_incomplete", 0),
+                "skipped_invalid": snapshot.get("skipped_invalid", 0),
+                "errors": snapshot.get("errors", 0),
+                "current_file": snapshot.get("current_file"),
+                "needs_reingest": True,
+                "pending_active": True,
+            }
+        )
+    return jsonify(_logscan_ingest_health())
+
+
+@app.route("/logscan/trends/archive-storage", methods=["GET"])
+def logscan_trends_archive_storage():
+    snapshot = _logscan_reingest_snapshot()
+    if logscan_ingest_lock.locked() or snapshot.get("status") == "running":
+        return jsonify({"status": "running", "archive_storage": None, "reingest": snapshot}), 202
+    resolution_context = _build_logscan_resolution_context()
+    all_runs = database.get_log_runs(limit=None) if database.get_log_runs_count() else []
     all_incomplete_runs = _get_logscan_incomplete_runs(limit=None)
     return jsonify(
         {
-            "runs": runs,
-            "incomplete_runs": incomplete_runs,
-            "total_runs": total_runs,
-            "total_incomplete_runs": len(all_incomplete_runs),
-            "ingest_health": ingest_health,
+            "status": "idle",
             "archive_storage": _get_logscan_archive_storage_summary(
                 all_runs=all_runs,
                 incomplete_runs=all_incomplete_runs,
@@ -4313,6 +4400,26 @@ def logscan_trends():
             ),
         }
     )
+
+
+@app.route("/logscan/trends/incomplete-runs", methods=["GET"])
+def logscan_trends_incomplete_runs():
+    snapshot = _logscan_reingest_snapshot()
+    if logscan_ingest_lock.locked() or snapshot.get("status") == "running":
+        return jsonify({"status": "running", "incomplete_runs": [], "total_incomplete_runs": 0, "reingest": snapshot}), 202
+    raw_limit = str(request.args.get("limit", "50")).strip().lower()
+    if raw_limit == "all":
+        limit = None
+    else:
+        try:
+            limit = int(raw_limit)
+        except Exception:
+            limit = 50
+        limit = max(1, min(limit, 500))
+    resolution_context = _build_logscan_resolution_context()
+    runs = _annotate_logscan_runs(_get_logscan_incomplete_runs(limit=limit), context=resolution_context)
+    all_runs = _get_logscan_incomplete_runs(limit=None)
+    return jsonify({"status": "idle", "incomplete_runs": runs, "total_incomplete_runs": len(all_runs)})
 
 
 @app.route("/logscan/trends/recommendations", methods=["GET"])
@@ -5105,6 +5212,15 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
         sample_incomplete = []
         sample_errors = []
 
+        def _flush_ingest_cache_progress(force=False):
+            nonlocal cache_dirty
+            if not cache_dirty:
+                return
+            if force:
+                ingest_cache["logs"] = cache_logs
+                _save_logscan_ingest_cache(ingest_cache)
+                cache_dirty = False
+
         for idx, path in enumerate(log_files, start=1):
             if update_state:
                 _update_logscan_reingest_state(current_file=path.name, scanned=max(0, idx - 1))
@@ -5295,6 +5411,8 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                     sample_incomplete=sample_incomplete,
                     sample_errors=sample_errors,
                 )
+            if idx % LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL == 0:
+                _flush_ingest_cache_progress(force=True)
 
         cache_dir = _get_logscan_cache_dir()
         missing_people_log = cache_dir / "meta_people_missing.log"
@@ -5362,8 +5480,7 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                 current_file=None,
                 **result,
             )
-        if cache_dirty:
-            _save_logscan_ingest_cache(ingest_cache)
+        _flush_ingest_cache_progress(force=True)
         return result
     finally:
         logscan_ingest_lock.release()

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3326,7 +3326,7 @@ function initScheduleBuilders (scope) {
       if (mode === 'custom') {
         nextValue = String(rawInput?.value || '').trim()
       } else {
-        nextValue = buildValueFromInputs(mode) || defaultValue || ''
+        nextValue = buildValueFromInputs(mode) || ''
       }
       hidden.value = nextValue
       updatePreview(nextValue)
@@ -3392,7 +3392,7 @@ function initScheduleBuilders (scope) {
     }
 
     hidden.addEventListener('change', () => {
-      const nextRaw = String(hidden.value || defaultValue || '').trim()
+      const nextRaw = String(hidden.value || '').trim()
       const nextParsed = parseSchedule(nextRaw)
       applyParsed(nextParsed)
       updateFromBuilder()
@@ -3402,7 +3402,6 @@ function initScheduleBuilders (scope) {
   })
 }
 
-/* eslint-disable quotes */
 const languageCollectionKeys = JSON.parse(`["ab", "aa", "af", "ak", "sq", "am", "ar", "an", "hy", "as", "av", "ae", "ay", "az", "bm", "ba", "eu", "be", "bn", "bi", "bs", "br", "bg", "my", "ca", "km", "ch", "ce", "ny", "zh", "cu", "cv", "kw", "co", "cr", "hr", "cs", "da", "dv", "nl", "dz", "en", "eo", "et", "ee", "fo", "fj", "fil", "fi", "fr", "ff", "gd", "gl", "lg", "ka", "de", "el", "gn", "gu", "ht", "ha", "he", "hz", "hi", "ho", "hu", "is", "io", "ig", "id", "ia", "ie", "iu", "ik", "ga", "it", "ja", "jv", "kl", "kn", "kr", "ks", "kk", "ki", "rw", "ky", "kv", "kg", "ko", "kj", "ku", "lo", "la", "lv", "li", "ln", "lt", "lu", "lb", "mk", "mg", "ms", "ml", "mt", "gv", "mi", "mr", "mh", "myn", "mn", "na", "nv", "ng", "ne", "nd", "se", "no", "nb", "nn", "oc", "oj", "or", "om", "os", "pi", "ps", "fa", "pl", "pt", "pa", "qu", "ro", "rm", "rom", "rn", "ru", "sm", "sg", "sa", "sc", "sr", "sn", "ii", "sd", "si", "sk", "sl", "so", "nr", "st", "es", "su", "sw", "ss", "sv", "tl", "ty", "tai", "tg", "ta", "tt", "te", "th", "bo", "ti", "to", "ts", "tn", "tr", "tk", "tw", "ug", "uk", "ur", "uz", "ve", "vi", "vo", "wa", "cy", "fy", "wo", "xh", "yi", "yo", "za", "zu", "other"]`).map(value => String(value))
 const countryNameCollectionKeys = JSON.parse(`["Algeria", "Egypt", "Libya", "Morocco", "Sudan", "Tunisia", "Western Sahara", "British Indian Ocean Territory", "Burundi", "Comoros", "Djibouti", "Eritrea", "Ethiopia", "French Southern Territories", "Kenya", "Madagascar", "Malawi", "Mauritius", "Mayotte", "Mozambique", "R\u00e9union", "Rwanda", "Seychelles", "Somalia", "South Sudan", "Uganda", "Tanzania", "Zambia", "Zimbabwe", "Angola", "Cameroon", "Central African Republic", "Chad", "Republic of the Congo", "Democratic Republic of the Congo", "Equatorial Guinea", "Gabon", "S\u00e3o Tom\u00e9 and Pr\u00edncipe", "Botswana", "Eswatini", "Lesotho", "Namibia", "South Africa", "Benin", "Burkina Faso", "Cape Verde", "C\u00f4te d'Ivoire", "Gambia", "Ghana", "Guinea", "Guinea-Bissau", "Liberia", "Mali", "Mauritania", "Niger", "Nigeria", "Saint Helena, Ascension and Tristan da Cunha", "Senegal", "Sierra Leone", "Togo", "Anguilla", "Antigua and Barbuda", "Aruba", "Bahamas", "Barbados", "Bonaire, Sint Eustatius and Saba", "Netherlands Antilles", "British Virgin Islands", "Cayman Islands", "Cuba", "Cura\u00e7ao", "Dominica", "Dominican Republic", "Grenada", "Guadeloupe", "Haiti", "Jamaica", "Martinique", "Montserrat", "Puerto Rico", "Saint Barth\u00e9lemy", "Saint Kitts and Nevis", "Saint Lucia", "Saint Martin", "Saint Vincent and the Grenadines", "Sint Maarten", "Trinidad and Tobago", "Turks and Caicos Islands", "US Virgin Islands", "Belize", "Costa Rica", "El Salvador", "Guatemala", "Honduras", "Mexico", "Nicaragua", "Panama", "Argentina", "Bolivia", "Bouvet Island", "Brazil", "Chile", "Colombia", "Ecuador", "Falkland Islands", "French Guiana", "Guyana", "Paraguay", "Peru", "South Georgia and the South Sandwich Islands", "Suriname", "Uruguay", "Venezuela", "Bermuda", "Canada", "Greenland", "Saint Pierre and Miquelon", "United States", "Antarctica", "Kazakhstan", "Kyrgyzstan", "Tajikistan", "Turkmenistan", "Uzbekistan", "China", "Hong Kong", "Macao", "North Korea", "Japan", "Mongolia", "South Korea", "Taiwan", "Brunei", "Cambodia", "Indonesia", "Laos", "Malaysia", "Myanmar", "Philippines", "Singapore", "Thailand", "East Timor", "Vietnam", "Afghanistan", "Bangladesh", "Bhutan", "India", "Iran", "Maldives", "Nepal", "Pakistan", "Sri Lanka", "Armenia", "Azerbaijan", "Bahrain", "Cyprus", "Georgia", "Iraq", "Israel", "Jordan", "Kuwait", "Lebanon", "Oman", "Qatar", "Saudi Arabia", "Palestine", "Syria", "Turkey", "United Arab Emirates", "Yemen", "Belarus", "Bulgaria", "Czech Republic", "Hungary", "Poland", "Moldova", "Romania", "Russia", "Slovakia", "Ukraine", "\u00c5land Islands", "Guernsey", "Jersey", "Sark", "Denmark", "Estonia", "Faroe Islands", "Finland", "Iceland", "Ireland", "Northern Ireland", "Isle of Man", "Latvia", "Lithuania", "Norway", "Svalbard and Jan Mayen Islands", "Sweden", "United Kingdom", "Albania", "Andorra", "Bosnia and Herzegovina", "Croatia", "Gibraltar", "Greece", "Kosovo", "Vatican City", "Italy", "Malta", "Montenegro", "North Macedonia", "Portugal", "San Marino", "Serbia", "Serbia and Montenegro", "Slovenia", "Spain", "Yugoslavia", "Austria", "Belgium", "France", "Germany", "Liechtenstein", "Luxembourg", "Monaco", "Netherlands", "Switzerland", "Australia", "Christmas Island", "Cocos (Keeling) Islands", "Heard Island and McDonald Islands", "New Zealand", "Norfolk Island", "Fiji", "New Caledonia", "Papua New Guinea", "Solomon Islands", "Vanuatu", "Guam", "Kiribati", "Marshall Islands", "Micronesia", "Nauru", "Northern Mariana Islands", "Palau", "US Minor Outlying Islands", "American Samoa", "Cook Islands", "French Polynesia", "Niue", "Pitcairn Islands", "Samoa", "Tokelau", "Tonga", "Tuvalu", "Wallis and Futuna Islands", "other"]`).map(value => String(value))
 const countryCodeCollectionKeys = JSON.parse(`["dz", "eg", "ly", "ma", "sd", "tn", "eh", "io", "bi", "km", "dj", "er", "et", "tf", "ke", "mg", "mw", "mu", "yt", "mz", "re", "rw", "sc", "so", "ss", "ug", "tz", "zm", "zw", "ao", "cm", "cf", "td", "cg", "cd", "gq", "ga", "st", "bw", "sz", "ls", "na", "za", "bj", "bf", "cv", "ci", "gm", "gh", "gn", "gw", "lr", "ml", "mr", "ne", "ng", "sh", "sn", "sl", "tg", "ai", "ag", "aw", "bs", "bb", "bq", "an", "vg", "ky", "cu", "cw", "dm", "do", "gd", "gp", "ht", "jm", "mq", "ms", "pr", "bl", "kn", "lc", "mf", "vc", "sx", "tt", "tc", "vi", "bz", "cr", "sv", "gt", "hn", "mx", "ni", "pa", "ar", "bo", "bv", "br", "cl", "co", "ec", "fk", "gf", "gy", "py", "pe", "gs", "sr", "uy", "ve", "bm", "ca", "gl", "pm", "us", "aq", "kz", "kg", "tj", "tm", "uz", "cn", "hk", "mo", "kp", "jp", "mn", "kr", "tw", "bn", "kh", "id", "la", "my", "mm", "ph", "sg", "th", "tp", "vn", "af", "bd", "bt", "in", "ir", "mv", "np", "pk", "lk", "am", "az", "bh", "cy", "ge", "iq", "il", "jo", "kw", "lb", "om", "qa", "sa", "ps", "sy", "tr", "ae", "ye", "by", "bg", "cz", "hu", "pl", "md", "ro", "ru", "sk", "ua", "ax", "gg", "je", "cq", "dk", "ee", "fo", "fi", "is", "ie", "im", "lv", "lt", "no", "sj", "se", "gb", "al", "ad", "ba", "hr", "gi", "gr", "xk", "va", "it", "mt", "me", "mk", "pt", "sm", "rs", "si", "es", "yu", "at", "be", "fr", "de", "li", "lu", "mc", "nl", "ch", "au", "cx", "cc", "hm", "nz", "nf", "fj", "nc", "pg", "sb", "vu", "gu", "ki", "mh", "fm", "nr", "mp", "pw", "um", "as", "ck", "pf", "nu", "pn", "ws", "tk", "to", "tv", "wf", "other"]`).map(value => String(value))
@@ -3410,8 +3409,6 @@ const continentCollectionKeys = JSON.parse(`["Africa", "Americas", "Antarctica",
 const regionCollectionKeys = JSON.parse(`["Northern Africa", "Eastern Africa", "Central Africa", "Southern Africa", "Western Africa", "Caribbean", "Central America", "South America", "North America", "Antarctica", "Central Asia", "Eastern Asia", "South-Eastern Asia", "Southern Asia", "Western Asia", "Eastern Europe", "Northern Europe", "Southern Europe", "Western Europe", "Australia and New Zealand", "Melanesia", "Micronesia", "Polynesia", "other"]`).map(value => String(value))
 const studioCollectionKeys = JSON.parse(`["8bit", "A-1 Pictures", "A.C.G.T.", "Acca effe", "Actas", "AIC", "Ajia-Do", "Akatsuki", "Animation Do", "Ankama", "APPP", "Arms", "Artland", "Artmic", "Arvo Animation", "Asahi Production", "Ashi Productions", "asread.", "AtelierPontdarc", "B.CMAY PICTURES", "Bandai Namco Pictures", "Bee Train", "Berlanti Productions", "Bibury Animation Studios", "bilibili", "Bones", "Brain's Base", "Bridge", "BUG FILMS", "C-Station", "C2C", "Children's Playground Entertainment", "Cloud Hearts", "CloverWorks", "Colored Pencil Animation", "CoMix Wave Films", "Connect", "Craftar Studios", "Creators in Pack", "CygamesPictures", "David Production", "Diomed\\u00e9a", "DLE", "Doga Kobo", "domerica", "Drive", "EMT Squared", "Encourage Films", "ENGI", "feel.", "Felix Film", "Fenz", "GAINAX", "Gallop", "Geek Toys", "Gekkou", "Gemba", "GENCO", "Geno Studio", "GoHands", "Gonzo", "Graphinica", "Group Tac", "Hal Film Maker", "Haoliners Animation League", "Hoods Entertainment", "Hotline", "J.C.Staff", "Jumondou", "Kadokawa", "Khara", "Kinema Citrus", "Kyoto Animation", "Lan Studio", "LandQ Studio", "Lay-duce", "Lerche", "LIDENFILMS", "M.S.C", "Madhouse", "Magic Bus", "Maho Film", "Manglobe", "MAPPA", "Millepensee", "Namu Animation", "NAZ", "Nexus", "Nippon Animation", "Nomad", "Nut", "Okuruto Noboru", "OLM", "Orange", "Ordet", "OZ", "P.A. Works", "P.I.C.S.", "Passione", "Pb Animation Co. Ltd", "Pierrot", "Pine Jam", "Platinum Vision", "Polygon Pictures", "Pony Canyon", "Production +h.", "Production I.G", "Production IMS", "Production Reed", "Project No.9", "Quad", "Radix", "Revoroot", "Saetta", "SANZIGEN", "Satelight", "Science SARU", "Sentai Filmworks", "Seven Arcs", "Shaft", "Shin-Ei Animation", "Shogakukan", "Shuka", "Signal.MD", "Silver", "SILVER LINK.", "Square Enix", "Staple Entertainment", "Studio 3Hz", "Studio A-CAT", "Studio Bind", "Studio Blanc.", "Studio Chizu", "Studio Comet", "Studio Deen", "Studio Elle", "Studio Ghibli", "Studio Flad", "Studio Gokumi", "Studio Guts", "Studio Hibari", "Studio Kafka", "Studio Kai", "Studio Mir", "studio MOTHER", "Studio Palette", "Studio Rikka", "Studio Signpost", "Studio VOLN", "STUDIO4\\u00b0C", "Sunrise Beyond", "Sunrise", "SynergySP", "Tatsunoko Production", "Telecom Animation Film", "Tezuka Productions", "TMS Entertainment", "TNK", "Toei Animation", "Topcraft", "Triangle Staff", "Trigger", "TROYCA", "TYO Animations", "Typhoon Graphics", "ufotable", "V1 Studio", "W-Toon Studio", "Wawayu Animation", "White Fox", "Wit Studio", "Wolfsbane", "Xebec", "Yokohama Animation Lab", "Yostar Pictures", "Yumeta Company", "Zero-G", "Zexcs", "3 Arts Entertainment", "6th & Idaho", "20th Century Animation", "20th Century Studios", "20th Century Fox Television", "21 Laps Entertainment", "87Eleven", "87North Productions", "101 Studios", "1492 Pictures", "A Bigger Boat", "A+E Studios", "A24", "Aardman", "Aamir Khan Productions", "ABC Signature", "ABC Studios", "Ace Entertainment", "AGBO", "Amazon Studios", "Amblin Entertainment", "AMC Studios", "Anima Sola Productions", "Annapurna Pictures", "Ardustry Entertainment", "Artisan Entertainment", "Artists First", "Atlas Entertainment", "Atresmedia", "Bad Hat Harry Productions", "Bad Robot", "Bad Wolf", "Barunson E&A", "Bakken Record", "Bardel Entertainment", "BBC Studios", "Bill Melendez Productions", "Blade", "Bleecker Street", "Blown Deadline Productions", "Blue Ice Pictures", "Blue Sky Studios", "Bluegrass Films", "Blueprint Pictures", "Blumhouse Productions", "Blur Studio", "Bold Films", "Bona Film Group", "Bonanza Productions", "Boo Pictures", "Bosque Ranch Productions", "Box to Box Films", "Brandywine Productions", "Broken Lizard Industries", "Broken Road Productions", "Calt Production", "Canal+", "Carnival Films", "Carolco", "Cartoon Saloon", "Carsey-Werner Company", "Castle Rock Entertainment", "CBS Productions", "CBS Studios", "CBS Television Studios", "Centropolis Entertainment", "Chernin Entertainment", "Chimp Television", "Chris Morgan Productions", "Cinergi Pictures Entertainment", "Codeblack Entertainment", "Columbia Pictures", "Constantin Film", "Cowboy Films", "Cross Creek Pictures", "Dark Horse Entertainment", "Davis Entertainment", "DC Comics", "Dimension Films", "Dino De Laurentiis Company", "Disney Television Animation", "DisneyToon Studios", "Don Simpson Jerry Bruckheimer Films", "Doozer", "Dreams Salon Entertainment Culture", "DreamWorks Studios", "DreamWorks Pictures", "Dropout", "Dynamic Planning", "Eleventh Hour Films", "EMJAG Productions", "Endeavor Content", "Entertainment 360", "Entertainment One", "Eon Productions", "Everest Entertainment", "Expectation Entertainment", "Exposure Labs", "Fandango", "Fields Entertainment", "Film4 Productions", "FilmDistrict", "FilmNation Entertainment", "Flynn Picture Company", "Focus Features", "Food Network", "Fortiche Production", "Fox Television Studios", "Freckle Films", "Frederator Studios", "FremantleMedia", "Fuqua Films", "Gallagher Films Ltd", "Gary Sanchez Productions", "Gaumont", "Generator Entertainment", "Golden Harvest", "Gracie Films", "Green Hat Films", "Grindstone Entertainment Group", "Hallmark", "HandMade Films", "Happy Madison Productions", "HartBeat Productions", "Hartswood Films", "Hasbro", "HBO", "Heyday Films", "Hughes Entertainment", "Hungry Man", "Hurwitz & Schlossberg Productions", "Hyperobject Industries", "Icon Entertainment International", "IFC Films", "Illumination Entertainment", "Imagin", "Imperative Entertainment", "Impossible Factual", "Ingenious Media", "Irwin Entertainment", "Jerry Bruckheimer Films", "Jessie Films", "Jinks-Cohen Company", "Kazak Productions", "Kennedy Miller Productions", "Kilter Films", "Kjam Media", "Kudos", "Kurtzman Orci", "Laika Entertainment", "Landscape Entertainment", "Laura Ziskin Productions", "Leftfield Pictures", "Legendary Pictures", "Let's Not Turn This Into a Whole Big Production", "Lifetime", "Levity Entertainment Group", "Lightstorm Entertainment", "Likely Story", "Lionsgate", "Live Entertainment", "Lord Miller Productions", "Lucasfilm Ltd", "Magic Light Pictures", "Magnolia Pictures", "Malevolent Films", "Mandalay Entertainment", "Mandarin", "Mandarin Motion Pictures Limited", "Marv Films", "Marvel Animation", "Marvel Studios", "Matt Tolmach Productions", "Maximum Effort", "Media Res", "Metro-Goldwyn-Mayer", "Michael Patrick King Productions", "Millennium Films", "Miramax", "NEON", "Netflix", "New Line Cinema", "Nickelodeon Animation Studio", "NorthSouth Productions", "Nu Boyana Film Studios", "O2 Filmes", "Open Road Films", "Original Film", "Orion Pictures", "Palomar", "Paramount Animation", "Paramount Pictures", "Paramount Television Studios", "Participant", "Phoenix Pictures", "Piki Films", "Pixar", "Plan B Entertainment", "PlayStation Productions", "Playtone", "Plum Pictures", "Powerhouse Animation Studios", "PRA", "Prescience", "Prospect Park", "Pulse Films", "Radar Pictures", "RadicalMedia", "Railsplitter Pictures", "Rankin Bass Productions", "RatPac Entertainment", "Red Dog Culture House", "Regency Pictures", "Reveille Productions", "Rip Cord Productions", "RocketScience", "Savoy Pictures", "Scenic Labs", "Scion Films", "Scott Free Productions", "Sculptor Media", "Screen Gems", "Sean Daniel Company", "Searchlight Pictures", "Secret Hideout", "See-Saw Films", "Serendipity Pictures", "Shaw Brothers", "Show East", "Showtime Networks", "Sil-Metropole Organisation", "Silverback Films", "Siren Pictures", "SISTER", "Sixteen String Jack Productions", "SKA Films", "Sky studios", "Skydance", "Sony Pictures Animation", "Sony Pictures", "Sph\\u00e8re M\\u00e9dia Plus", "Spyglass Entertainment", "St\\u00f6\\u00f0 2", "Star Thrower Entertainment", "Stark Raving Black Productions", "StudioCanal", "Studio 8", "Studio Babelsberg", "Studio Dragon", "Studio Live", "STX Entertainment", "Summit Entertainment", "Syfy", "Syncopy", "T-Street Productions", "Tall Ship Productions", "Team Downey", "Temple Street Productions", "The Cat in the Hat Productions", "The Donners' Company", "The Jim Henson Company", "The Kennedy-Marshall Company", "The Linson Company", "The Littlefield Company", "The Mark Gordon Company", "The Sea Change Project", "The Stone Quarry", "The Weinstein Company", "Tim Burton Productions", "TOHO", "Thunder Road", "Titmouse", "Tomorrow Studios", "Touchstone Pictures", "Touchstone Television", "Trademark Films", "Triage Entertainment", "Tribeca Productions", "TriStar Pictures", "TSG Entertainment", "Twisted Pictures", "UCP", "United Artists", "Universal Animation Studios", "Universal Pictures", "Universal Television", "Vancouver Media", "Vertigo Entertainment", "Village Roadshow Pictures", "W. Chump and Sons", "Walden Media", "Walt Disney Animation Studios", "Walt Disney Pictures", "Walt Disney Productions", "Warner Animation Group", "Warner Bros. Pictures", "Warner Bros. Television", "Warner Premiere", "warparty", "Waverly Films", "Wayfare Entertainment", "Williams Street", "Whitaker Entertainment", "Wiedemann & Berg Television", "Winkler Films", "Wolf Entertainment", "Working Title Films"]`).map(value => String(value))
 const networkCollectionKeys = JSON.parse(`["#0", 5, "7mate", "ABC", "ABC Family", "ABC Kids", "ABC TV", "ABS-CBN", "Acorn TV", "Adult Swim", "AHC", "ALTBalaji", "Amazon Kids+", "AMC", "AMC+", "Animal Planet", "ANIMAX", "Angel Studios", "Antena 3", "Apple TV", "ARD", "Arte", "Atresplayer Premium", "Atres Player", "AT-X", "Audience", "AXN", "Azteca Uno", "A&E", "BBC America", "BBC Four", "BBC iPlayer", "BBC One", "BBC Scotland", "BBC Three", "BBC Two", "BET", "BET+", "bilibili", "Binge", "BluTV", "Boomerang", "Bravo", "BritBox", "C More", "Canale 5", "Canal+", "Cartoon Network", "Cartoonito", "CBC", "CBC Television", "Cbeebies", "CBS", "Channel 3", "Channel 4", "CHCH-DT", "Cinemax", "Citytv", "CNN", "Comedy Central", "Cooking Channel", "Crackle", "Crave", "Criterion Channel", "Crunchyroll", "CTV", "Cuatro", "Curiosity Stream", "DC Universe", "Discovery", "Discovery Kids", "discovery+", "Disney Channel", "Disney Junior", "Disney XD", "Disney+", "DR1", "Dropout", "Elisa Viihde", "Elisa Viihde Viaplay", "ENA", "Epix", "ESPN", "EXXEN", "E!", "E4", "Facebook Watch", "Family Channel", "Ficci\\u00f3n Producciones", "Flooxer", "Food Network", "FOX", "Fox Kids", "France 2", "Freeform", "Freevee", "Fuji TV", "funnyordie.com", "FX", "FXX", "GA\\u0130N", "Game Show Network", "Global TV", "Globoplay", "GMA Network", "Hallmark", "HBO", "HBO Max", "HGTV", "History", "HOT3", "Hulu", "ICTV", "IFC", "IMDb TV", "Investigation Discovery", "ION Television", "iQiyi", "ITV", "ITV Encore", "ITV1", "ITV2", "ITV3", "ITV4", "ITVBe", "ITVX", "JioCinema", "joyn", "JTBC", "Kan 11", "Kanal 5", "KBS2", "Kids WB", "La 1", "La Une", "Las Estrellas", "Lifetime", "Lionsgate+", "Logo", "Magnolia Network", "MasterClass", "MBC", "MBN", "MGM+", "mitele", "Movistar Plus+", "MTV", "M-Net", "National Geographic", "NBC", "Netflix", "Network 10", "NFL Network", "NHK", "Nick", "Nick Jr", "Nickelodeon", "Nicktoons", "Nine Network", "Nippon TV", "NRK1", "OCS City", "OCS Max", "ORF", "Oxygen", "Pantaya", "Paramount Network", "Paramount+", "PBS", "PBS Kids", "Peacock", "Plan\\u00e8te+ A&E", "Prime Video", "Quibi", "Rai 1", "Reelz", "RT\\u00c9 One", "RTL", "RTL T\\u00e9l\\u00e9", "RTP1", "R\\u00daV", "S4C", "SAT.1", "SBS", "Science", "Seeso", "Seven Network", "Shahid", "Showcase", "Showmax", "Showtime", "Shudder", "Sky", "Smithsonian", "Space", "Spectrum", "Spike", "St\\u00f6\\u00f0 2", "Stan", "Starz", "STAR+", "Sundance TV", "SVT", "SVT Play", "SVT1", "Syfy", "Syndication", "TBS", "Telecinco", "Telefe", "Telemundo", "Televisi\\u00f3n de Galicia", "Televisi\\u00f3n P\\u00fablica Argentina", "Tencent Video", "TF1", "The CW", "The Daily Wire", "The Roku Channel", "The WB", "TLC", "TNT", "Tokyo MX", "Travel Channel", "truTV", "tubi", "Turner Classic Movies", "TV 2", "tv asahi", "TV Globo", "TV Land", "TV Tokyo", "TV3", "TV4", "TV4 Play", "TVB Jade", "tving", "tvN", "TVNZ 1", "TVNZ 2", "TVP1", "U", "U&Alibi", "U&Dave", "U&Drama", "U&Eden", "U&Gold", "U&W", "U&Yesterday", "UniM\\u00e1s", "Universal Kids", "Universal TV", "Univision", "UPN", "USA Network", "U+ Mobile TV", "VH1", "Viaplay", "Vice", "Virgin Media One", "ViuTV", "ViX+", "VRT 1", "VRT Max", "VTM", "W", "WE tv", "Xbox Live", "YLE", "Youku", "YouTube", "ZDF", "ZEE5"]`).map(value => String(value))
-/* eslint-enable quotes */
-
 const templateStringListPresetConfigs = {
   generic_text: {
     duplicateInsensitive: false,
@@ -5377,6 +5374,8 @@ function mountCard (card, libraryId) {
   wireCollectionTemplateSections(card)
   wireOverlayVariableSections(card)
   wireCollectionVariableSections(card)
+  wireLibraryOverrideScopes(card)
+  wireOffsetReset(card)
   if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
     OverlayHandler.initializeOverlayBoards(card)
   }
@@ -5403,6 +5402,37 @@ function mountCard (card, libraryId) {
   wireFontPickerButtons(card)
   bindDependencyRequirementHintLiveRefresh(card)
   scheduleDependencyRequirementHintRefresh(0)
+}
+
+function fetchLibraryFragment (libraryId, attempt = 0) {
+  return fetch(`/library_fragment/${encodeURIComponent(libraryId)}`, {
+    credentials: 'same-origin'
+  })
+    .then(res => {
+      if (!res.ok) {
+        throw new Error(`Failed to load library ${libraryId} (${res.status})`)
+      }
+      return res.text()
+    })
+    .catch(err => {
+      if (attempt < 1) {
+        return new Promise(resolve => window.setTimeout(resolve, 250))
+          .then(() => fetchLibraryFragment(libraryId, attempt + 1))
+      }
+      throw err
+    })
+}
+
+function restorePreviousLibrarySelection (previousLibraryId) {
+  if (libraryPicker && previousLibraryId) {
+    libraryPicker.value = previousLibraryId
+  }
+  if (!libraryContainer.firstElementChild && previousLibraryId) {
+    const previousCard = libraryCache.querySelector(`[data-library-id="${previousLibraryId}"]`)
+    if (previousCard) {
+      mountCard(previousCard, previousLibraryId)
+    }
+  }
 }
 
 wireFontPickerModal()
@@ -5458,7 +5488,7 @@ function buildPayloadFromCard (card) {
     })
   }
   card.querySelectorAll('input.playlist-library-toggle[type="checkbox"][name]:disabled').forEach(el => {
-    payload[el.name] = 'false'
+    payload[el.name] = el.checked ? (el.value || 'true') : 'false'
   })
   return payload
 }
@@ -5784,28 +5814,23 @@ function loadLibrary (libraryId, context = 'switch') {
       if (requestId !== loadRequestId) return
 
       if (!libraryId) {
+        moveCurrentToCache()
         libraryContainer.replaceChildren()
         activeLibraryId = null
         setLoading(false)
         return
       }
 
-      // Move currently active card to cache (to preserve state/inputs)
-      moveCurrentToCache()
-
       const cached = libraryCache.querySelector(`[data-library-id="${libraryId}"]`)
       if (cached) {
         if (requestId !== loadRequestId) return
+        moveCurrentToCache()
         mountCard(cached, libraryId)
         setLoading(false)
         return
       }
 
-      fetch(`/library_fragment/${encodeURIComponent(libraryId)}`)
-        .then(res => {
-          if (!res.ok) throw new Error(`Failed to load library ${libraryId}`)
-          return res.text()
-        })
+      fetchLibraryFragment(libraryId)
         .then(html => {
           if (requestId !== loadRequestId) return
           const parser = new DOMParser()
@@ -5813,19 +5838,23 @@ function loadLibrary (libraryId, context = 'switch') {
           const parsedCard = doc.body.firstElementChild
           const card = parsedCard ? document.importNode(parsedCard, true) : null
           if (!card) throw new Error('Empty fragment response')
+          moveCurrentToCache()
           mountCard(card, libraryId)
           setLoading(false)
         })
         .catch(err => {
-          console.error(err)
+          if (requestId !== loadRequestId) return
+          console.error('[Libraries] Failed to load library fragment', err)
+          restorePreviousLibrarySelection(previousLibraryId)
+          if (typeof showToast === 'function') {
+            showToast('error', 'Unable to load that library. Your current library stayed open; try again.')
+          }
           setLoading(false)
         })
     })
     .catch(() => {
       if (requestId !== loadRequestId) return
-      if (libraryPicker && previousLibraryId) {
-        libraryPicker.value = previousLibraryId
-      }
+      restorePreviousLibrarySelection(previousLibraryId)
       setLoading(false)
     })
 }
@@ -6638,8 +6667,11 @@ async function runCollectionGroupReset (btn, group) {
         if (changed) input.value = defaultValue
       }
 
-      if (changed && shouldDispatchCollectionChange(input)) {
-        pendingChangeInputs.add(input)
+      if (changed) {
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+        if (shouldDispatchCollectionChange(input)) {
+          pendingChangeInputs.add(input)
+        }
       }
 
       if (index > 0 && index % 30 === 0) {
@@ -6702,6 +6734,22 @@ function wireOffsetReset (scope) {
             console.error('[overlay section reset failed]', error)
             if (typeof showToast === 'function') {
               showToast('error', 'Overlay section reset to defaults failed.')
+            }
+          })
+          return
+        }
+      }
+
+      if (btn.dataset.libraryOverrideReset === 'true') {
+        const section = btn.closest('[data-library-override-scope="true"]')
+        const sectionBody = getDirectAccordionBody(section)
+        if (sectionBody) {
+          runCollectionGroupReset(btn, sectionBody).then(() => {
+            refreshTemplateOverrideState(section.closest('.library-settings-card') || section)
+          }).catch(error => {
+            console.error('[library override reset failed]', error)
+            if (typeof showToast === 'function') {
+              showToast('error', 'Section reset to defaults failed.')
             }
           })
           return
@@ -6991,23 +7039,9 @@ function setupParentChildToggleVisibility (scope) {
         }
       })
       let parentChecked = parentToggle.checked
-      const wasChecked = parentToggle.dataset.wasChecked === 'true'
 
       if (!parentChecked) {
-        childrenToggles.forEach(child => {
-          child.dataset.lastChecked = child.checked ? 'true' : 'false'
-          child.checked = false
-          syncChildHidden(child)
-        })
-      } else if (parentChecked && !wasChecked) {
-        childrenToggles.forEach(child => {
-          if (child.dataset.lastChecked !== undefined) {
-            child.checked = child.dataset.lastChecked === 'true'
-          } else {
-            child.checked = child.dataset.initialChecked === 'true'
-          }
-          syncChildHidden(child)
-        })
+        childrenToggles.forEach(child => syncChildHidden(child))
       } else {
         childrenToggles.forEach(child => syncChildHidden(child))
       }
@@ -7639,6 +7673,7 @@ function isInternalTemplateMetadataField (field) {
   const name = String(field.name || '').trim()
   return field.dataset?.skipOverrideCount === 'true' ||
     field.dataset?.templateMetadata === 'lookup-labels' ||
+    name.endsWith('_hidden') ||
     name.endsWith('__lookup_labels')
 }
 
@@ -7704,17 +7739,13 @@ function findTemplateVariableFieldRow (field) {
     '[data-collection-field-wrapper], ' +
     '.rgba-group, ' +
     '.font-row, ' +
-    '.input-group, ' +
-    '.form-check'
+    '.input-group'
   )
 }
 
 function updateTemplateVariableFieldOverrideStates (body, fieldsByName) {
   if (!body) return
-  body.querySelectorAll('.template-variable-field-has-override').forEach(row => {
-    row.classList.remove('template-variable-field-has-override')
-    row.removeAttribute('data-template-variable-field-override')
-  })
+  clearTemplateVariableFieldOverrideStates(body)
 
   fieldsByName.forEach(fields => {
     if (!isCollectionSectionFieldConfigured(fields)) return
@@ -7725,6 +7756,21 @@ function updateTemplateVariableFieldOverrideStates (body, fieldsByName) {
       row.classList.add('template-variable-field-has-override')
       row.dataset.templateVariableFieldOverride = 'true'
     })
+  })
+}
+
+function clearTemplateVariableFieldOverrideStates (scope) {
+  if (!scope) return
+  const rows = []
+  if (scope.classList?.contains('template-variable-field-has-override')) {
+    rows.push(scope)
+  }
+  scope.querySelectorAll?.('.template-variable-field-has-override').forEach(row => {
+    rows.push(row)
+  })
+  rows.forEach(row => {
+    row.classList.remove('template-variable-field-has-override')
+    row.removeAttribute('data-template-variable-field-override')
   })
 }
 
@@ -7794,11 +7840,101 @@ function updateTemplateGroupOverrideSummary (section) {
 
 function refreshTemplateOverrideState (scope) {
   const root = scope || document
+  clearTemplateVariableFieldOverrideStates(root)
   root.querySelectorAll('[data-collection-variable-section="true"]').forEach(section => {
     updateCollectionVariableSectionSummary(section)
   })
   root.querySelectorAll('[data-overlay-variable-section="true"]').forEach(section => {
     updateOverlayVariableSectionSummary(section)
+  })
+  getLibraryOverrideScopes(root).forEach(section => {
+    updateLibraryOverrideScopeSummary(section)
+  })
+}
+
+function getLibraryOverrideScopes (root) {
+  if (!root) return []
+  const scopes = []
+  if (root.matches?.('[data-library-override-scope="true"]')) {
+    scopes.push(root)
+  }
+  root.querySelectorAll?.('[data-library-override-scope="true"]').forEach(section => {
+    scopes.push(section)
+  })
+  return scopes
+}
+
+function getDirectAccordionHeader (scope) {
+  const item = scope?.closest('.accordion-item')
+  if (!item) return null
+  return Array.from(item.children).find(child => child.classList?.contains('accordion-header')) || item.querySelector(':scope > .accordion-header')
+}
+
+function getDirectAccordionBody (scope) {
+  if (!scope) return null
+  return Array.from(scope.children).find(child => child.classList?.contains('accordion-body')) || scope.querySelector(':scope > .accordion-body') || scope
+}
+
+function getLibraryOverrideScopeFields (scope) {
+  const body = getDirectAccordionBody(scope)
+  const fieldsByName = new Map()
+  if (!body) return fieldsByName
+  body.querySelectorAll('[name]').forEach(field => {
+    if (!field || field.disabled) return
+    if (isInternalTemplateMetadataField(field)) return
+    const name = String(field.name || '').trim()
+    if (!name) return
+    if (!fieldsByName.has(name)) fieldsByName.set(name, [])
+    fieldsByName.get(name).push(field)
+  })
+  return fieldsByName
+}
+
+function ensureLibraryOverrideResetButton (scope) {
+  const body = getDirectAccordionBody(scope)
+  if (!body || body.dataset.libraryOverrideResetPrepared === 'true') return
+  const label = scope.dataset.libraryOverrideLabel || getDirectAccordionHeader(scope)?.textContent?.trim() || 'Section'
+  const actions = document.createElement('div')
+  actions.className = 'd-flex justify-content-end mb-2'
+  actions.dataset.libraryOverrideResetActions = 'true'
+  actions.innerHTML = `
+    <button type="button" class="btn btn-outline-secondary btn-sm reset-offset-btn" data-library-override-reset="true">
+      Reset ${label}
+    </button>
+  `
+  body.prepend(actions)
+  body.dataset.libraryOverrideResetPrepared = 'true'
+}
+
+function updateLibraryOverrideScopeSummary (scope) {
+  if (!scope) return
+  const fieldsByName = getLibraryOverrideScopeFields(scope)
+  let configuredCount = 0
+  fieldsByName.forEach(fields => {
+    if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
+  })
+
+  const body = getDirectAccordionBody(scope)
+  updateTemplateVariableFieldOverrideStates(body, fieldsByName)
+
+  scope.dataset.overrideCount = String(configuredCount)
+  const item = scope.closest('.accordion-item')
+  const header = getDirectAccordionHeader(scope)
+  item?.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
+  header?.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
+  setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), configuredCount)
+}
+
+function wireLibraryOverrideScopes (scope) {
+  const root = scope || document
+  getLibraryOverrideScopes(root).forEach(section => {
+    if (section.dataset.libraryOverrideScopeBound === 'true') return
+    ensureLibraryOverrideResetButton(section)
+    const refresh = () => updateLibraryOverrideScopeSummary(section)
+    section.addEventListener('input', refresh)
+    section.addEventListener('change', refresh)
+    refresh()
+    section.dataset.libraryOverrideScopeBound = 'true'
   })
 }
 

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -3115,10 +3115,10 @@ function stopReingestPolling () {
 
 function fetchReingestStatus (jobId) {
   const query = jobId ? `?job=${encodeURIComponent(jobId)}` : ''
-  fetch(`/logscan/trends/reingest/status${query}`)
+  return fetch(`/logscan/trends/reingest/status${query}`)
     .then(res => res.json().then(data => ({ ok: res.ok, data })))
     .then(({ ok, data }) => {
-      if (!ok || !data) return
+      if (!ok || !data) return data
       if (typeof window.QS_handleLogscanReingestStatus === 'function') {
         window.QS_handleLogscanReingestStatus(data)
       }
@@ -3138,12 +3138,12 @@ function fetchReingestStatus (jobId) {
           setControlsDisabled(true)
           reingestPollTimer = setInterval(() => fetchReingestStatus(reingestJobId), 1500)
         }
-        return
+        return data
       }
       if (data.status === 'complete') {
         stopReingestPolling()
         applyReingestSummary(data)
-        return
+        return data
       }
       if (data.status === 'error') {
         stopReingestPolling()
@@ -3152,9 +3152,11 @@ function fetchReingestStatus (jobId) {
         setControlsDisabled(false)
         setReingestButtonLabel(defaultReingestButtonLabel)
       }
+      return data
     })
     .catch(err => {
       console.error(err)
+      return null
     })
 }
 
@@ -3345,6 +3347,76 @@ function maybeStartAutoReingest (ingestHealth) {
     })
 }
 
+function handleRunningTrendsPayload (data) {
+  if (!data || !data.reingest_running) return false
+  const state = data.reingest || data.ingest_health || {}
+  updateProgressFromState(state)
+  startReingestPolling(state.job_id || null)
+  updateStatus('Reingest is running. Analytics will refresh when it finishes.')
+  return true
+}
+
+function fetchIngestHealth () {
+  return fetch('/logscan/trends/ingest-health')
+    .then(res => res.json().then(data => ({ ok: res.ok, status: res.status, data })))
+    .then(({ ok, status, data }) => {
+      if (!ok && status !== 202) return null
+      if (data && data.status === 'running') {
+        updateProgressFromState(data)
+        startReingestPolling(data.job_id || null)
+        return data
+      }
+      if (data && (!lastIngestState || lastIngestState.status !== 'running')) {
+        lastIngestState = data
+        renderIngestHealth(lastIngestState)
+        maybeStartAutoReingest(data)
+      }
+      return data
+    })
+    .catch(err => {
+      console.error(err)
+      return null
+    })
+}
+
+function fetchArchiveStorage () {
+  return fetch('/logscan/trends/archive-storage')
+    .then(res => res.json().then(data => ({ ok: res.ok, status: res.status, data })))
+    .then(({ ok, status, data }) => {
+      if (status === 202) return data
+      if (!ok || !data || !data.archive_storage) return data
+      latestArchiveStorage = data.archive_storage
+      renderArchiveStorageSummary(latestArchiveStorage)
+      return data
+    })
+    .catch(err => {
+      console.error(err)
+      return null
+    })
+}
+
+function fetchIncompleteRuns (safeLimit) {
+  return fetch(`/logscan/trends/incomplete-runs?limit=${encodeURIComponent(safeLimit)}`)
+    .then(res => res.json().then(data => ({ ok: res.ok, status: res.status, data })))
+    .then(({ ok, status, data }) => {
+      if (status === 202) return data
+      if (!ok || !data) return null
+      allIncompleteRuns = Array.isArray(data.incomplete_runs) ? data.incomplete_runs : []
+      allIncompleteRunsTotal = Number.isFinite(data.total_incomplete_runs) ? data.total_incomplete_runs : allIncompleteRuns.length
+      allTableRuns = allRuns.concat(allIncompleteRuns)
+      pruneSelectedRunKeys()
+      updateConfigFilter(allTableRuns)
+      updateCommandFilter(allTableRuns)
+      updateDateRangeInputs(allTableRuns, getFilterState())
+      applyFiltersAndRender()
+      return data
+    })
+    .catch(err => {
+      console.error(err)
+      return null
+    })
+}
+
 function showSectionDetails (runKey) {
   const payload = sectionDetailsByRunKey.get(runKey)
   if (!payload) return
@@ -3502,20 +3574,16 @@ function fetchRuns (options = {}) {
   const rawLimit = String(limit.value || '500').toLowerCase()
   const safeLimit = rawLimit === 'all' ? 'all' : (Number.isFinite(parseInt(rawLimit, 10)) ? parseInt(rawLimit, 10) : 500)
   if (!suppressStatus) updateStatus('Loading trends...')
-  fetch(`/logscan/trends?limit=${safeLimit}`)
+  fetch(`/logscan/trends?limit=${safeLimit}&include_archive_storage=0&include_ingest_health=0&include_incomplete=0`)
     .then(res => res.json())
     .then(data => {
+      if (handleRunningTrendsPayload(data)) return
       allRuns = Array.isArray(data.runs) ? data.runs : []
-      allIncompleteRuns = Array.isArray(data.incomplete_runs) ? data.incomplete_runs : []
-      allTableRuns = allRuns.concat(allIncompleteRuns)
+      allIncompleteRuns = []
+      allTableRuns = allRuns
       pruneSelectedRunKeys()
       allRunsTotal = Number.isFinite(data.total_runs) ? data.total_runs : allRuns.length
-      allIncompleteRunsTotal = Number.isFinite(data.total_incomplete_runs) ? data.total_incomplete_runs : allIncompleteRuns.length
-      latestArchiveStorage = data && data.archive_storage ? data.archive_storage : null
-      renderArchiveStorageSummary(latestArchiveStorage)
-      if (data && data.ingest_health && (!lastIngestState || lastIngestState.status !== 'running')) {
-        lastIngestState = data.ingest_health
-      }
+      allIncompleteRunsTotal = 0
       updateConfigFilter(allTableRuns)
       updateCommandFilter(allTableRuns)
       updateDateRangeInputs(allTableRuns, getFilterState())
@@ -3525,7 +3593,9 @@ function fetchRuns (options = {}) {
           if (!suppressStatus && (!lastIngestState || lastIngestState.status !== 'running')) {
             updateStatus(`Last updated: ${formatTimestamp(new Date().toISOString())}`)
           }
-          maybeStartAutoReingest(data && data.ingest_health)
+          fetchIncompleteRuns(safeLimit)
+          fetchArchiveStorage()
+          fetchIngestHealth()
         })
     })
     .catch(err => {
@@ -3553,8 +3623,11 @@ function fetchRuns (options = {}) {
 function refreshAnalyticsPage (options = {}) {
   const suppressStatus = Boolean(options && options.suppressStatus)
   checkMissingDownload()
-  fetchRuns({ suppressStatus })
   fetchReingestStatus()
+    .then(data => {
+      if (data && (data.status === 'running' || data.status === 'complete')) return
+      fetchRuns({ suppressStatus })
+    })
 }
 
 function getSelectedRuns () {

--- a/templates/partials/_library_playlist_files.html
+++ b/templates/partials/_library_playlist_files.html
@@ -6,7 +6,7 @@
     <div class="playlist-files-editor" data-playlist-files-editor data-library-id="{{ library.id }}">
         <div class="alert small mb-4" role="alert" data-playlist-custom-repo-status></div>
         <input type="hidden" name="playlist_files_entries" id="{{ library.id }}-playlist_files_entries"
-            value="{{ data['libraries'].get('playlist_files_entries', '[]') }}">
+            value="{{ data['libraries'].get('playlist_files_entries', '[]') }}" data-default="[]">
         <div class="playlist-files-list d-flex flex-column gap-3 mt-1" data-playlist-files-list></div>
         <div class="d-flex justify-content-between align-items-center mt-3">
             <button type="button" class="btn btn-outline-secondary btn-sm" data-add-playlist-file>

--- a/templates/partials/_library_playlist_template_variables.html
+++ b/templates/partials/_library_playlist_template_variables.html
@@ -44,7 +44,7 @@ playlist-template_variables[{{ field_key }}]
 {% set is_checked = stored_val|string|lower == 'true' %}
 <div class="form-check form-switch d-flex align-items-center mb-2">
   <input class="form-check-input template-child-toggle me-2" type="checkbox" id="{{ input_id }}"
-    name="{{ input_name }}" value="true" {% if is_checked %}checked{% endif %}>
+    name="{{ input_name }}" value="true" data-default="false" {% if is_checked %}checked{% endif %}>
   <input type="hidden" name="{{ input_name }}" value="false">
   <label class="form-check-label me-2 mb-0" for="{{ input_id }}">{{ label }}</label>
   {% if tooltip %}
@@ -90,6 +90,7 @@ playlist-template_variables[{{ field_key }}]
       {% endif %}
     </span>
     <input type="text" class="form-control" id="{{ input_id }}" name="{{ input_name }}" aria-describedby="{{ input_id }}_text"
+      data-default=""
       value="{{ playlist_text_value(field_key) }}" placeholder="{{ placeholder }}" {% if validation_preset %}data-validation-preset="{{ validation_preset }}"{% endif %}>
   </div>
 </div>
@@ -170,6 +171,7 @@ playlist-template_variables[{{ field_key }}]
       {% endif %}
     </span>
     <input type="text" class="form-control" id="{{ input_id }}" name="{{ input_name }}" aria-describedby="{{ input_id }}_text"
+      data-default=""
       value="{{ playlist_csv_value(field_key) }}" placeholder="{{ input_placeholder }}" readonly data-playlist-user-input>
     <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#{{ modal_id }}"
       {% if not user_list %}disabled{% endif %}>Select</button>

--- a/templates/partials/_library_playlists.html
+++ b/templates/partials/_library_playlists.html
@@ -5,7 +5,8 @@
       Playlists
     </button>
   </h2>
-  <div id="{{ library.id }}-playlists" class="accordion-collapse collapse">
+  <div id="{{ library.id }}-playlists" class="accordion-collapse collapse"
+    data-library-override-scope="true" data-library-override-label="Playlists">
     <div class="accordion-body">
       <div class="alert alert-info mb-3" role="alert">
         <h6><b>Playlist files</b></h6>
@@ -18,7 +19,7 @@
       <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
         <input class="form-check-input playlist-library-toggle" type="checkbox" id="{{ library.id }}-playlist"
           name="{{ library.id }}-playlist" value="true" data-include-toggle="{{ library.id }}-include"
-          {% if playlist_checked %}checked{% endif %}>
+          data-default="false" {% if playlist_checked %}checked{% endif %}>
         <label class="form-check-label mb-0" for="{{ library.id }}-playlist">
           Include {{ library.name }}
         </label>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -26,7 +26,8 @@ container_class="border rounded p-3 mb-2", number_input=None
             </button>
         </h2>
         <div id="{{ library.id }}-{{ prefix }}-body" class="accordion-collapse collapse"
-            aria-labelledby="{{ library.id }}-{{ prefix }}-header">
+            aria-labelledby="{{ library.id }}-{{ prefix }}-header"
+            data-library-override-scope="true" data-library-override-label="{{ title }}">
             <div class="accordion-body">
                 {% else %}
                 <div class="{{ container_class }}">
@@ -46,7 +47,8 @@ container_class="border rounded p-3 mb-2", number_input=None
                             <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox"
                                     id="{{ library.id }}-attribute_{{ prefix }}_{{ source }}"
-                                    name="{{ library.id }}-attribute_{{ prefix }}_{{ source }}" value="true" {% if
+                                    name="{{ library.id }}-attribute_{{ prefix }}_{{ source }}" value="true"
+                                    data-default="false" {% if
                                     data['libraries'][library.id ~ '-attribute_' ~ prefix ~ '_' ~
                                     source]|string|lower=='true' %}checked{% endif %}>
                                 <input type="hidden" name="{{ library.id }}-attribute_{{ prefix }}_{{ source }}"
@@ -86,7 +88,7 @@ container_class="border rounded p-3 mb-2", number_input=None
                                     min="{{ number_input.min | default(1) }}" {% set
                                     raw_number=data.libraries[library.id ~ '-attribute_' ~ number_input.key] %} {% set
                                     safe_number='' if raw_number in [None, 'None' ] else raw_number %}
-                                    value="{{ safe_number }}">
+                                    value="{{ safe_number }}" data-default="">
                             </div>
                         </div>
                     </div>
@@ -116,7 +118,8 @@ container_class="border rounded p-3 mb-2", number_input=None
                             <ul class="list-group mb-2" id="{{ library.id }}-attribute_{{ prefix }}_custom_list"></ul>
                             <input type="hidden" name="{{ library.id }}-attribute_{{ prefix }}_custom"
                                 id="{{ library.id }}-attribute_{{ prefix }}_custom_hidden"
-                                value="{{ data['libraries'].get(library.id ~ '-attribute_' ~ prefix ~ '_custom', '[]') }}">
+                                value="{{ data['libraries'].get(library.id ~ '-attribute_' ~ prefix ~ '_custom', '[]') }}"
+                                data-default="[]">
                         </div>
                     </div>
                     {% else %}
@@ -140,12 +143,14 @@ container_class="border rounded p-3 mb-2", number_input=None
                             <input type="date" class="form-control"
                                 id="{{ library.id }}-attribute_{{ prefix }}_custom_input"
                                 name="{{ library.id }}-attribute_{{ prefix }}_custom_string" value="{{ safe_val }}"
+                                data-default=""
                                 placeholder="{{ custom_string_placeholder | default('YYYY-MM-DD') }}">
                             {% elif val_type == "rating" %}
                             <input type="number" class="form-control rating-range"
                                 data-validate="rating"
                                 id="{{ library.id }}-attribute_{{ prefix }}_custom_input"
                                 name="{{ library.id }}-attribute_{{ prefix }}_custom_string" min="0" max="10" step="0.1"
+                                data-default=""
                                 value="{{ safe_val }}"
                                 placeholder="{{ custom_string_placeholder | default('Enter rating between 0.0 and 10.0') }}">
                             <div class="invalid-feedback">
@@ -155,12 +160,14 @@ container_class="border rounded p-3 mb-2", number_input=None
                             <input type="number" class="form-control"
                                 id="{{ library.id }}-attribute_{{ prefix }}_custom_input"
                                 name="{{ library.id }}-attribute_{{ prefix }}_custom_string" min="1" step="1"
+                                data-default=""
                                 value="{{ safe_val }}"
                                 placeholder="{{ custom_string_placeholder | default('Enter number greater than 0') }}">
                             {% else %}
                             <input type="text" class="form-control"
                                 id="{{ library.id }}-attribute_{{ prefix }}_custom_input"
                                 name="{{ library.id }}-attribute_{{ prefix }}_custom_string" value="{{ safe_val }}"
+                                data-default=""
                                 placeholder="{{ custom_string_placeholder | default('Enter custom string') }}">
                             {% endif %}
                         </div>
@@ -178,7 +185,8 @@ container_class="border rounded p-3 mb-2", number_input=None
                             </ul>
                             <input type="hidden" name="{{ library.id }}-attribute_{{ prefix }}_order"
                                 id="{{ library.id }}-attribute_{{ prefix }}_order"
-                                value='{{ data["libraries"].get(library.id ~ "-attribute_" ~ prefix ~ "_order", "[]") }}'>
+                                value='{{ data["libraries"].get(library.id ~ "-attribute_" ~ prefix ~ "_order", "[]") }}'
+                                data-default="[]">
                         </div>
                     </div>
                     {% endif %}
@@ -210,7 +218,8 @@ prefix if yml_location == "top_level" else
 %}
 <div class="{{ container_class }}">
     <div class="form-check form-switch">
-        <input class="form-check-input" type="checkbox" id="{{ full_id }}" name="{{ full_name }}" value="true" {% if
+        <input class="form-check-input" type="checkbox" id="{{ full_id }}" name="{{ full_name }}" value="true"
+            data-default="false" {% if
             data.libraries[full_name]|string|lower=='true' %}checked{% endif %}>
         <input type="hidden" name="{{ full_name }}_hidden" value="false">
         <label class="form-check-label" for="{{ full_id }}">
@@ -237,7 +246,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
         </button>
     </h2>
     <div id="{{ library.id }}-{{ prefix }}-body" class="accordion-collapse collapse"
-        aria-labelledby="{{ library.id }}-{{ prefix }}-header">
+        aria-labelledby="{{ library.id }}-{{ prefix }}-header"
+        data-library-override-scope="true" data-library-override-label="{{ title }}">
         <div class="accordion-body">
             {% else %}
             <div class="{{ container_class }}">
@@ -257,7 +267,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox"
                                 id="{{ library.id }}-attribute_{{ toggle_id }}"
-                                name="{{ library.id }}-attribute_{{ toggle_id }}" value="true" {% if
+                                name="{{ library.id }}-attribute_{{ toggle_id }}" value="true" data-default="false" {% if
                                 data['libraries'][library.id ~ '-attribute_' ~ toggle_id]|string|lower=='true'
                                 %}checked{% endif %}>
                             <input type="hidden" name="{{ library.id }}-attribute_{{ toggle_id }}" value="false">
@@ -315,6 +325,7 @@ prefix if yml_location == "top_level" else
                     </span>
                 </span>
                 <select class="form-select" id="{{ field_id }}" {% if not disable_for_plex_pass %}name="{{ field_name }}"{% endif %}
+                    data-default=""
                     aria-describedby="{{ field_id }}_text" {% if preview_image %}data-preview="true" {% endif %}{% if disable_for_plex_pass %} disabled aria-disabled="true"{% endif %}>
                     {% for value, label in options %}
                     <option value="{{ value }}" {% if selected==value %}selected{% endif %}>{{ label }}</option>
@@ -480,7 +491,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
         <div class="col-md-6 mb-2">
             <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" id="{{ library.id }}-attribute_{{ toggle.key }}"
-                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true" {% if data.libraries[library.id
+                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true" data-default="false" {% if data.libraries[library.id
                     ~ '-attribute_' ~ toggle.key]|string|lower=='true' %}checked{% endif %}>
                 <input type="hidden" name="{{ library.id }}-attribute_{{ toggle.key }}" value="false">
                 <label class="form-check-label" for="{{ library.id }}-attribute_{{ toggle.key }}">
@@ -512,7 +523,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                 <input type="number" class="form-control" id="{{ library.id }}-attribute_{{ number_input.key }}"
                     name="{{ library.id }}-attribute_{{ number_input.key }}" min="{{ number_input.min | default(1) }}"
                     {% set raw_number=data.libraries[library.id ~ '-attribute_' ~ number_input.key] %} {% set
-                    safe_number='' if raw_number in [None, 'None' ] else raw_number %} value="{{ safe_number }}">
+                    safe_number='' if raw_number in [None, 'None' ] else raw_number %} value="{{ safe_number }}"
+                    data-default="">
             </div>
         </div>
     </div>
@@ -544,7 +556,8 @@ tooltip_variant='info', container_class='border rounded p-3 mb-2') %}
             </button>
         </h2>
         <div id="{{ library.id }}-{{ prefix }}-body" class="accordion-collapse collapse"
-            aria-labelledby="{{ library.id }}-{{ prefix }}-header">
+            aria-labelledby="{{ library.id }}-{{ prefix }}-header"
+            data-library-override-scope="true" data-library-override-label="{{ title }}">
             <div class="accordion-body">
                 {% else %}
                 <div class="{{ container_class }}">
@@ -564,7 +577,8 @@ tooltip_variant='info', container_class='border rounded p-3 mb-2') %}
                             <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox"
                                     id="{{ library.id }}-attribute_{{ toggle.key }}"
-                                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true" {% if
+                                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true"
+                                    data-default="false" {% if
                                     data.libraries[library.id ~ '-attribute_' ~ toggle.key]|string|lower=='true'
                                     %}checked{% endif %}>
                                 <input type="hidden" name="{{ library.id }}-attribute_{{ toggle.key }}" value="false">
@@ -599,7 +613,7 @@ tooltip_variant='info', container_class='border rounded p-3 mb-2') %}
                                     min="{{ number_input.min | default(1) }}" {% set
                                     raw_number=data.libraries[library.id ~ '-attribute_' ~ number_input.key] %} {% set
                                     safe_number='' if raw_number in [None, 'None' ] else raw_number %}
-                                    value="{{ safe_number }}"
+                                    value="{{ safe_number }}" data-default=""
                                     aria-describedby="{{ library.id }}-attribute_{{ number_input.key }}_text">
                             </div>
                         </div>
@@ -610,7 +624,8 @@ tooltip_variant='info', container_class='border rounded p-3 mb-2') %}
                             <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox"
                                     id="{{ library.id }}-attribute_{{ toggle.key }}"
-                                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true" {% if
+                                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true"
+                                    data-default="false" {% if
                                     data.libraries[library.id ~ '-attribute_' ~ toggle.key]|string|lower=='true'
                                     %}checked{% endif %}>
                                 <input type="hidden" name="{{ library.id }}-attribute_{{ toggle.key }}" value="false">
@@ -674,7 +689,8 @@ select_input.key if yml_location == "top_level" else
             </button>
         </h2>
         <div id="{{ library.id }}-{{ prefix }}-body" class="accordion-collapse collapse"
-            aria-labelledby="{{ library.id }}-{{ prefix }}-header">
+            aria-labelledby="{{ library.id }}-{{ prefix }}-header"
+            data-library-override-scope="true" data-library-override-label="{{ title }}">
             <div class="accordion-body">
                 {% else %}
                 <div class="{{ container_class }}">
@@ -702,7 +718,7 @@ select_input.key if yml_location == "top_level" else
                         <div class="col-md-6 mb-2">
                             <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox" id="{{ toggle_id }}"
-                                    name="{{ toggle_name }}" value="true" {% if
+                                    name="{{ toggle_name }}" value="true" data-default="false" {% if
                                     data.libraries[toggle_name]|string|lower=='true' %}checked{% endif %}>
                                 <input type="hidden" name="{{ toggle_name }}" value="false">
                                 <label class="form-check-label" for="{{ toggle_id }}">
@@ -731,6 +747,7 @@ select_input.key if yml_location == "top_level" else
                                     </span>
                                 </span>
                                 <select class="form-select" id="{{ select_id }}" name="{{ select_name }}"
+                                    data-default=""
                                     aria-describedby="{{ select_id }}_label">
                                     {% set selected = data.libraries.get(select_name, '') %}
                                     {% for value, label in select_input.options %}
@@ -777,7 +794,8 @@ select_input.key if yml_location == "top_level" else
             </button>
         </h2>
         <div id="{{ library.id }}-{{ section.prefix }}-body" class="accordion-collapse collapse"
-            aria-labelledby="{{ library.id }}-{{ section.prefix }}-header">
+            aria-labelledby="{{ library.id }}-{{ section.prefix }}-header"
+            data-library-override-scope="true" data-library-override-label="{{ section.title }}">
             <div class="accordion-body">
                 {% else %}
                 <div class="{{ section.container_class }}">
@@ -798,6 +816,7 @@ select_input.key if yml_location == "top_level" else
                                 id="{{ library.id }}-attribute_{{ section.prefix }}_path"
                                 name="{{ library.id }}-attribute_{{ section.prefix }}_path"
                                 value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix ~ '_path'] | default('') }}"
+                                data-default=""
                                 placeholder="{{ section.text_input.placeholder }}">
                         </div>
                     </div>
@@ -823,7 +842,8 @@ select_input.key if yml_location == "top_level" else
                             <ul class="list-group mb-2" id="{{ library.id }}-{{ section.prefix }}_custom_list"></ul>
                             <input type="hidden" name="{{ library.id }}-attribute_{{ section.prefix }}_exclude"
                                 id="{{ library.id }}-{{ section.prefix }}_custom_hidden"
-                                value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix ~ '_exclude'] | default('[]') }}">
+                                value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix ~ '_exclude'] | default('[]') }}"
+                                data-default="[]">
                         </div>
                     </div>
 
@@ -834,7 +854,8 @@ select_input.key if yml_location == "top_level" else
                             <div class="form-check form-switch">
                                 <input class="form-check-input" type="checkbox"
                                     id="{{ library.id }}-attribute_{{ toggle.key }}"
-                                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true" {% if
+                                    name="{{ library.id }}-attribute_{{ toggle.key }}" value="true"
+                                    data-default="false" {% if
                                     data.libraries[library.id ~ '-attribute_' ~ toggle.key]|string|lower=='true'
                                     %}checked{% endif %}>
                                 <input type="hidden" name="{{ library.id }}-attribute_{{ toggle.key }}" value="false">
@@ -886,7 +907,8 @@ select_input.key if yml_location == "top_level" else
             </button>
         </h2>
         <div id="{{ library.id }}-{{ section.prefix }}-body" class="accordion-collapse collapse"
-            aria-labelledby="{{ library.id }}-{{ section.prefix }}-header">
+            aria-labelledby="{{ library.id }}-{{ section.prefix }}-header"
+            data-library-override-scope="true" data-library-override-label="{{ section.title }}">
             <div class="accordion-body">
                 {% else %}
                 <div class="{{ section.container_class }}">
@@ -912,7 +934,8 @@ select_input.key if yml_location == "top_level" else
                     <ul class="list-group mb-2" id="{{ library.id }}-attribute_{{ section.prefix }}_list"></ul>
                     <input type="hidden" name="{{ library.id }}-attribute_{{ section.prefix }}"
                         id="{{ library.id }}-attribute_{{ section.prefix }}_hidden"
-                        value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix] | default('{}') }}">
+                        value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix] | default('{}') }}"
+                        data-default="{}">
 
                     {% if "accordion" in section.container_class %}
                 </div> {# .accordion-body #}
@@ -1025,7 +1048,7 @@ field_prefix ~ "_" ~ prefix if field_prefix else prefix) %}
             <input type="text" class="form-control" id="{{ full_id }}_schedule_raw" data-schedule-raw
                 placeholder="{{ placeholder }}" value="{{ field_value }}">
         </details>
-        <input type="hidden" id="{{ full_id }}" name="{{ full_name }}" value="{{ field_value }}">
+        <input type="hidden" id="{{ full_id }}" name="{{ full_name }}" value="{{ field_value }}" data-default="">
     </div>
 </div>
 {% else %}
@@ -1040,10 +1063,10 @@ field_prefix ~ "_" ~ prefix if field_prefix else prefix) %}
             </span>
         </span>
         {% if multiline %}
-        <textarea class="form-control" id="{{ full_id }}" name="{{ full_name }}"
+        <textarea class="form-control" id="{{ full_id }}" name="{{ full_name }}" data-default=""
             placeholder="{{ placeholder }}" rows="{{ rows }}">{{ field_value }}</textarea>
         {% else %}
-        <input type="text" class="form-control" id="{{ full_id }}" name="{{ full_name }}"
+        <input type="text" class="form-control" id="{{ full_id }}" name="{{ full_name }}" data-default=""
             placeholder="{{ placeholder }}" value="{{ field_value }}">
         {% endif %}
     </div>

--- a/templates/partials/_movie_attributes.html
+++ b/templates/partials/_movie_attributes.html
@@ -13,7 +13,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseSeparators" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-separatorsAccordion">
+      data-bs-parent="#{{ library.id }}-separatorsAccordion"
+      data-library-override-scope="true" data-library-override-label="Separators">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'movie' in section.media_types and
         section.accordion == 'separators' %}
@@ -49,7 +50,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseOverlays" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-overlayOperationsAccordion">
+      data-bs-parent="#{{ library.id }}-overlayOperationsAccordion"
+      data-library-override-scope="true" data-library-override-label="Overlay Operations">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'movie' in section.media_types and
         section.accordion == 'overlays' %}
@@ -126,7 +128,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseLibrary" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-libraryOperationsAccordion">
+      data-bs-parent="#{{ library.id }}-libraryOperationsAccordion"
+      data-library-override-scope="true" data-library-override-label="Library Operations">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'movie' in section.media_types and
         section.accordion == 'library' %}
@@ -269,7 +272,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseMiscellaneous" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-miscellaneousAccordion">
+      data-bs-parent="#{{ library.id }}-miscellaneousAccordion"
+      data-library-override-scope="true" data-library-override-label="Miscellaneous">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'movie' in section.media_types and section.accordion == 'miscellaneous' %}
           {% if section.type == 'select' %}

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -40,7 +40,8 @@
                     Attributes
                 </button>
             </h2>
-            <div id="{{ library.id }}-attributes" class="accordion-collapse collapse">
+            <div id="{{ library.id }}-attributes" class="accordion-collapse collapse"
+                data-library-override-scope="true" data-library-override-label="Attributes">
                 <div class="accordion-body">
                     {% include "partials/_movie_attributes.html" %}
                 </div>

--- a/templates/partials/_show_attributes.html
+++ b/templates/partials/_show_attributes.html
@@ -13,7 +13,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseSeparators" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-separatorsAccordion">
+      data-bs-parent="#{{ library.id }}-separatorsAccordion"
+      data-library-override-scope="true" data-library-override-label="Separators">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'show' in section.media_types and
         section.accordion == 'separators' %}
@@ -49,7 +50,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseOverlays" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-overlayOperationsAccordion">
+      data-bs-parent="#{{ library.id }}-overlayOperationsAccordion"
+      data-library-override-scope="true" data-library-override-label="Overlay Operations">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'show' in section.media_types and
         section.accordion == 'overlays' %}
@@ -126,7 +128,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseLibrary" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-libraryOperationsAccordion">
+      data-bs-parent="#{{ library.id }}-libraryOperationsAccordion"
+      data-library-override-scope="true" data-library-override-label="Library Operations">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'show' in section.media_types and
         section.accordion == 'library' %}
@@ -269,7 +272,8 @@
       </button>
     </h2>
     <div id="{{ library.id }}-collapseMiscellaneous" class="accordion-collapse collapse"
-      data-bs-parent="#{{ library.id }}-miscellaneousAccordion">
+      data-bs-parent="#{{ library.id }}-miscellaneousAccordion"
+      data-library-override-scope="true" data-library-override-label="Miscellaneous">
       <div class="accordion-body">
         {% for section in attribute_config.sections if section.media_types and 'show' in section.media_types and section.accordion == 'miscellaneous' %}
           {% if section.type == 'select' %}

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -40,7 +40,8 @@
                     Attributes
                 </button>
             </h2>
-            <div id="{{ library.id }}-attributes" class="accordion-collapse collapse">
+            <div id="{{ library.id }}-attributes" class="accordion-collapse collapse"
+                data-library-override-scope="true" data-library-override-label="Attributes">
                 <div class="accordion-body">
                     {% include "partials/_show_attributes.html" %}
                 </div>

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -102,6 +102,99 @@ def test_playlist_toggle_preserves_mirrored_state_when_excluded():
 
     assert "{% if playlist_checked %}checked{% endif %}" in partial
     assert "playlistToggle.checked = false" not in script
+    assert "payload[el.name] = el.checked ? (el.value || 'true') : 'false'" in script
+
+
+def test_parent_collection_toggle_does_not_clear_child_toggles():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "child.checked = false" not in script
+    assert "child.checked = child.dataset.lastChecked === 'true'" not in script
+    assert "child.checked = child.dataset.initialChecked === 'true'" not in script
+
+
+def test_library_fragment_load_failure_preserves_current_card():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    load_body = script.split("function loadLibrary (libraryId, context = 'switch')", 1)[1].split(
+        "if (libraryPicker) {\n  libraryPicker.addEventListener",
+        1,
+    )[0]
+
+    assert "function fetchLibraryFragment (libraryId, attempt = 0)" in script
+    assert "attempt < 1" in script
+    assert "credentials: 'same-origin'" in script
+    assert "function restorePreviousLibrarySelection (previousLibraryId)" in script
+    assert "restorePreviousLibrarySelection(previousLibraryId)" in load_body
+
+    cached_swap = (
+        'const cached = libraryCache.querySelector(`[data-library-id="${libraryId}"]`)\n'
+        "      if (cached) {\n"
+        "        if (requestId !== loadRequestId) return\n"
+        "        moveCurrentToCache()\n"
+        "        mountCard(cached, libraryId)"
+    )
+    fetched_swap = "fetchLibraryFragment(libraryId)\n" "        .then(html => {\n" "          if (requestId !== loadRequestId) return\n" "          const parser = new DOMParser()"
+    assert cached_swap in load_body
+    assert fetched_swap in load_body
+    assert load_body.index("fetchLibraryFragment(libraryId)") < load_body.index(
+        "if (!card) throw new Error('Empty fragment response')\n" "          moveCurrentToCache()\n" "          mountCard(card, libraryId)"
+    )
+    assert "Your current library stayed open" in load_body
+
+
+def test_schedule_builder_allows_clearing_weekly_days():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "nextValue = buildValueFromInputs(mode) || ''" in script
+    assert "const nextRaw = String(hidden.value || '').trim()" in script
+    assert "nextValue = buildValueFromInputs(mode) || defaultValue || ''" not in script
+    assert "const nextRaw = String(hidden.value || defaultValue || '').trim()" not in script
+
+
+def test_attributes_and_playlists_have_override_scope_counts_and_resets():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    movie_settings = (ROOT / "templates" / "partials" / "_movie_library_settings.html").read_text(encoding="utf-8")
+    show_settings = (ROOT / "templates" / "partials" / "_show_library_settings.html").read_text(encoding="utf-8")
+    movie_attributes = (ROOT / "templates" / "partials" / "_movie_attributes.html").read_text(encoding="utf-8")
+    show_attributes = (ROOT / "templates" / "partials" / "_show_attributes.html").read_text(encoding="utf-8")
+    playlists = PLAYLIST_PARTIAL_PATH.read_text(encoding="utf-8")
+    macros = MACROS_PATH.read_text(encoding="utf-8")
+    playlist_vars = (ROOT / "templates" / "partials" / "_library_playlist_template_variables.html").read_text(encoding="utf-8")
+
+    assert "function wireLibraryOverrideScopes" in script
+    assert "function updateLibraryOverrideScopeSummary" in script
+    assert "function getLibraryOverrideScopes" in script
+    assert "function clearTemplateVariableFieldOverrideStates" in script
+    assert "clearTemplateVariableFieldOverrideStates(root)" in script
+    assert "root.matches?.('[data-library-override-scope=\"true\"]')" in script
+    assert "refreshTemplateOverrideState(section.closest('.library-settings-card') || section)" in script
+    assert 'data-library-override-reset="true"' in script
+    assert "wireLibraryOverrideScopes(card)" in script
+    assert "name.endsWith('_hidden')" in script
+
+    assert 'data-library-override-label="Attributes"' in movie_settings
+    assert 'data-library-override-label="Attributes"' in show_settings
+    assert 'data-library-override-label="Playlists"' in playlists
+    for label in ("Separators", "Overlay Operations", "Library Operations", "Miscellaneous"):
+        assert f'data-library-override-label="{label}"' in movie_attributes
+        assert f'data-library-override-label="{label}"' in show_attributes
+
+    assert 'data-default=""' in macros
+    assert 'data-default="false"' in macros
+    assert 'data-default="false"' in playlists
+    assert 'data-default="false"' in playlist_vars
+
+
+def test_analytics_page_checks_reingest_status_before_loading_trends():
+    script = (ROOT / "static" / "local-js" / "905-analytics.js").read_text(encoding="utf-8")
+
+    assert "fetchReingestStatus()\n    .then(data => {" in script
+    assert "if (data && (data.status === 'running' || data.status === 'complete')) return" in script
+    assert "fetchRuns({ suppressStatus })" in script
+    assert "/logscan/trends?limit=${safeLimit}&include_archive_storage=0&include_ingest_health=0&include_incomplete=0" in script
+    assert "fetchIncompleteRuns(safeLimit)" in script
+    assert "fetchArchiveStorage()" in script
+    assert "fetchIngestHealth()" in script
 
 
 def test_template_variable_sections_show_override_rail():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -5837,6 +5837,27 @@ def test_build_libraries_section_emits_schedule(app):
     assert list(movies.keys())[:2] == ["schedule", "template_variables"]
 
 
+def test_build_libraries_section_omits_blank_top_level_schedules(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_top_level={
+                "movies": {
+                    "mov-library_movies-top_level_schedule": "",
+                    "mov-library_movies-top_level_schedule_overlays": "",
+                }
+            },
+            movie_templates={"movies": {"mov-library_movies-template_variables[use_separator]": "gray"}},
+        )
+
+    movies = libraries_section["libraries"]["Movies"]
+    assert "schedule" not in movies
+    assert "schedule_overlays" not in movies
+    assert movies["template_variables"]["sep_style"] == "gray"
+
+
 def test_save_kometa_install_mode_persists_existing_root(client, tmp_path):
     from modules import database
 

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -110,6 +110,48 @@ def test_logscan_trends_reports_invalid_archived_log_candidates(client, isolated
     assert payload["ingest_health"]["invalid_archived_sample"] == [invalid_path.name]
 
 
+def test_logscan_trends_returns_lightweight_payload_while_reingest_runs(client, isolated_config_dir, monkeypatch, qs_module):
+    qs_module._reset_logscan_reingest_state()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-existing",
+            "finished_at": "2026-04-23T10:00:00Z",
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:00:00Z",
+        }
+    )
+    qs_module._update_logscan_reingest_state(
+        status="running",
+        job_id="job-running",
+        trigger="manual",
+        total=20,
+        scanned=7,
+        ingested=3,
+        current_file="meta-7.log.gz",
+    )
+    monkeypatch.setattr(qs_module, "_logscan_ingest_health", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("health scan should be skipped")))
+    monkeypatch.setattr(qs_module, "_build_logscan_resolution_context", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("resolution scan should be skipped")))
+    monkeypatch.setattr(qs_module, "_get_logscan_archive_storage_summary", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("archive storage should be skipped")))
+    acquired = qs_module.logscan_ingest_lock.acquire(blocking=False)
+    assert acquired is True
+    try:
+        resp = client.get("/logscan/trends")
+    finally:
+        qs_module.logscan_ingest_lock.release()
+        qs_module._reset_logscan_reingest_state()
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["reingest_running"] is True
+    assert payload["runs"] == []
+    assert payload["incomplete_runs"] == []
+    assert payload["total_runs"] == 1
+    assert payload["archive_storage"] is None
+    assert payload["ingest_health"]["source"] == "running"
+    assert payload["ingest_health"]["job_id"] == "job-running"
+    assert payload["ingest_health"]["scanned"] == 7
+
+
 def test_logscan_invalid_archived_log_delete_route_removes_only_invalid_archives(client, isolated_config_dir):
     archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "imagemaid"
     archive_dir.mkdir(parents=True, exist_ok=True)
@@ -1252,6 +1294,58 @@ def test_logscan_reingest_ingests_day_runtime_log(client, isolated_config_dir, m
     runs = qs_module.database.get_log_runs(limit=10)
     assert runs
     assert runs[0]["start_mode"] == "recovery"
+
+
+def test_logscan_reingest_flushes_ingest_cache_incrementally(isolated_config_dir, monkeypatch, qs_module):
+    class FakeAnalyzer:
+        _people_index = {}
+
+        def preload_people_index(self, *_args, **_kwargs):
+            return None
+
+        def analyze_content(self, _content, log_path=None, **_kwargs):
+            run_key = Path(log_path).stem
+            return {
+                "summary": {
+                    "run_key": run_key,
+                    "finished_at": f"2026-04-{run_key[-2:]}T10:00:00Z",
+                    "run_complete": True,
+                    "tool_name": "kometa",
+                    "created_at": f"2026-04-{run_key[-2:]}T10:00:00Z",
+                },
+                "recommendations": [],
+                "missing_people": [],
+            }
+
+        def collect_missing_people_lines(self, *_args, **_kwargs):
+            return []
+
+    log_dir = isolated_config_dir / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_files = []
+    for idx in range(qs_module.LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL + 1):
+        path = log_dir / f"meta-{idx:02d}.log"
+        path.write_text("finished run\n", encoding="utf-8")
+        log_files.append(path)
+
+    cache = {"version": 1, "logs": {}}
+    save_sizes = []
+    monkeypatch.setattr(qs_module.logscan, "LogscanAnalyzer", FakeAnalyzer)
+    monkeypatch.setattr(qs_module, "_get_logscan_log_files", lambda *_args, **_kwargs: log_files)
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: cache)
+    monkeypatch.setattr(qs_module, "_clear_logscan_ingest_cache", lambda: None)
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda payload: save_sizes.append(len(payload.get("logs", {}))))
+    monkeypatch.setattr(qs_module, "_build_completed_log_progress_snapshot", lambda **_kwargs: {})
+    monkeypatch.setattr(qs_module, "_archive_log_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module.database, "clear_log_runs", lambda: True)
+    monkeypatch.setattr(qs_module.database, "save_log_run", lambda *_args, **_kwargs: True)
+
+    result = qs_module._perform_logscan_reingest(reset=True, update_state=False)
+
+    assert result["success"] is True
+    assert result["scanned"] == len(log_files)
+    assert save_sizes[0] == qs_module.LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL
+    assert save_sizes[-1] == len(log_files)
 
 
 def test_logscan_reingest_archives_incomplete_rotated_live_log(client, isolated_config_dir, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Improve analytics reingest behavior and Libraries override UX

## Summary
- Makes analytics page loads lighter during logscan reingest by checking reingest status first and avoiding heavy trends/runs work while ingest is active.
- Adds lightweight reingest responses and lazy/heavier analytics endpoint behavior for archive storage, ingest health, incomplete runs, and recent runs.
- Hardens Libraries page fragment switching so transient `/library_fragment/...` failures do not blank or break the current library card.
- Fixes mirror behavior so mirrored playlist/content-rating child toggles remain configured while target libraries stay excluded from final YAML until users explicitly enable them.
- Fixes top-level library schedule clearing so blank `schedule` / `schedule_overlays` values are not rehydrated or emitted.
- Adds override counts and reset buttons for Attributes and Playlists accordions, including nested attribute sections.
- Cleans up stale green override indicators after reset and removes noisy toggle-row override rails.

## Testing
- `npm run lint:eslint`
- `node --check static\local-js\025-libraries.js`
- `venv\Scripts\python.exe -m pytest tests\test_collection_details_contract.py`
- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py::test_build_libraries_section_emits_schedule tests\test_core_backend.py::test_build_libraries_section_emits_schedule_overlays tests\test_core_backend.py::test_build_libraries_section_omits_blank_top_level_schedules`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
