### PR TITLE
Fix mirror of content ratings

### DIFF
--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5445,6 +5445,17 @@ function buildPayloadFromCard (card) {
       .map(el => String(el.name || '').trim())
       .filter(Boolean)
   )
+  const radioCheckboxValues = new Map()
+  card.querySelectorAll('input[type="checkbox"][name][data-radio-group="true"]').forEach(el => {
+    const name = String(el.name || '').trim()
+    if (!name || el.disabled) return
+    if (!radioCheckboxValues.has(name)) {
+      radioCheckboxValues.set(name, '')
+    }
+    if (el.checked) {
+      radioCheckboxValues.set(name, el.value || 'true')
+    }
+  })
   card.querySelectorAll('input, select, textarea').forEach(el => {
     if (!el.name || el.disabled) return
     if (el.dataset && el.dataset.skipYaml === 'true') return
@@ -5460,6 +5471,12 @@ function buildPayloadFromCard (card) {
     }
 
     if (el.type === 'checkbox') {
+      if (el.dataset && el.dataset.radioGroup === 'true') {
+        if (!Object.prototype.hasOwnProperty.call(payload, el.name)) {
+          payload[el.name] = radioCheckboxValues.get(el.name) || ''
+        }
+        return
+      }
       payload[el.name] = el.checked ? (el.value || 'true') : 'false'
       return
     }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5317,9 +5317,23 @@ function wireLibraryServiceValidationButtons (card) {
   card.dataset.libraryServiceValidationBound = 'true'
 }
 
+function setCachedCardFormSubmission (card, cached) {
+  if (!card) return
+  card.querySelectorAll('input, select, textarea').forEach(el => {
+    if (cached) {
+      el.dataset.qsCachedDisabled = el.disabled ? 'true' : 'false'
+      el.disabled = true
+    } else if (el.dataset.qsCachedDisabled !== undefined) {
+      el.disabled = el.dataset.qsCachedDisabled === 'true'
+      delete el.dataset.qsCachedDisabled
+    }
+  })
+}
+
 function moveCurrentToCache () {
   const current = libraryContainer.firstElementChild
   if (current) {
+    setCachedCardFormSubmission(current, true)
     current.style.display = 'none'
     libraryCache.appendChild(current)
   }
@@ -5327,6 +5341,7 @@ function moveCurrentToCache () {
 
 function mountCard (card, libraryId) {
   libraryContainer.replaceChildren()
+  setCachedCardFormSubmission(card, false)
   card.style.display = ''
   libraryContainer.appendChild(card)
   activeLibraryId = libraryId

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -142,6 +142,17 @@ def test_library_fragment_load_failure_preserves_current_card():
     assert "Your current library stayed open" in load_body
 
 
+def test_cached_library_cards_do_not_submit_stale_form_fields():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "function setCachedCardFormSubmission" in script
+    assert "el.dataset.qsCachedDisabled = el.disabled ? 'true' : 'false'" in script
+    assert "el.disabled = true" in script
+    assert "el.disabled = el.dataset.qsCachedDisabled === 'true'" in script
+    assert "setCachedCardFormSubmission(current, true)" in script
+    assert "setCachedCardFormSubmission(card, false)" in script
+
+
 def test_schedule_builder_allows_clearing_weekly_days():
     script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```md
## Summary
- Fixes Libraries mirror behavior for content-rating overlay selections so pseudo-radio checkbox groups preserve the selected enabled value.
- Prevents hidden cached library cards from submitting stale form fields that could unintentionally clear other configured libraries from final YAML output.
- Adds contract coverage for cached-card form submission safety.

## Testing
- `venv\Scripts\python.exe -m pytest tests\test_collection_details_contract.py::test_cached_library_cards_do_not_submit_stale_form_fields tests\test_core_backend.py::test_copy_library_settings_keeps_target_excluded_for_playlist_and_content_rating`
- `node --check static\local-js\025-libraries.js`
- `npm run lint:eslint`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
