### PR TITLE
many fixes

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -171,43 +171,345 @@ def _migrate_legacy_playlist_libraries_to_library_toggles(movie_libraries=None, 
 # --- card fragment + autosave ----------------------------------------------
 
 
-@bp.route("/library_fragment/<library_id>")
-def library_fragment(library_id):
-    """Return a single library form fragment so we can lazy-load library settings on the page."""
+def _library_fragment_context(library_id, *, include_attributes=True, include_collections=True, include_overlays=True):
     movie_libraries, show_libraries, telemetry_data = _build_library_lists()
     all_libraries = {lib["id"]: lib for lib in movie_libraries + show_libraries}
     library = all_libraries.get(library_id)
 
     if not library:
-        return jsonify({"error": "Library not found"}), 404
+        return None
 
-    attribute_config = helpers.load_quickstart_config("quickstart_attributes.json")
-    collection_config = helpers.load_quickstart_config("quickstart_collections.json")
-    overlay_config = helpers.load_quickstart_overlay_config()
+    attribute_config = helpers.load_quickstart_config("quickstart_attributes.json") if include_attributes else {}
+    collection_config = helpers.load_quickstart_config("quickstart_collections.json") if include_collections else []
+    overlay_config = helpers.load_quickstart_overlay_config() if include_overlays else []
 
     legacy_playlist_libraries = _migrate_legacy_playlist_libraries_to_library_toggles(movie_libraries, show_libraries)
     data = persistence.retrieve_settings("025-libraries")
     configured_ids = _configured_library_ids(data.get("libraries", {}))
 
-    image_data = _build_preview_image_data()
+    image_data = _build_preview_image_data() if include_overlays else {}
 
     page_info = {"telemetry": telemetry_data}
 
+    return {
+        "library": library,
+        "data": data,
+        "page_info": page_info,
+        "telemetry": telemetry_data,
+        "attribute_config": attribute_config,
+        "collection_config": collection_config,
+        "overlay_config": overlay_config,
+        "image_data": image_data,
+        "movie_images": image_data.get("movie", []),
+        "configured_ids": configured_ids,
+        "legacy_playlist_libraries": legacy_playlist_libraries,
+        "lazy_section_override_counts": _lazy_section_override_counts(library, data.get("libraries", {}), telemetry_data),
+    }
+
+
+def _coerce_loaded_library_sections(raw_value):
+    if isinstance(raw_value, list):
+        return {str(item).strip() for item in raw_value if str(item).strip()}
+    if isinstance(raw_value, tuple):
+        return {str(item).strip() for item in raw_value if str(item).strip()}
+    if isinstance(raw_value, str):
+        return {item.strip() for item in raw_value.split(",") if item.strip()}
+    return set()
+
+
+def _loaded_sections_with_payload_evidence(library_id, incoming_libraries, loaded_sections):
+    """Ignore lazy-section loaded markers when their form fields are absent.
+
+    A stale/incorrect ``__loaded_sections`` value is dangerous: autosave would
+    believe a lazy section was intentionally posted and could replace saved
+    collection/overlay selections with an incomplete payload. Raw
+    ``*_collection_files`` / ``*_overlay_files`` fields are advanced file-entry
+    controls and do not prove the heavy defaults section was loaded.
+    """
+    loaded_sections = set(loaded_sections or set())
+    if not isinstance(incoming_libraries, dict) or not library_id:
+        return loaded_sections
+
+    def has_collection_payload():
+        collection_files_key = f"{library_id}-collection_files"
+        for key in incoming_libraries:
+            if not isinstance(key, str) or not key.startswith(f"{library_id}-"):
+                continue
+            if key == collection_files_key:
+                continue
+            if f"{library_id}-collection_" in key or f"{library_id}-template_collection_" in key:
+                return True
+        return False
+
+    def has_overlay_payload():
+        overlay_files_key = f"{library_id}-overlay_files"
+        overlay_markers = (
+            f"{library_id}-overlay_",
+            f"{library_id}-movie-overlay_",
+            f"{library_id}-show-overlay_",
+            f"{library_id}-season-overlay_",
+            f"{library_id}-episode-overlay_",
+            f"{library_id}-movie-template_overlay_",
+            f"{library_id}-show-template_overlay_",
+            f"{library_id}-season-template_overlay_",
+            f"{library_id}-episode-template_overlay_",
+        )
+        for key in incoming_libraries:
+            if not isinstance(key, str) or not key.startswith(f"{library_id}-"):
+                continue
+            if key == overlay_files_key:
+                continue
+            if any(marker in key for marker in overlay_markers):
+                return True
+        return False
+
+    if "collections" in loaded_sections and not has_collection_payload():
+        loaded_sections.discard("collections")
+    if "overlays" in loaded_sections and not has_overlay_payload():
+        loaded_sections.discard("overlays")
+    return loaded_sections
+
+
+def _has_saved_value(value):
+    return value not in [None, "", [], {}, "[]", "{}"]
+
+
+def _coerce_bool(value):
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _jsonish(value, fallback):
+    if isinstance(value, (list, dict)):
+        return value
+    if value in [None, ""]:
+        return fallback
+    try:
+        import json
+
+        parsed = json.loads(str(value))
+        if isinstance(parsed, type(fallback)):
+            return parsed
+    except Exception:
+        return fallback
+    return fallback
+
+
+def _template_value_is_configured(value, default=None, field_type=""):
+    field_type = str(field_type or "").strip().lower()
+    if value is None:
+        return False
+    if field_type == "toggle" or isinstance(default, bool) or isinstance(value, bool):
+        return _coerce_bool(value) != _coerce_bool(default)
+    if field_type in {"string_list", "list"} or isinstance(default, list):
+        return _jsonish(value, []) != _jsonish(default, [])
+    if field_type in {"mapping_list", "dict", "map"} or isinstance(default, dict):
+        return _jsonish(value, {}) != _jsonish(default, {})
+    if not _has_saved_value(value):
+        return False
+    default_value = "" if default is None else str(default).strip()
+    value = str(value).strip()
+    return value != default_value if default_value else True
+
+
+def _count_collection_overrides_for_library(library, libraries_data, collection_config):
+    if not isinstance(libraries_data, dict):
+        return 0
+    library_id = library["id"]
+    library_type = library["type"]
+    count = 0
+    for group in collection_config or []:
+        for collection in group.get("collections", []):
+            if library_type not in collection.get("media_types", []):
+                continue
+            clean_id = str(collection.get("id", "")).replace("collection_", "")
+            for item in collection.get("template_variables", []) or []:
+                key = item.get("key") if isinstance(item, dict) else None
+                if not key:
+                    continue
+                media_types = item.get("media_types") or []
+                if media_types and library_type not in media_types:
+                    continue
+                if str(key).startswith("visible_") and not library.get("plex_pass", False):
+                    continue
+                field_name = f"{library_id}-template_collection_{clean_id}_{key}"
+                if _template_value_is_configured(libraries_data.get(field_name), item.get("default"), item.get("type")):
+                    count += 1
+    return count
+
+
+def _iter_overlay_template_items(template_variables):
+    if isinstance(template_variables, dict):
+        for key, details in template_variables.items():
+            if isinstance(details, dict):
+                yield key, details
+    elif isinstance(template_variables, list):
+        for item in template_variables:
+            if isinstance(item, dict):
+                key = item.get("key")
+                if key:
+                    yield key, item
+
+
+def _count_overlay_overrides_for_library(library, libraries_data, overlay_config):
+    if not isinstance(libraries_data, dict):
+        return 0
+    library_id = library["id"]
+    library_type = library["type"]
+    render_types = ["movie"] if library_type == "movie" else ["show", "season", "episode"]
+    count = 0
+    for group in overlay_config or []:
+        for overlay in group.get("overlays", []):
+            for render_type in render_types:
+                media_types = overlay.get("media_types") or []
+                if media_types and render_type not in media_types:
+                    continue
+                template_name = f"{library_id}-{render_type}-template_{overlay.get('id')}"
+                for key, details in _iter_overlay_template_items(overlay.get("template_variables")):
+                    if key == "builder_level":
+                        continue
+                    var_media_types = details.get("media_types") or []
+                    if var_media_types and render_type not in var_media_types:
+                        continue
+                    field_name = f"{template_name}[{key}]"
+                    if _template_value_is_configured(libraries_data.get(field_name), details.get("default"), details.get("input_type")):
+                        count += 1
+    return count
+
+
+def _lazy_section_override_counts(library, libraries_data, telemetry_data=None):
+    library_with_plex = dict(library)
+    # Collection visibility for visible_* variables depends on Plex Pass.
+    telemetry_data = telemetry_data if isinstance(telemetry_data, dict) else {}
+    library_with_plex["plex_pass"] = bool(telemetry_data.get("plex_pass"))
+    collection_config = helpers.load_quickstart_config("quickstart_collections.json")
+    overlay_config = helpers.load_quickstart_overlay_config()
+    return {
+        "collections": _count_collection_overrides_for_library(library_with_plex, libraries_data, collection_config),
+        "overlays": _count_overlay_overrides_for_library(library, libraries_data, overlay_config),
+    }
+
+
+def _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections):
+    """Keep persisted collection/overlay values when those lazy sections were never opened."""
+    incoming_libraries = incoming_libraries if isinstance(incoming_libraries, dict) else {}
+    unloaded_sections = {"collections", "overlays"} - set(loaded_sections or set())
+    if not unloaded_sections:
+        return incoming_libraries
+
+    settings = persistence.retrieve_settings("025-libraries")
+    existing_libraries = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+    if not isinstance(existing_libraries, dict):
+        return incoming_libraries
+
+    preserved = dict(incoming_libraries)
+    prefix = f"{library_id}-"
+
+    def should_preserve(key):
+        if not isinstance(key, str) or not key.startswith(prefix):
+            return False
+        if "collections" in unloaded_sections and (f"{library_id}-collection_" in key or f"{library_id}-template_collection_" in key or key == f"{library_id}-collection_files"):
+            return True
+        if "overlays" in unloaded_sections and (
+            f"{library_id}-overlay_" in key
+            or key == f"{library_id}-overlay_files"
+            or f"{library_id}-movie-overlay_" in key
+            or f"{library_id}-show-overlay_" in key
+            or f"{library_id}-season-overlay_" in key
+            or f"{library_id}-episode-overlay_" in key
+            or f"{library_id}-movie-template_overlay_" in key
+            or f"{library_id}-show-template_overlay_" in key
+            or f"{library_id}-season-template_overlay_" in key
+            or f"{library_id}-episode-template_overlay_" in key
+        ):
+            return True
+        if unloaded_sections and key.startswith(f"{library_id}-template_variables"):
+            return True
+        return False
+
+    for key, value in existing_libraries.items():
+        if key not in preserved and should_preserve(key):
+            preserved[key] = value
+
+    return preserved
+
+
+def _save_lookup_label_only_library_payload(library_id, incoming):
+    """Persist lookup-label metadata without running full library validation."""
+    if not isinstance(incoming, dict):
+        return jsonify({"success": False, "error": "Invalid lookup label payload."}), 400
+
+    config_name = persistence.resolve_request_config_name(incoming)
+    settings = persistence.retrieve_settings("025-libraries")
+    existing_libraries = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+    existing_libraries = existing_libraries.copy() if isinstance(existing_libraries, dict) else {}
+    allowed_prefixes = (f"{library_id}-", "playlist-template_variables[")
+    updates = {}
+    for key, value in incoming.items():
+        key = str(key or "").strip()
+        if not key.endswith("__lookup_labels"):
+            continue
+        if not key.startswith(allowed_prefixes):
+            continue
+        updates[key] = str(value or "{}").strip() or "{}"
+
+    if not updates:
+        return jsonify({"success": True, "lookup_labels_only": True, "updated": 0})
+
+    existing_libraries.update(updates)
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=helpers.booler(settings.get("validated", False)),
+        user_entered=True,
+        data={"libraries": existing_libraries, "validated": helpers.booler(settings.get("validated", False))},
+    )
+    return jsonify({"success": True, "lookup_labels_only": True, "updated": len(updates)})
+
+
+@bp.route("/library_fragment/<library_id>")
+def library_fragment(library_id):
+    """Return a single library form fragment so we can lazy-load library settings on the page."""
+    context = _library_fragment_context(library_id, include_collections=False, include_overlays=False)
+
+    if not context:
+        return jsonify({"error": "Library not found"}), 404
+
     html = render_template(
         "partials/_library_card.html",
-        library=library,
-        data=data,
-        page_info=page_info,
-        attribute_config=attribute_config,
-        collection_config=collection_config,
-        overlay_config=overlay_config,
-        image_data=image_data,
-        movie_images=image_data["movie"],
-        configured_ids=configured_ids,
-        legacy_playlist_libraries=legacy_playlist_libraries,
+        defer_heavy_sections=True,
+        **context,
     )
 
     return html
+
+
+@bp.route("/library_fragment/<library_id>/section/<section_name>")
+def library_fragment_section(library_id, section_name):
+    """Return a heavy library section fragment on demand."""
+    if section_name not in {"collections", "overlays"}:
+        return jsonify({"error": "Unsupported library section"}), 404
+
+    include_collections = section_name == "collections"
+    include_overlays = section_name == "overlays"
+    context = _library_fragment_context(
+        library_id,
+        include_attributes=False,
+        include_collections=include_collections,
+        include_overlays=include_overlays,
+    )
+
+    if not context:
+        return jsonify({"error": "Library not found"}), 404
+
+    library = context["library"]
+    if section_name == "collections":
+        template_name = "partials/_movie_collections.html" if library["type"] == "movie" else "partials/_show_collections.html"
+    else:
+        template_name = "partials/_movie_overlays.html" if library["type"] == "movie" else "partials/_show_overlays.html"
+
+    return render_template(template_name, **context)
 
 
 @bp.route("/autosave_library/<library_id>", methods=["POST"])
@@ -219,12 +521,20 @@ def autosave_library(library_id):
 
     try:
         incoming = request.get_json(silent=True) or request.form
+        if isinstance(incoming, dict) and helpers.booler(incoming.get("__lookup_labels_only")):
+            return _save_lookup_label_only_library_payload(library_id, incoming)
+        loaded_sections = _coerce_loaded_library_sections(incoming.get("__loaded_sections") if hasattr(incoming, "get") else None)
         config_name = persistence.resolve_request_config_name(incoming if isinstance(incoming, dict) else {})
         errors = path_validation.validate_payload(incoming)
         if errors:
             return jsonify({"success": False, "error": "Invalid path values.", "errors": errors}), 400
-        clean_payload = persistence.clean_form_data(MultiDict(incoming))
+        clean_source = dict(incoming) if isinstance(incoming, dict) else incoming
+        if isinstance(clean_source, dict):
+            clean_source.pop("__loaded_sections", None)
+        clean_payload = persistence.clean_form_data(MultiDict(clean_source))
         incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
+        loaded_sections = _loaded_sections_with_payload_evidence(library_id, incoming_libraries, loaded_sections)
+        incoming_libraries = _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections)
         selected_library_ids = _qs._selected_library_ids_from_libraries_data(incoming_libraries)
         collection_errors = _qs._validate_library_collection_files(incoming_libraries, selected_library_ids)
         metadata_errors = _qs._validate_library_metadata_files(incoming_libraries, selected_library_ids)
@@ -392,7 +702,9 @@ def copy_library_settings():
 
         # If the client sent a fresh payload for the source card, merge it in before copying
         if isinstance(source_payload, dict) and source_payload:
-            payload_errors = path_validation.validate_payload(source_payload)
+            source_payload_for_merge = dict(source_payload)
+            loaded_sections = _coerce_loaded_library_sections(source_payload_for_merge.pop("__loaded_sections", []))
+            payload_errors = path_validation.validate_payload(source_payload_for_merge)
             if payload_errors:
                 return (
                     jsonify(
@@ -405,11 +717,11 @@ def copy_library_settings():
                     400,
                 )
             try:
-                clean_payload = persistence.clean_form_data(MultiDict(source_payload))
+                clean_payload = persistence.clean_form_data(MultiDict(source_payload_for_merge))
                 incoming_dict = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
                 normalized_incoming, normalization_errors, _ = _qs._normalize_library_file_entries_payload(
                     incoming_dict,
-                    session.get("config_name") or source_payload.get("config_name"),
+                    session.get("config_name") or source_payload_for_merge.get("config_name"),
                     validate_local=False,
                 )
                 if normalization_errors:
@@ -423,7 +735,8 @@ def copy_library_settings():
                         ),
                         400,
                     )
-                incoming_dict = normalized_incoming
+                loaded_sections = _loaded_sections_with_payload_evidence(source_prefix, normalized_incoming, loaded_sections)
+                incoming_dict = _preserve_unloaded_lazy_section_values(source_prefix, normalized_incoming, loaded_sections)
 
                 merged = libraries_data.copy()
 

--- a/modules/helpers/_overlays.py
+++ b/modules/helpers/_overlays.py
@@ -7,11 +7,22 @@ import re
 
 from modules.helpers._constants import JSON_SETTINGS
 
+_QUICKSTART_CONFIG_CACHE: dict[str, tuple[float, int, object]] = {}
+_QUICKSTART_OVERLAY_CONFIG_CACHE: tuple[float, int, object] | None = None
+
 
 def load_quickstart_config(filename: str):
     json_path = os.path.join(JSON_SETTINGS, filename)
+    stat = os.stat(json_path)
+    cache_key = os.path.abspath(json_path)
+    cached = _QUICKSTART_CONFIG_CACHE.get(cache_key)
+    if cached and cached[0] == stat.st_mtime and cached[1] == stat.st_size:
+        return copy.deepcopy(cached[2])
+
     with open(json_path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        data = json.load(f)
+    _QUICKSTART_CONFIG_CACHE[cache_key] = (stat.st_mtime, stat.st_size, data)
+    return copy.deepcopy(data)
 
 
 def _overlay_origin_alignment_defaults(origin):
@@ -261,4 +272,14 @@ def enrich_quickstart_overlay_config(config):
 
 
 def load_quickstart_overlay_config():
-    return enrich_quickstart_overlay_config(load_quickstart_config("quickstart_overlays.json"))
+    global _QUICKSTART_OVERLAY_CONFIG_CACHE
+
+    json_path = os.path.join(JSON_SETTINGS, "quickstart_overlays.json")
+    stat = os.stat(json_path)
+    cached = _QUICKSTART_OVERLAY_CONFIG_CACHE
+    if cached and cached[0] == stat.st_mtime and cached[1] == stat.st_size:
+        return copy.deepcopy(cached[2])
+
+    enriched = enrich_quickstart_overlay_config(load_quickstart_config("quickstart_overlays.json"))
+    _QUICKSTART_OVERLAY_CONFIG_CACHE = (stat.st_mtime, stat.st_size, enriched)
+    return copy.deepcopy(enriched)

--- a/modules/importer_simple_sections.py
+++ b/modules/importer_simple_sections.py
@@ -110,6 +110,36 @@ def _normalize_apprise_section(section_payload: Any) -> str:
     return str(apprise_location).strip() if apprise_location is not None else ""
 
 
+def _record_apprise_source_paths(section_payload: Any, report: ImportReport) -> None:
+    """Record the original Apprise YAML key shape as imported.
+
+    Apprise is normalized internally to ``apprise.location`` because that is
+    the Quickstart form field, but Kometa configs commonly use
+    ``apprise.config``. Recording the source key keeps the annotated import
+    report from marking a successfully-normalized source line as unmapped.
+    """
+    if isinstance(section_payload, dict):
+        if "config" in section_payload:
+            report.add("imported", "apprise.config")
+            return
+        if "location" in section_payload:
+            report.add("imported", "apprise.location")
+            return
+        if "apprise" in section_payload:
+            nested_apprise = section_payload.get("apprise")
+            if isinstance(nested_apprise, dict):
+                if "config" in nested_apprise:
+                    report.add("imported", "apprise.apprise.config")
+                    return
+                if "location" in nested_apprise:
+                    report.add("imported", "apprise.apprise.location")
+                    return
+            report.add("imported", "apprise.apprise")
+            return
+    elif isinstance(section_payload, str):
+        report.add("imported", "apprise")
+
+
 def _normalize_settings_section(section_payload: dict) -> dict:
     """Normalize the settings section's asset_directory (str-or-list to list)."""
     asset_directory = section_payload.get("asset_directory")
@@ -167,6 +197,7 @@ def process_simple_sections(
                 normalized_apprise = {"location": apprise_location}
                 payload[section] = {section: normalized_apprise}
                 _flatten_dict(section, normalized_apprise, report)
+                _record_apprise_source_paths(section_payload, report)
             else:
                 report.add("unmapped", section, "Unsupported section format.")
             continue

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -99,6 +99,9 @@ _PLAIN_SCALAR_SECTIONS = frozenset(
 )
 
 
+_SETTINGS_WARNING_DEFAULT_KEYS = ("auto_sort_hubs", "playlist_exclude_users")
+
+
 # --- pruning / cleaning ---------------------------------------------------
 
 
@@ -364,7 +367,8 @@ def _apply_settings_normalization(cleaned_data):
     """
     settings_block = cleaned_data.get("settings")
     if not isinstance(settings_block, dict):
-        return
+        settings_block = {}
+        cleaned_data["settings"] = settings_block
 
     for setting_key in list(settings_block.keys()):
         normalized_value = _normalize_settings_section_value(setting_key, settings_block.get(setting_key))
@@ -375,6 +379,9 @@ def _apply_settings_normalization(cleaned_data):
 
     if "asset_directory" in settings_block and isinstance(settings_block["asset_directory"], (str, list)):
         settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
+
+    for setting_key in _SETTINGS_WARNING_DEFAULT_KEYS:
+        settings_block.setdefault(setting_key, None)
 
 
 # --- validation comment ---------------------------------------------------

--- a/modules/output_overlay_builder.py
+++ b/modules/output_overlay_builder.py
@@ -108,14 +108,16 @@ def _apply_content_rating_color(overlay_entry, overlay_name, full_key_prefix_bas
 
     The color key lives on the un-variant-suffixed template overlay
     key (``..._template_overlay_content_rating_<variant>[color]``).
-    Mutates ``overlay_entry`` in place, setting
-    ``template_variables['color']`` to a bool.  Default: False.
+    Mutates ``overlay_entry`` in place only when the user supplied the
+    field. Missing means "use the Kometa/Quickstart default".
     """
     if not overlay_name.startswith("content_rating_"):
         return
     variant = overlay_name[len("content_rating_") :]
     color_key = f"{full_key_prefix_base}_content_rating_{variant}[color]"
-    color_value = raw_overlay_entries.get(color_key, False)
+    if color_key not in raw_overlay_entries:
+        return
+    color_value = raw_overlay_entries.get(color_key)
     if isinstance(color_value, str):
         color_value = color_value.lower() == "true"
     overlay_entry.setdefault("template_variables", {})["color"] = color_value

--- a/modules/validations_shared.py
+++ b/modules/validations_shared.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from modules import helpers, persistence
 
 
+def _config_dir_path() -> Path:
+    return Path(helpers.CONFIG_DIR).resolve()
+
+
 def _resolve_managed_library_path(location: str | None) -> str:
     """Resolve a managed-library path token into an absolute filesystem path.
 
@@ -40,18 +44,18 @@ def _resolve_managed_library_path(location: str | None) -> str:
         return raw
     expanded = Path(os.path.expandvars(os.path.expanduser(raw)))
     if expanded.is_absolute():
-        return str(expanded)
+        return str(expanded.resolve())
     normalized_parts = [part for part in str(expanded).replace("\\", "/").split("/") if part]
     if normalized_parts and normalized_parts[0] == "config":
-        return str(Path(helpers.CONFIG_DIR) / Path(*normalized_parts[1:]))
+        return str((_config_dir_path() / Path(*normalized_parts[1:])).resolve())
     if len(normalized_parts) >= 3 and normalized_parts[1] in helpers.MANAGED_LIBRARY_FILE_DIRS:
-        return str(Path(helpers.CONFIG_DIR) / Path(*normalized_parts))
+        return str((_config_dir_path() / Path(*normalized_parts)).resolve())
     if len(normalized_parts) >= 3 and normalized_parts[1] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
-        return str(Path(helpers.CONFIG_DIR) / Path(*normalized_parts))
+        return str((_config_dir_path() / Path(*normalized_parts)).resolve())
     if normalized_parts and normalized_parts[0] in helpers.MANAGED_LIBRARY_FILE_DIRS:
-        return str(Path(helpers.CONFIG_DIR) / expanded)
+        return str((_config_dir_path() / expanded).resolve())
     if normalized_parts and normalized_parts[0] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
-        return str(Path(helpers.CONFIG_DIR) / expanded)
+        return str((_config_dir_path() / expanded).resolve())
     return raw
 
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -2352,7 +2352,11 @@ def step(name):
 
     start_time = time.perf_counter()
 
-    needs_library_payload = name == "025-libraries"
+    # The Libraries page lazy-loads the actual library card via
+    # /library_fragment/<id>. Avoid loading the multi-MB collection/overlay
+    # payload during the initial picker-only render; the fragment route still
+    # loads the full payload when a card is requested.
+    needs_library_payload = False
     attribute_config = {}
     collection_config = []
     overlay_config = []

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -176,6 +176,7 @@ document.addEventListener('DOMContentLoaded', function () {
   let importReportFilter = 'all'
   let importNeedsPlexCredentials = false
   let importNeedsTmdbCredentials = false
+  let importConfirmInFlight = false
 
   if (importPlexTokenToggle && importPlexToken) {
     if (!importPlexToken.value.trim()) {
@@ -2001,12 +2002,15 @@ document.addEventListener('DOMContentLoaded', function () {
     })
   }
 
-  if (confirmImportButton) {
+  if (confirmImportButton && confirmImportButton.dataset.importConfirmBound !== 'true') {
+    confirmImportButton.dataset.importConfirmBound = 'true'
     confirmImportButton.addEventListener('click', async () => {
+      if (importConfirmInFlight) return
       if (!importToken) {
         setImportError('Preview the import before confirming.')
         return
       }
+      importConfirmInFlight = true
       confirmImportButton.disabled = true
       confirmImportButton.textContent = 'Importing...'
 
@@ -2242,6 +2246,7 @@ document.addEventListener('DOMContentLoaded', function () {
           setImportError(message)
         }
       } finally {
+        importConfirmInFlight = false
         confirmImportButton.disabled = false
         confirmImportButton.textContent = 'Import'
       }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5339,12 +5339,7 @@ function moveCurrentToCache () {
   }
 }
 
-function mountCard (card, libraryId) {
-  libraryContainer.replaceChildren()
-  setCachedCardFormSubmission(card, false)
-  card.style.display = ''
-  libraryContainer.appendChild(card)
-  activeLibraryId = libraryId
+function initializeLibraryCardControls (card, libraryId) {
   initPlaylistKeyToggleGroups(card)
   initPlaylistUserPickers(card)
   initPlaylistFilesEditors(card)
@@ -5390,6 +5385,7 @@ function mountCard (card, libraryId) {
   wireOverlayVariableSections(card)
   wireCollectionVariableSections(card)
   wireLibraryOverrideScopes(card)
+  updateLazySectionOverrideSummaries(card)
   wireOffsetReset(card)
   if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
     OverlayHandler.initializeOverlayBoards(card)
@@ -5401,7 +5397,7 @@ function mountCard (card, libraryId) {
     OverlayHandler.initializeJumpButtons(card)
   }
   if (typeof EventHandler !== 'undefined') {
-    EventHandler.attachLibraryListeners()
+    EventHandler.attachLibraryListeners(card)
   }
   if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
     PathValidation.attach(card)
@@ -5417,6 +5413,63 @@ function mountCard (card, libraryId) {
   wireFontPickerButtons(card)
   bindDependencyRequirementHintLiveRefresh(card)
   scheduleDependencyRequirementHintRefresh(0)
+}
+
+function wireLazyLibrarySections (card) {
+  if (!card || card.dataset.lazyLibrarySectionsBound === 'true') return
+
+  card.addEventListener('shown.bs.collapse', event => {
+    const collapse = event.target
+    if (!collapse || !collapse.querySelector) return
+    const placeholder = collapse.querySelector('[data-library-lazy-section][data-library-id]')
+    if (!placeholder || placeholder.dataset.lazyState === 'loaded' || placeholder.dataset.lazyState === 'loading') return
+
+    const sectionName = placeholder.dataset.libraryLazySection
+    const libraryId = placeholder.dataset.libraryId
+    if (!sectionName || !libraryId) return
+
+    const spinner = placeholder.querySelector('.spinner-border')
+    const status = placeholder.querySelector('span')
+    placeholder.dataset.lazyState = 'loading'
+    spinner?.classList.remove('d-none')
+    if (status) status.textContent = `Loading ${sectionName} settings...`
+
+    fetch(`/library_fragment/${encodeURIComponent(libraryId)}/section/${encodeURIComponent(sectionName)}`, {
+      credentials: 'same-origin'
+    })
+      .then(res => {
+        if (!res.ok) throw new Error(`Failed to load ${sectionName} (${res.status})`)
+        return res.text()
+      })
+      .then(html => {
+        const body = placeholder.closest('.accordion-body')
+        if (!body) return
+        body.innerHTML = html
+        placeholder.dataset.lazyState = 'loaded'
+        initializeLibraryCardControls(card, libraryId)
+      })
+      .catch(err => {
+        console.error('[Libraries] Failed to load lazy library section', err)
+        placeholder.dataset.lazyState = 'error'
+        spinner?.classList.add('d-none')
+        if (status) status.textContent = `Unable to load ${sectionName} settings. Close and reopen this section to retry.`
+        if (typeof showToast === 'function') {
+          showToast('error', `Unable to load ${sectionName} settings. Try again.`)
+        }
+      })
+  })
+
+  card.dataset.lazyLibrarySectionsBound = 'true'
+}
+
+function mountCard (card, libraryId) {
+  libraryContainer.replaceChildren()
+  setCachedCardFormSubmission(card, false)
+  card.style.display = ''
+  libraryContainer.appendChild(card)
+  activeLibraryId = libraryId
+  wireLazyLibrarySections(card)
+  initializeLibraryCardControls(card, libraryId)
 }
 
 function fetchLibraryFragment (libraryId, attempt = 0) {
@@ -5455,6 +5508,15 @@ wireFontPickerModal()
 function buildPayloadFromCard (card) {
   const payload = {}
   const libraryId = activeLibraryId || String(card?.querySelector('[name]')?.name || '').split('-')[0]
+  const loadedLazySections = []
+  ;['collections', 'overlays'].forEach(sectionName => {
+    const section = document.getElementById(`${libraryId}-${sectionName}`)
+    const placeholder = card.querySelector(`[data-library-lazy-section="${sectionName}"][data-library-id="${libraryId}"]`)
+    if (section && !placeholder) {
+      loadedLazySections.push(sectionName)
+    }
+  })
+  payload.__loaded_sections = loadedLazySections
   const checkboxNames = new Set(
     Array.from(card.querySelectorAll('input[type="checkbox"][name]'))
       .map(el => String(el.name || '').trim())
@@ -5591,11 +5653,21 @@ function scheduleLookupLabelAutosave (delayMs = 900) {
   lookupLabelAutosaveTimer = setTimeout(() => {
     lookupLabelAutosaveTimer = null
     if (!activeLibraryId || window.QS_SWITCHING_CONFIG) return
-    autosaveActiveLibrary({ quiet: true })
+    autosaveActiveLibrary({ quiet: true, lookupLabelsOnly: true })
       .catch(err => {
         console.warn('[Autosave] Failed to persist lookup labels', err)
       })
   }, Math.max(0, Number(delayMs) || 0))
+}
+
+function buildLookupLabelPayloadFromCard (card) {
+  const payload = { __lookup_labels_only: true }
+  if (!card) return payload
+  card.querySelectorAll('input[type="hidden"][name$="__lookup_labels"]').forEach(el => {
+    if (!el.name || el.disabled) return
+    payload[el.name] = el.value ?? '{}'
+  })
+  return payload
 }
 
 function autosaveActiveLibrary (options = {}) {
@@ -5603,8 +5675,9 @@ function autosaveActiveLibrary (options = {}) {
   if (!activeLibraryId || !card) return Promise.resolve()
   if (window.QS_SWITCHING_CONFIG) return Promise.resolve()
   const quiet = Boolean(options && options.quiet)
+  const lookupLabelsOnly = Boolean(options && options.lookupLabelsOnly)
 
-  if (typeof PathValidation !== 'undefined' && PathValidation.validateAll) {
+  if (!lookupLabelsOnly && typeof PathValidation !== 'undefined' && PathValidation.validateAll) {
     const pathValid = PathValidation.validateAll(card)
     if (!pathValid) {
       if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.focusFirstInvalidField === 'function') {
@@ -5617,7 +5690,7 @@ function autosaveActiveLibrary (options = {}) {
     }
   }
 
-  if (typeof URLValidation !== 'undefined' && URLValidation.validateAll) {
+  if (!lookupLabelsOnly && typeof URLValidation !== 'undefined' && URLValidation.validateAll) {
     const urlValid = URLValidation.validateAll(card)
     if (!urlValid) {
       if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.focusFirstInvalidField === 'function') {
@@ -5630,7 +5703,7 @@ function autosaveActiveLibrary (options = {}) {
     }
   }
 
-  const payload = buildPayloadFromCard(card)
+  const payload = lookupLabelsOnly ? buildLookupLabelPayloadFromCard(card) : buildPayloadFromCard(card)
   const collectionEditor = card.querySelector('[data-collection-files-editor]')
   const metadataEditor = card.querySelector('[data-metadata-files-editor]')
   const overlayEditor = card.querySelector('[data-overlay-files-editor]')
@@ -5897,18 +5970,7 @@ if (libraryPicker) {
   })
 
   refreshPickerLabels()
-  const configuredFirst = libraryPicker.querySelector('option[data-configured="true"]')
-  const firstLibrary = libraryPicker.value ||
-    configuredFirst?.value ||
-    libraryPicker.querySelector('option[value]:not([value=""])')?.value
-  if (configuredFirst) {
-    libraryPicker.value = configuredFirst.value
-    loadLibrary(configuredFirst.value, 'initial')
-  } else if (firstLibrary) {
-    loadLibrary(firstLibrary, 'initial')
-  } else {
-    libraryPicker.value = ''
-  }
+  libraryPicker.value = ''
 }
 
 document.addEventListener('qs:before-step-navigation', (event) => {
@@ -7855,6 +7917,20 @@ function updateAncestorOverrideSummaries (element) {
   }
 }
 
+function updateLazySectionOverrideSummaries (scope) {
+  const root = scope || document
+  root.querySelectorAll?.('[data-library-lazy-section][data-lazy-override-count]').forEach(placeholder => {
+    const count = Number(placeholder.dataset.lazyOverrideCount || '0') || 0
+    const collapse = placeholder.closest('.accordion-collapse')
+    const item = collapse?.closest('.accordion-item')
+    const header = item?.querySelector(':scope > .accordion-header') || item?.querySelector('.accordion-header')
+
+    item?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    header?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
+  })
+}
+
 function updateTemplateGroupOverrideSummary (section) {
   const group = section?.closest('.template-toggle-group')
   if (!group) return
@@ -7873,6 +7949,7 @@ function updateTemplateGroupOverrideSummary (section) {
 function refreshTemplateOverrideState (scope) {
   const root = scope || document
   clearTemplateVariableFieldOverrideStates(root)
+  updateLazySectionOverrideSummaries(root)
   root.querySelectorAll('[data-collection-variable-section="true"]').forEach(section => {
     updateCollectionVariableSectionSummary(section)
   })

--- a/static/local-js/087-apprise.js
+++ b/static/local-js/087-apprise.js
@@ -6,6 +6,7 @@ createApiKeyValidator({
   validatedAtFieldId: 'apprise_validated_at',
   endpoint: '/validate_apprise',
   buildPayload: (location) => ({ apprise_location: location }),
+  maskPrimaryField: false,
   messages: {
     empty: 'Please enter an Apprise YAML path or URL.',
     success: 'Apprise location validated successfully!',

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -9,9 +9,21 @@ function callValidationHandler (methodName, ...args) {
   return handler[methodName](...args)
 }
 
+function queryScopedElements (scope, selector) {
+  const root = scope && typeof scope.querySelectorAll === 'function' ? scope : document
+  const elements = []
+
+  if (root !== document && typeof root.matches === 'function' && root.matches(selector)) {
+    elements.push(root)
+  }
+
+  elements.push(...root.querySelectorAll(selector))
+  return elements
+}
+
 const EventHandler = {
-  attachLibraryListeners: function () {
-    document.querySelectorAll('.library-checkbox').forEach((checkbox) => {
+  attachLibraryListeners: function (scope = document) {
+    queryScopedElements(scope, '.library-checkbox').forEach((checkbox) => {
       const libraryId = checkbox.id.replace(/-(library|card-container)$/, '')
 
       if (checkbox.dataset.listenerAdded !== 'true') {
@@ -31,7 +43,7 @@ const EventHandler = {
       }
     })
 
-    document.querySelectorAll("[id$='-card-container']").forEach((library) => {
+    queryScopedElements(scope, "[id$='-card-container']").forEach((library) => {
       const libraryId = library.id.replace('-card-container', '')
       const isMovie = libraryId.startsWith('mov-library_')
 
@@ -100,26 +112,26 @@ const EventHandler = {
       initializeOverlays(libraryId, isMovie)
 
       // Attach overlay selection listeners (CHANGE events)
+      library.querySelectorAll('.accordion select').forEach(select => {
+        if (!select.dataset.listenerAdded) {
+          select.addEventListener('change', () => {
+            console.log(`[DEBUG] Dropdown changed: ${select.id} -> ${select.value}`)
+            updateAccordionHighlights()
+            callValidationHandler('updateValidationState')
+
+            // Trigger preview update if template variable
+            if (select.classList.contains('template-variable-select')) {
+              const nameParts = select.name.split('-')
+              const previewLibraryId = nameParts.slice(0, 2).join('-') // e.g., mov-library_movies
+              const type = nameParts[2] // e.g., movie
+              ImageHandler.generateSinglePreview(previewLibraryId, type)
+            }
+          })
+          select.dataset.listenerAdded = 'true'
+        }
+      })
+
       library.querySelectorAll('.accordion input').forEach((input) => {
-        library.querySelectorAll('.accordion select').forEach(select => {
-          if (!select.dataset.listenerAdded) {
-            select.addEventListener('change', () => {
-              console.log(`[DEBUG] Dropdown changed: ${select.id} -> ${select.value}`)
-              updateAccordionHighlights()
-              callValidationHandler('updateValidationState')
-
-              // Trigger preview update if template variable
-              if (select.classList.contains('template-variable-select')) {
-                const nameParts = select.name.split('-')
-                const previewLibraryId = nameParts.slice(0, 2).join('-') // e.g., mov-library_movies
-                const type = nameParts[2] // e.g., movie
-                ImageHandler.generateSinglePreview(previewLibraryId, type)
-              }
-            })
-            select.dataset.listenerAdded = 'true'
-          }
-        })
-
         if (input.id && !input.dataset.listenerAdded) {
           console.log(`[DEBUG] Attaching toggle listener for ${input.id}`)
           input.addEventListener('change', () => {
@@ -136,7 +148,7 @@ const EventHandler = {
       })
 
       // Attach attribute_reset_overlays listeners
-      document.querySelectorAll("[id$='-attribute_reset_overlays']").forEach(dropdown => {
+      library.querySelectorAll("[id$='-attribute_reset_overlays']").forEach(dropdown => {
         if (!dropdown.dataset.listenerAdded) {
           console.log(`[DEBUG] Attaching change listener for Reset Overlays: ${dropdown.id}`)
 
@@ -366,22 +378,25 @@ const shouldReattachForNode = (node) => {
 }
 
 const observer = new MutationObserver((mutations) => {
-  let needsReattachment = false
+  const reattachmentScopes = new Set()
 
   mutations.forEach((mutation) => {
     if (mutation.addedNodes.length > 0) {
       mutation.addedNodes.forEach((node) => {
         if (shouldReattachForNode(node)) {
           console.log(`[DEBUG] New element detected: ${node.id || node.className}, triggering re-attachment.`)
-          needsReattachment = true
+          const cardScope = node.matches?.("[id$='-card-container']")
+            ? node
+            : node.closest?.("[id$='-card-container']")
+          reattachmentScopes.add(cardScope || node)
         }
       })
     }
   })
 
-  if (needsReattachment) {
+  if (reattachmentScopes.size > 0) {
     console.log('[DEBUG] Reattaching event listeners due to DOM mutation...')
-    EventHandler.attachLibraryListeners()
+    reattachmentScopes.forEach(scope => EventHandler.attachLibraryListeners(scope))
   }
 })
 

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -1,5 +1,5 @@
 // Shared factory for credential-validation wizards: ONE primary credential
-// input (api key or token), zero or more additional non-secret fields
+// input (api key or token by default), zero or more additional non-secret fields
 // (url, topic, etc.), one validate button, server endpoint that returns
 // { valid: boolean }. Used by every "fill in a credential then click
 // Validate" page in the wizard.
@@ -35,8 +35,8 @@
 //   gracefully no-op if an expected element is absent (defence in depth
 //   for partial template rendering).
 //
-//   The PRIMARY field (config.fieldId) is the credential -- it gets
-//   the show/hide toggle treatment. ADDITIONAL fields
+//   The PRIMARY field (config.fieldId) is the credential by default -- it gets
+//   the show/hide toggle treatment unless maskPrimaryField is false. ADDITIONAL fields
 //   (config.additionalFieldIds) are non-secret accompanying inputs
 //   that participate in the empty-validation check, the reset-on-input
 //   listener wiring, and the payload builder. The toggle never applies
@@ -62,7 +62,8 @@ const DEFAULT_MESSAGES = {
  *
  * @param {object} config
  * @param {string} config.fieldId                Element id of the primary credential input.
- *                                               Gets the show/hide toggle treatment.
+ *                                               Gets the show/hide toggle treatment unless
+ *                                               maskPrimaryField is false.
  * @param {string[]} [config.additionalFieldIds=[]]  Element ids of additional non-secret fields
  *                                                   (e.g. url, topic). All are required for
  *                                                   the empty-validation check, get input
@@ -120,6 +121,8 @@ const DEFAULT_MESSAGES = {
  *                                               `data.validated` for success but `data.valid: false` on
  *                                               failure -- asymmetric naming preserved from the legacy API).
  * @param {string} [config.spinnerKey='validate'] Argument passed to show/hideSpinner.
+ * @param {boolean} [config.maskPrimaryField=true] Whether to treat the primary field as a secret.
+ *                                                 Set false for path/URL validators that reuse this flow.
  */
 export function createApiKeyValidator (config) {
   const {
@@ -139,7 +142,8 @@ export function createApiKeyValidator (config) {
     onPreSubmit,
     revalidateOnLoad = false,
     isValid = (data) => !!data.valid,
-    spinnerKey = 'validate'
+    spinnerKey = 'validate',
+    maskPrimaryField = true
   } = config
 
   if (!fieldId) throw new Error('createApiKeyValidator: fieldId is required')
@@ -170,8 +174,10 @@ export function createApiKeyValidator (config) {
     .map(id => ({ id, el: document.getElementById(id) }))
     .filter(entry => entry.el)
 
-  // ── initial visibility of the credential field ──────────────────────
-  if (apiKeyInput.value.trim() === '') {
+  // ── initial visibility of the primary field ─────────────────────────
+  if (!maskPrimaryField) {
+    apiKeyInput.setAttribute('type', 'text')
+  } else if (apiKeyInput.value.trim() === '') {
     apiKeyInput.setAttribute('type', 'text') // show placeholder text
     if (toggleButton) setToggleButtonIcon(toggleButton, true)
   } else {
@@ -308,7 +314,7 @@ export function createApiKeyValidator (config) {
   }
 
   // ── show/hide toggle for the credential field ───────────────────────
-  if (toggleButton) {
+  if (maskPrimaryField && toggleButton) {
     toggleButton.addEventListener('click', function () {
       const currentType = apiKeyInput.getAttribute('type')
       apiKeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -8,6 +8,20 @@
 export const librariesValidatedAtInput = document.getElementById('libraries_validated_at')
 let librariesTouched = false
 
+function getConfiguredLibraryOptions (type) {
+  const picker = document.getElementById('libraryPicker')
+  if (!picker) return []
+  return Array.from(picker.querySelectorAll('option[value]')).filter(option => {
+    return option.value.startsWith(`${type}-library_`) && option.dataset.configured === 'true'
+  })
+}
+
+function optionLabel (option) {
+  return String(option.dataset.label || option.textContent || '')
+    .replace(/\s+\(configured\)$/, '')
+    .trim()
+}
+
 export const ValidationHandler = {
   updateValidationState: function () {
     console.log('[DEBUG] Running validation state update.')
@@ -285,21 +299,53 @@ export const ValidationHandler = {
   },
 
   getSelectedLibraryIds: function (type) {
-    const selected = [...document.querySelectorAll(`input[id$='-library-value'][id^='${type}-library_']`)]
-      .filter(input => input.value && input.value.trim() !== '')
-      .map(input => input.id.replace('-library-value', ''))
+    const configuredOptions = getConfiguredLibraryOptions(type)
+    const selectedIds = new Set(configuredOptions.map(option => option.value))
+    const configuredOptionIds = new Set(configuredOptions.map(option => option.value))
+    const picker = document.getElementById('libraryPicker')
+    const pickerOptionIds = new Set(
+      Array.from(picker?.querySelectorAll(`option[value^='${type}-library_']`) || []).map(option => option.value)
+    )
 
+    document.querySelectorAll(`input[id$='-library-value'][id^='${type}-library_']`).forEach(input => {
+      if (!input.value || input.value.trim() === '') return
+      const id = input.id.replace('-library-value', '')
+      if (pickerOptionIds.has(id) && !configuredOptionIds.has(id)) return
+      selectedIds.add(id)
+    })
+
+    const selected = Array.from(selectedIds)
     console.log('[DEBUG] Selected', type, 'Library IDs:', selected)
     return selected
   },
 
   getSelectedLibraryNames: function (type) {
-    const names = [...document.querySelectorAll(`input[id$='-library-value'][id^='${type}-library_']`)]
-      .filter(input => input.value && input.value.trim() !== '')
-      .map(input => input.value.trim())
+    const configuredOptions = getConfiguredLibraryOptions(type)
+    const selectedNames = []
+    const selectedIds = new Set()
+    const picker = document.getElementById('libraryPicker')
+    const pickerOptionIds = new Set(
+      Array.from(picker?.querySelectorAll(`option[value^='${type}-library_']`) || []).map(option => option.value)
+    )
+    const configuredOptionIds = new Set(configuredOptions.map(option => option.value))
 
-    console.log('[DEBUG] Selected', type, 'Library Names:', names)
-    return names
+    configuredOptions.forEach(option => {
+      const label = optionLabel(option)
+      if (!label) return
+      selectedNames.push(label)
+      selectedIds.add(option.value)
+    })
+
+    document.querySelectorAll(`input[id$='-library-value'][id^='${type}-library_']`).forEach(input => {
+      if (!input.value || input.value.trim() === '') return
+      const id = input.id.replace('-library-value', '')
+      if (selectedIds.has(id)) return
+      if (pickerOptionIds.has(id) && !configuredOptionIds.has(id)) return
+      selectedNames.push(input.value.trim())
+    })
+
+    console.log('[DEBUG] Selected', type, 'Library Names:', selectedNames)
+    return selectedNames
   },
 
   // Backward compatibility alias

--- a/templates/140-mal.html
+++ b/templates/140-mal.html
@@ -90,11 +90,11 @@
   <input type="hidden" class="form-control" id="access_token" name="access_token"
     value="{{ data['mal']['authorization']['access_token'] }}" readonly>
   <input type="hidden" class="form-control" id="token_type" name="token_type"
-    value="{{ data['mal']['authorization']['access_token'] }}" readonly>
+    value="{{ data['mal']['authorization']['token_type'] }}" readonly>
   <input type="hidden" class="form-control" id="expires_in" name="expires_in"
-    value="{{ data['mal']['authorization']['access_token'] }}" readonly>
+    value="{{ data['mal']['authorization']['expires_in'] }}" readonly>
   <input type="hidden" class="form-control" id="refresh_token" name="refresh_token"
-    value="{{ data['mal']['authorization']['access_token'] }}" readonly>
+    value="{{ data['mal']['authorization']['refresh_token'] }}" readonly>
 </div>
 </div>
 </div>

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -12,7 +12,17 @@
             </h2>
             <div id="{{ library.id }}-collections" class="accordion-collapse collapse">
                 <div class="accordion-body">
+                    {% if defer_heavy_sections %}
+                    <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
+                        data-library-lazy-section="collections" data-library-id="{{ library.id }}"
+                        data-lazy-override-count="{{ lazy_section_override_counts.collections | default(0) }}">
+                        <div class="spinner-border spinner-border-sm text-info d-none" role="status"
+                            aria-hidden="true"></div>
+                        <span>Open this section to load collection settings.</span>
+                    </div>
+                    {% else %}
                     {% include "partials/_movie_collections.html" %}
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -27,7 +37,17 @@
             </h2>
             <div id="{{ library.id }}-overlays" class="accordion-collapse collapse">
                 <div class="accordion-body">
+                    {% if defer_heavy_sections %}
+                    <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
+                        data-library-lazy-section="overlays" data-library-id="{{ library.id }}"
+                        data-lazy-override-count="{{ lazy_section_override_counts.overlays | default(0) }}">
+                        <div class="spinner-border spinner-border-sm text-info d-none" role="status"
+                            aria-hidden="true"></div>
+                        <span>Open this section to load overlay settings.</span>
+                    </div>
+                    {% else %}
                     {% include "partials/_movie_overlays.html" %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -12,7 +12,17 @@
             </h2>
             <div id="{{ library.id }}-collections" class="accordion-collapse collapse">
                 <div class="accordion-body">
+                    {% if defer_heavy_sections %}
+                    <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
+                        data-library-lazy-section="collections" data-library-id="{{ library.id }}"
+                        data-lazy-override-count="{{ lazy_section_override_counts.collections | default(0) }}">
+                        <div class="spinner-border spinner-border-sm text-info d-none" role="status"
+                            aria-hidden="true"></div>
+                        <span>Open this section to load collection settings.</span>
+                    </div>
+                    {% else %}
                     {% include "partials/_show_collections.html" %}
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -27,7 +37,17 @@
             </h2>
             <div id="{{ library.id }}-overlays" class="accordion-collapse collapse">
                 <div class="accordion-body">
+                    {% if defer_heavy_sections %}
+                    <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
+                        data-library-lazy-section="overlays" data-library-id="{{ library.id }}"
+                        data-lazy-override-count="{{ lazy_section_override_counts.overlays | default(0) }}">
+                        <div class="spinner-border spinner-border-sm text-info d-none" role="status"
+                            aria-hidden="true"></div>
+                        <span>Open this section to load overlay settings.</span>
+                    </div>
+                    {% else %}
                     {% include "partials/_show_overlays.html" %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -148,6 +148,12 @@ describe('createApiKeyValidator initial field state', () => {
     expect(document.getElementById('test_apikey').getAttribute('type')).toBe('password')
   })
 
+  it('keeps a populated primary field visible when maskPrimaryField=false', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '/config/apprise.yml' })
+    createApiKeyValidator(defaultConfig({ maskPrimaryField: false }))
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('text')
+  })
+
   it('treats whitespace-only credential as empty (still password initially, then text)', () => {
     document.body.innerHTML = buildBaseHTML({ keyValue: '   ' })
     createApiKeyValidator(defaultConfig())

--- a/tests/js/validationHandler.test.js
+++ b/tests/js/validationHandler.test.js
@@ -187,6 +187,28 @@ describe('ValidationHandler.getSelectedLibraryIds', () => {
     expect(window.ValidationHandler.getSelectedLibraryIds('mov')).toEqual([])
   })
 
+  it('uses configured picker options when lazy library cards are not loaded', () => {
+    document.body.innerHTML = `
+      <select id="libraryPicker">
+        <option value="mov-library_movies" data-library-type="movie" data-configured="true" data-label="Movies">Movies (configured)</option>
+        <option value="mov-library_anime" data-library-type="movie" data-configured="false" data-label="Anime">Anime</option>
+        <option value="sho-library_shows" data-library-type="show" data-configured="true" data-label="Shows">Shows (configured)</option>
+      </select>
+    `
+    expect(window.ValidationHandler.getSelectedLibraryIds('mov')).toEqual(['mov-library_movies'])
+    expect(window.ValidationHandler.getSelectedLibraryIds('sho')).toEqual(['sho-library_shows'])
+  })
+
+  it('does not let stale hidden inputs reselect picker options marked unconfigured', () => {
+    document.body.innerHTML = `
+      <select id="libraryPicker">
+        <option value="mov-library_movies" data-library-type="movie" data-configured="false" data-label="Movies">Movies</option>
+      </select>
+      <input id="mov-library_movies-library-value" value="Movies">
+    `
+    expect(window.ValidationHandler.getSelectedLibraryIds('mov')).toEqual([])
+  })
+
   it('returns [] when all matching inputs are empty', () => {
     document.body.innerHTML = `
       <input id="mov-library_1-library-value" value="">
@@ -221,6 +243,26 @@ describe('ValidationHandler.getSelectedLibraryNames', () => {
   })
 
   it('returns [] when no matches', () => {
+    expect(window.ValidationHandler.getSelectedLibraryNames('mov')).toEqual([])
+  })
+
+  it('uses configured picker option labels when lazy library cards are not loaded', () => {
+    document.body.innerHTML = `
+      <select id="libraryPicker">
+        <option value="mov-library_movies" data-library-type="movie" data-configured="true" data-label="Movies">Movies (configured)</option>
+        <option value="mov-library_anime" data-library-type="movie" data-configured="false" data-label="Anime">Anime</option>
+      </select>
+    `
+    expect(window.ValidationHandler.getSelectedLibraryNames('mov')).toEqual(['Movies'])
+  })
+
+  it('does not let stale hidden input names reselect picker options marked unconfigured', () => {
+    document.body.innerHTML = `
+      <select id="libraryPicker">
+        <option value="mov-library_movies" data-library-type="movie" data-configured="false" data-label="Movies">Movies</option>
+      </select>
+      <input id="mov-library_movies-library-value" value="Movies">
+    `
     expect(window.ValidationHandler.getSelectedLibraryNames('mov')).toEqual([])
   })
 })
@@ -627,6 +669,19 @@ describe('ValidationHandler.validateForm (integration surface)', () => {
     `
     const result = window.ValidationHandler.validateForm()
     expect(result).toBe(true)
+  })
+
+  it('stays valid for configured lazy libraries before their cards are loaded', () => {
+    document.body.innerHTML += `
+      <select id="libraryPicker">
+        <option value="mov-library_movies" data-library-type="movie" data-configured="true" data-label="Movies">Movies (configured)</option>
+        <option value="sho-library_shows" data-library-type="show" data-configured="true" data-label="Shows">Shows (configured)</option>
+      </select>
+    `
+    const result = window.ValidationHandler.validateForm()
+    expect(result).toBe(true)
+    const box = document.getElementById('validation-messages')
+    expect(box.classList.contains('alert-success')).toBe(true)
   })
 
   it('ignores .accordion-header.selected nested under data-qs-minimal-yaml="false"', () => {

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -5,7 +5,9 @@ ROOT = Path(__file__).resolve().parents[1]
 MACROS_PATH = ROOT / "templates" / "partials" / "_macros.html"
 STYLES_PATH = ROOT / "static" / "css" / "styles.css"
 LIBRARIES_JS_PATH = ROOT / "static" / "local-js" / "025-libraries.js"
+EVENT_HANDLER_JS_PATH = ROOT / "static" / "local-js" / "eventHandler.js"
 VALIDATION_JS_PATH = ROOT / "static" / "local-js" / "validationHandler.js"
+START_JS_PATH = ROOT / "static" / "local-js" / "001-start.js"
 OVERLAYS_PATH = ROOT / "static" / "json" / "quickstart_overlays.json"
 LIBRARIES_TEMPLATE_PATH = ROOT / "templates" / "025-libraries.html"
 PLAYLIST_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_playlists.html"
@@ -48,6 +50,19 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "[data-collection-field-wrapper]" in script
 
 
+def test_event_handler_does_not_scan_selects_inside_input_loop():
+    script = EVENT_HANDLER_JS_PATH.read_text(encoding="utf-8")
+    attach_section = script.split("initializeOverlays(libraryId, isMovie)", 1)[1]
+    attach_section = attach_section.split("// Attach attribute_reset_overlays listeners", 1)[0]
+
+    assert "function queryScopedElements" in script
+    assert "attachLibraryListeners: function (scope = document)" in script
+    assert "reattachmentScopes.forEach(scope => EventHandler.attachLibraryListeners(scope))" in script
+    assert attach_section.index("library.querySelectorAll('.accordion select')") < attach_section.index("library.querySelectorAll('.accordion input')")
+    input_loop = attach_section.split("library.querySelectorAll('.accordion input')", 1)[1]
+    assert "library.querySelectorAll('.accordion select')" not in input_loop
+
+
 def test_overlay_macros_render_collapsible_variable_sections():
     macros = MACROS_PATH.read_text(encoding="utf-8")
 
@@ -85,6 +100,26 @@ def test_libraries_script_replaces_mirror_confirm_handler():
 
     assert "copyConfirmBtn.onclick = onConfirm" in script
     assert "copyConfirmBtn.addEventListener('click', onConfirm)" not in script
+
+
+def test_start_import_confirm_is_single_bound_and_in_flight_guarded():
+    script = START_JS_PATH.read_text(encoding="utf-8")
+
+    assert "let importConfirmInFlight = false" in script
+    assert "confirmImportButton.dataset.importConfirmBound !== 'true'" in script
+    assert "confirmImportButton.dataset.importConfirmBound = 'true'" in script
+    assert "if (importConfirmInFlight) return" in script
+    assert "importConfirmInFlight = true" in script
+    assert "importConfirmInFlight = false" in script
+
+
+def test_libraries_lookup_label_autosave_uses_narrow_payload():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "function buildLookupLabelPayloadFromCard" in script
+    assert "__lookup_labels_only: true" in script
+    assert "autosaveActiveLibrary({ quiet: true, lookupLabelsOnly: true })" in script
+    assert "lookupLabelsOnly ? buildLookupLabelPayloadFromCard(card) : buildPayloadFromCard(card)" in script
 
 
 def test_mirror_modal_explains_targets_stay_excluded():
@@ -140,6 +175,58 @@ def test_library_fragment_load_failure_preserves_current_card():
         "if (!card) throw new Error('Empty fragment response')\n" "          moveCurrentToCache()\n" "          mountCard(card, libraryId)"
     )
     assert "Your current library stayed open" in load_body
+
+
+def test_libraries_page_does_not_auto_load_first_library():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    picker_init = script.split("if (libraryPicker) {", 1)[1].split(
+        "document.addEventListener('qs:before-step-navigation'",
+        1,
+    )[0]
+
+    assert "refreshPickerLabels()" in picker_init
+    assert "libraryPicker.value = ''" in picker_init
+    assert "loadLibrary(configuredFirst.value, 'initial')" not in picker_init
+    assert "loadLibrary(firstLibrary, 'initial')" not in picker_init
+
+
+def test_library_card_mount_scopes_event_handler_to_current_card():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    initializer_body = script.split("function initializeLibraryCardControls (card, libraryId) {", 1)[1].split(
+        "function wireLazyLibrarySections",
+        1,
+    )[0]
+    mount_body = script.split("function mountCard (card, libraryId) {", 1)[1].split(
+        "function fetchLibraryFragment",
+        1,
+    )[0]
+
+    assert "EventHandler.attachLibraryListeners(card)" in initializer_body
+    assert "initializeLibraryCardControls(card, libraryId)" in mount_body
+    assert "EventHandler.attachLibraryListeners()" not in mount_body
+
+
+def test_libraries_lazy_loads_heavy_collection_and_overlay_sections():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    movie_settings = (ROOT / "templates" / "partials" / "_movie_library_settings.html").read_text(encoding="utf-8")
+    show_settings = (ROOT / "templates" / "partials" / "_show_library_settings.html").read_text(encoding="utf-8")
+    routes = (ROOT / "blueprints" / "library_routes.py").read_text(encoding="utf-8")
+
+    assert "function wireLazyLibrarySections" in script
+    assert "function updateLazySectionOverrideSummaries" in script
+    assert "shown.bs.collapse" in script
+    assert "/section/${encodeURIComponent(sectionName)}" in script
+    assert "initializeLibraryCardControls(card, libraryId)" in script
+    assert "wireLazyLibrarySections(card)" in script
+    assert "updateLazySectionOverrideSummaries(card)" in script
+    assert "data-lazy-override-count" in movie_settings
+    assert "data-lazy-override-count" in show_settings
+    assert 'data-library-lazy-section="collections"' in movie_settings
+    assert 'data-library-lazy-section="overlays"' in movie_settings
+    assert 'data-library-lazy-section="collections"' in show_settings
+    assert 'data-library-lazy-section="overlays"' in show_settings
+    assert "defer_heavy_sections=True" in routes
+    assert '@bp.route("/library_fragment/<library_id>/section/<section_name>")' in routes
 
 
 def test_cached_library_cards_do_not_submit_stale_form_fields():

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -169,6 +169,57 @@ def test_autosave_library_returns_400_on_collection_file_errors(client, isolated
     assert "collection" in data["error"].lower()
 
 
+def test_autosave_library_lookup_labels_only_skips_file_validation(client, isolated_config_dir, qs_module, monkeypatch):
+    from modules import database
+
+    config_name = "pytest_lookup_label_only_autosave"
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
+                "mov-library_movies-template_collection_franchise_exclude": '["893731"]',
+            },
+            "validated": True,
+        },
+    )
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("lookup-label-only autosave must not run library file validators")
+
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", fail_if_called)
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", fail_if_called)
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", fail_if_called)
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", fail_if_called)
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", fail_if_called)
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": config_name,
+            "__lookup_labels_only": True,
+            "mov-library_movies-template_collection_franchise_exclude__lookup_labels": '{"893731":"PAW Patrol"}',
+            "mov-library_other-template_collection_franchise_exclude__lookup_labels": '{"230161":"Wrong library"}',
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["lookup_labels_only"] is True
+    assert payload["updated"] == 1
+    _validated, _user_entered, saved = database.retrieve_section_data(config_name, "libraries")
+    libraries = saved["libraries"]
+    assert libraries["mov-library_movies-collection_files"] == '[{"type":"url","location":"https://example.com/missing.yml"}]'
+    assert libraries["mov-library_movies-template_collection_franchise_exclude"] == '["893731"]'
+    assert libraries["mov-library_movies-template_collection_franchise_exclude__lookup_labels"] == '{"893731":"PAW Patrol"}'
+    assert "mov-library_other-template_collection_franchise_exclude__lookup_labels" not in libraries
+
+
 def test_autosave_library_returns_400_on_overlay_file_errors(client, isolated_config_dir, qs_module, monkeypatch):
     monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: set())
     monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
@@ -225,6 +276,117 @@ def test_autosave_library_reports_normalized_flag(client, isolated_config_dir, q
     data = resp.get_json()
     assert data["success"] is True
     assert data["normalized"] is True
+
+
+def test_autosave_library_preserves_unloaded_lazy_collection_and_overlay_values(client, isolated_config_dir, qs_module, monkeypatch):
+    from modules import database
+
+    config_name = "pytest_lazy_autosave"
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_language": "English",
+                "mov-library_movies-collection_award": "true",
+                "mov-library_movies-template_collection_award_style": "signature",
+                "mov-library_movies-collection_files": '[{"type":"folder","location":"config/test/collection_files/movies"}]',
+                "mov-library_movies-overlay_resolution": "true",
+                "mov-library_movies-movie-template_overlay_resolution[style]": "compact",
+                "mov-library_movies-overlay_files": '[{"type":"folder","location":"config/test/overlay_files/movies"}]',
+                "mov-library_movies-template_variables[style]": "signature",
+            },
+            "validated": True,
+        },
+    )
+
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: {"mov-library_movies"})
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_library_file_entries_payload",
+        lambda libs, config_name, **kw: (libs, [], False),
+    )
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": [],
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_language": "French",
+        },
+    )
+
+    assert resp.status_code == 200
+    _validated, _user_entered, saved = database.retrieve_section_data(config_name, "libraries")
+    libraries = saved["libraries"]
+    assert libraries["mov-library_movies-attribute_language"] == "French"
+    assert libraries["mov-library_movies-collection_award"] is True
+    assert libraries["mov-library_movies-template_collection_award_style"] == "signature"
+    assert libraries["mov-library_movies-collection_files"] == '[{"type":"folder","location":"config/test/collection_files/movies"}]'
+    assert libraries["mov-library_movies-overlay_resolution"] is True
+    assert libraries["mov-library_movies-movie-template_overlay_resolution[style]"] == "compact"
+    assert libraries["mov-library_movies-overlay_files"] == '[{"type":"folder","location":"config/test/overlay_files/movies"}]'
+    assert libraries["mov-library_movies-template_variables[style]"] == "signature"
+
+
+def test_autosave_library_ignores_lazy_loaded_marker_without_collection_payload(client, isolated_config_dir, qs_module, monkeypatch):
+    from modules import database
+
+    config_name = "pytest_lazy_autosave_false_loaded_marker"
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_language": "English",
+                "mov-library_movies-collection_oscars": "true",
+                "mov-library_movies-template_collection_oscars_data_starting": "first",
+                "mov-library_movies-collection_files": '[{"type":"folder","location":"config/test/collection_files/movies"}]',
+            },
+            "validated": True,
+        },
+    )
+
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: {"mov-library_movies"})
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_library_file_entries_payload",
+        lambda libs, config_name, **kw: (libs, [], False),
+    )
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": ["collections"],
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_language": "French",
+            "mov-library_movies-collection_files": '[{"type":"folder","location":"config/test/collection_files/movies"}]',
+        },
+    )
+
+    assert resp.status_code == 200
+    _validated, _user_entered, saved = database.retrieve_section_data(config_name, "libraries")
+    libraries = saved["libraries"]
+    assert libraries["mov-library_movies-attribute_language"] == "French"
+    assert libraries["mov-library_movies-collection_oscars"] is True
+    assert libraries["mov-library_movies-template_collection_oscars_data_starting"] == "first"
+    assert libraries["mov-library_movies-collection_files"] == '[{"type":"folder","location":"config/test/collection_files/movies"}]'
 
 
 # ===========================================================================

--- a/tests/test_content_rating_overlay_contracts.py
+++ b/tests/test_content_rating_overlay_contracts.py
@@ -169,6 +169,15 @@ def _build_form_payload(case):
     return {"validated": True, "libraries": data}
 
 
+def _build_form_payload_with_color(case, color):
+    payload = _build_form_payload(case)
+    base, _library_name = _base_parts(case)
+    builder = case["builder"]
+    overlay_key = case["overlay_key"]
+    payload["libraries"][f"{base}-{builder}-template_overlay_{overlay_key}[color]"] = color
+    return payload
+
+
 def _run_build_config_with_payload(qs_module, monkeypatch, payload):
     monkeypatch.setattr(
         qs_module.output.helpers,
@@ -254,3 +263,22 @@ def test_content_rating_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_modu
         template_vars = _template_vars_from_yaml(yaml_content, case)
         for key in case["template_vars"]:
             assert template_vars[key] is False
+
+
+def test_content_rating_yaml_omits_default_color_when_not_supplied(monkeypatch, qs_module):
+    case = next(item for item in OVERLAY_CASES if item["id"] == "uk")
+
+    yaml_content = _run_build_config_with_payload(qs_module, monkeypatch, _build_form_payload(case))
+    template_vars = _template_vars_from_yaml(yaml_content, case)
+
+    assert "color" not in template_vars
+
+
+def test_content_rating_yaml_preserves_explicit_false_color(monkeypatch, qs_module):
+    case = next(item for item in OVERLAY_CASES if item["id"] == "uk")
+
+    payload = _build_form_payload_with_color(case, False)
+    yaml_content = _run_build_config_with_payload(qs_module, monkeypatch, payload)
+    template_vars = _template_vars_from_yaml(yaml_content, case)
+
+    assert template_vars["color"] is False

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1,3 +1,6 @@
+import builtins
+import json
+import os
 import re
 
 import pytest
@@ -145,6 +148,47 @@ def test_settings_page_enables_auto_sort_hubs_with_plex_pass(client, monkeypatch
     assert 'value="configured.desc" selected' in html
 
 
+def test_mal_page_preserves_distinct_authorization_hidden_fields(client, monkeypatch, qs_module):
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "140-mal":
+            return {
+                "validated": True,
+                "validated_at": "2026-07-20T00:00:00Z",
+                "user_entered": True,
+                "code_verifier": "verifier",
+                "mal": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "cache_expiration": 60,
+                    "authorization": {
+                        "access_token": "MAL-AT",
+                        "token_type": "Bearer",
+                        "expires_in": 2592000,
+                        "refresh_token": "MAL-RT",
+                    },
+                },
+            }
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/step/140-mal")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    for field_id, expected in {
+        "access_token": "MAL-AT",
+        "token_type": "Bearer",
+        "expires_in": "2592000",
+        "refresh_token": "MAL-RT",
+    }.items():
+        match = re.search(rf'id="{field_id}"[^>]+value="([^"]*)"', html)
+        assert match is not None
+        assert match.group(1) == expected
+
+
 def test_validate_library_auto_sort_hubs_rejects_invalid_value(qs_module):
     errors = qs_module._validate_library_auto_sort_hubs(
         {
@@ -186,6 +230,197 @@ def test_library_fragment_disables_auto_sort_hubs_without_plex_pass(client, monk
     assert 'name="mov-library_movies-top_level_auto_sort_hubs"' not in attrs
     assert 'name="mov-library_movies-top_level_auto_sort_hubs" value="alpha"' in html
     assert "Requires Plex Pass. Validate Plex first if this should be available." in html
+
+
+def test_library_fragment_defers_heavy_collection_and_overlay_sections(client, monkeypatch, qs_module, library_routes_module):
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: ([{"id": "mov-library_movies", "name": "Movies", "type": "movie"}], [], {"plex_pass": True}),
+    )
+    monkeypatch.setattr(library_routes_module, "_migrate_legacy_playlist_libraries_to_library_toggles", lambda *_args: set())
+    monkeypatch.setattr(
+        library_routes_module.helpers,
+        "load_quickstart_config",
+        lambda filename: (
+            [
+                {
+                    "accordion": "Award Collections",
+                    "collections": [
+                        {
+                            "id": "collection_award",
+                            "media_types": ["movie"],
+                            "template_variables": [
+                                {"key": "style", "type": "text_input", "default": "default"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+            if filename == "quickstart_collections.json"
+            else {}
+        ),
+    )
+    monkeypatch.setattr(
+        library_routes_module.helpers,
+        "load_quickstart_overlay_config",
+        lambda: [
+            {
+                "accordion": "Media Overlays",
+                "overlays": [
+                    {
+                        "id": "overlay_resolution",
+                        "media_types": ["movie"],
+                        "template_variables": {
+                            "style": {"input_type": "select", "default": "default"},
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_preview_image_data",
+        lambda: (_ for _ in ()).throw(AssertionError("Initial library fragment should defer preview image data")),
+    )
+
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "025-libraries":
+            return {
+                "libraries": {
+                    "mov-library_movies-library": "Movies",
+                    "mov-library_movies-template_collection_award_style": "custom",
+                    "mov-library_movies-movie-template_overlay_resolution[style]": "custom",
+                }
+            }
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/library_fragment/mov-library_movies")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert 'data-library-lazy-section="collections"' in html
+    assert 'data-library-lazy-section="overlays"' in html
+    assert html.count('data-lazy-override-count="1"') == 2
+    assert "Open this section to load collection settings." in html
+    assert "Open this section to load overlay settings." in html
+
+
+def test_library_fragment_section_renders_requested_heavy_section(client, monkeypatch, qs_module, library_routes_module):
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: ([{"id": "mov-library_movies", "name": "Movies", "type": "movie"}], [], {"plex_pass": True}),
+    )
+    monkeypatch.setattr(library_routes_module, "_migrate_legacy_playlist_libraries_to_library_toggles", lambda *_args: set())
+    monkeypatch.setattr(library_routes_module, "_build_preview_image_data", lambda: {"movie": [], "show": [], "season": [], "episode": []})
+
+    original_load_quickstart_config = library_routes_module.helpers.load_quickstart_config
+
+    def fake_load_quickstart_config(filename):
+        if filename == "quickstart_collections.json":
+            return []
+        return original_load_quickstart_config(filename)
+
+    monkeypatch.setattr(library_routes_module.helpers, "load_quickstart_config", fake_load_quickstart_config)
+    monkeypatch.setattr(library_routes_module.helpers, "load_quickstart_overlay_config", lambda: [])
+
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "025-libraries":
+            return {"libraries": {"mov-library_movies-library": "Movies"}}
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    collections = client.get("/library_fragment/mov-library_movies/section/collections")
+    overlays = client.get("/library_fragment/mov-library_movies/section/overlays")
+
+    assert collections.status_code == 200
+    assert "Reorder Collection Sections" in collections.get_data(as_text=True)
+    assert overlays.status_code == 200
+    assert "Preview Overlays" in overlays.get_data(as_text=True)
+
+
+def test_libraries_step_initial_render_skips_heavy_lazy_card_payload(client, monkeypatch, qs_module):
+    original_load_quickstart_config = qs_module.helpers.load_quickstart_config
+
+    def fail_on_lazy_card_payload(filename):
+        if filename in {
+            "quickstart_attributes.json",
+            "quickstart_collections.json",
+            "quickstart_overlays.json",
+        }:
+            raise AssertionError(f"{filename} should only load from library fragments")
+        return original_load_quickstart_config(filename)
+
+    monkeypatch.setattr(qs_module.helpers, "load_quickstart_config", fail_on_lazy_card_payload)
+    monkeypatch.setattr(
+        qs_module.helpers,
+        "load_quickstart_overlay_config",
+        lambda: (_ for _ in ()).throw(AssertionError("quickstart_overlays.json should only load from library fragments")),
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_build_preview_image_data",
+        lambda: (_ for _ in ()).throw(AssertionError("preview image data should only load from library fragments")),
+    )
+    resp = client.get("/step/025-libraries")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'id="libraryPicker"' in html
+    assert 'id="library-form-container"' in html
+
+
+def test_quickstart_json_config_cache_reuses_file_reads_and_isolates_callers(tmp_path, monkeypatch):
+    from modules.helpers import _overlays
+
+    json_dir = tmp_path / "json"
+    json_dir.mkdir()
+    config_file = json_dir / "sample.json"
+    config_file.write_text(json.dumps({"items": [{"name": "one"}]}), encoding="utf-8")
+    monkeypatch.setattr(_overlays, "JSON_SETTINGS", str(json_dir))
+    _overlays._QUICKSTART_CONFIG_CACHE.clear()
+
+    first = _overlays.load_quickstart_config("sample.json")
+    first["items"][0]["name"] = "mutated"
+
+    original_open = builtins.open
+
+    def fail_open(*args, **kwargs):
+        raise AssertionError("cached config should not reopen the JSON file")
+
+    monkeypatch.setattr(builtins, "open", fail_open)
+    second = _overlays.load_quickstart_config("sample.json")
+    monkeypatch.setattr(builtins, "open", original_open)
+
+    assert second == {"items": [{"name": "one"}]}
+
+
+def test_quickstart_json_config_cache_invalidates_when_file_changes(tmp_path, monkeypatch):
+    from modules.helpers import _overlays
+
+    json_dir = tmp_path / "json"
+    json_dir.mkdir()
+    config_file = json_dir / "sample.json"
+    config_file.write_text(json.dumps({"value": "old"}), encoding="utf-8")
+    monkeypatch.setattr(_overlays, "JSON_SETTINGS", str(json_dir))
+    _overlays._QUICKSTART_CONFIG_CACHE.clear()
+
+    assert _overlays.load_quickstart_config("sample.json") == {"value": "old"}
+
+    config_file.write_text(json.dumps({"value": "new"}), encoding="utf-8")
+    stat = config_file.stat()
+    os.utime(config_file, ns=(stat.st_atime_ns + 1_000_000_000, stat.st_mtime_ns + 1_000_000_000))
+
+    assert _overlays.load_quickstart_config("sample.json") == {"value": "new"}
 
 
 def test_validate_apprise_rejects_bad_url(client):
@@ -1612,6 +1847,30 @@ def test_validate_collection_folder_accepts_managed_relative_folder_path(client,
     assert payload["valid"] is True
     assert payload["normalized_location"].startswith("config/pytest_managed_collection_folder/collection_files/mov-library_movies/")
     assert payload["organized"] is True
+
+
+def test_validate_overlay_folder_accepts_imported_managed_config_path(client, isolated_config_dir):
+    config_name = "pytest_imported_overlay_folder"
+    managed_dir = isolated_config_dir / config_name / "overlay_files" / "mov-library_movies" / "config_overlay_files_abc123"
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    (managed_dir / "ratings.yml").write_text("overlays:\n  test:\n    overlay:\n      name: test\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_overlay_file",
+        json={
+            "config_name": config_name,
+            "library_id": "mov-library_movies",
+            "overlay_file_type": "folder",
+            "overlay_file_location": f"config/{config_name}/overlay_files/mov-library_movies/config_overlay_files_abc123",
+        },
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["validated_files"] == 1
+    assert payload["files"] == ["ratings.yml"]
+    assert payload["organized"] is False
 
 
 def test_validate_metadata_folder_rejects_empty_folder(client, tmp_path):
@@ -5139,6 +5398,81 @@ def test_copy_library_settings_keeps_target_excluded_for_playlist_and_content_ra
     assert libraries["mov-library_target-template_collection_content_rating_us_limit"] == 40
     assert libraries["mov-library_target-movie-overlay_content_rating"] == "uk"
     assert libraries["mov-library_target-movie-template_overlay_content_rating_uk[color]"] == "white"
+
+
+def test_copy_library_settings_preserves_unloaded_lazy_source_sections(client, isolated_config_dir, monkeypatch, app, library_routes_module):
+    from modules import database
+    from flask import session
+
+    config_name = "pytest_copy_lazy_source_sections"
+    database.save_section_data(
+        section="libraries",
+        validated=False,
+        user_entered=True,
+        name=config_name,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-playlist": "true",
+                "mov-library_movies-attribute_language": "en",
+                "mov-library_movies-collection_award": True,
+                "mov-library_movies-template_collection_award_style": "signature",
+                "mov-library_movies-movie-overlay_resolution": "true",
+                "mov-library_movies-movie-template_overlay_resolution[horizontal_align]": "right",
+                "mov-library_target-library": "Other Movies",
+                "libraries": "Movies,Other Movies",
+            },
+            "validated": False,
+        },
+    )
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: (
+            [
+                {"id": "mov-library_movies", "name": "Movies"},
+                {"id": "mov-library_target", "name": "Other Movies"},
+            ],
+            [],
+            {},
+        ),
+    )
+
+    with app.test_request_context("/copy_library_settings"):
+        session["config_name"] = config_name
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/copy_library_settings",
+        json={
+            "source_library_id": "mov-library_movies",
+            "target_library_ids": ["mov-library_target"],
+            "source_payload": {
+                "__loaded_sections": [],
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-playlist": "true",
+                "mov-library_movies-attribute_language": "fr",
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["success"] is True
+
+    _validated, _user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    libraries = stored["libraries"]
+    assert libraries["mov-library_movies-attribute_language"] == "fr"
+    assert libraries["mov-library_movies-template_collection_award_style"] == "signature"
+    assert libraries["mov-library_movies-movie-template_overlay_resolution[horizontal_align]"] == "right"
+    assert libraries["mov-library_target-library"] == ""
+    assert libraries["mov-library_target-playlist"] is True
+    assert libraries["mov-library_target-attribute_language"] == "fr"
+    assert libraries["mov-library_target-collection_award"] is True
+    assert libraries["mov-library_target-template_collection_award_style"] == "signature"
+    assert libraries["mov-library_target-movie-overlay_resolution"] in {True, "true"}
+    assert libraries["mov-library_target-movie-template_overlay_resolution[horizontal_align]"] == "right"
 
 
 def test_sync_managed_library_artifacts_to_kometa_copies_and_prunes(isolated_config_dir, app):

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -161,7 +161,19 @@ def test_prepare_import_payload_maps_apprise_config_to_location():
     payload, report = importer.prepare_import_payload({"apprise": {"config": "/config/apprise.yml"}}, set(), set())
 
     assert payload["apprise"]["apprise"]["location"] == "/config/apprise.yml"
+    assert any(line == "imported: apprise.config" for line in report.lines)
     assert report.counts["imported"] >= 1
+
+
+def test_annotate_yaml_marks_apprise_config_as_imported():
+    raw = "apprise:\n  config: /config/apprise.yml\n"
+    _, report = importer.prepare_import_payload({"apprise": {"config": "/config/apprise.yml"}}, set(), set())
+
+    annotated = importer.annotate_yaml_with_report(raw, report.lines)
+
+    assert "apprise:  # mapped" in annotated
+    assert "config: /config/apprise.yml  # mapped" in annotated
+    assert "No matching Quickstart mapping" not in annotated
 
 
 def test_prepare_import_payload_maps_yamtrack_credentials():

--- a/tests/test_output_id_list_annotations.py
+++ b/tests/test_output_id_list_annotations.py
@@ -93,6 +93,22 @@ def test_settings_ignore_ids_emit_as_commented_sorted_rows(app):
     assert "__lookup_labels" not in yaml_content
 
 
+def test_settings_warning_defaults_emit_as_blank_keys(app):
+    settings = {
+        "settings": {
+            "cache": True,
+            "auto_sort_hubs": None,
+            "playlist_exclude_users": None,
+        }
+    }
+
+    with app.app_context():
+        yaml_content = dump_section("", "settings", settings, "none", None)
+
+    assert re.search(r"^  auto_sort_hubs:\s*$", yaml_content, re.MULTILINE)
+    assert re.search(r"^  playlist_exclude_users:\s*$", yaml_content, re.MULTILINE)
+
+
 def test_library_placeholder_id_emits_saved_lookup_comment(app):
     config_data = {
         "libraries": {


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR improves the Libraries page performance and fixes several regressions caused by lazy-loaded library cards, mirror/autosave behavior, import handling, and final YAML output cleanup.

The biggest change is that the Libraries page no longer loads the full collections/overlays payload during initial page render or automatically loads the first configured library. Instead, the page renders the picker first, loads the selected library card on demand, and defers the heavy Collections and Overlays sections until those accordions are opened.

## Changes

- Lazy-load heavy library sections:
  - Initial `/step/025-libraries` render now skips the large attribute/collection/overlay payload.
  - `/library_fragment/<library_id>` renders the selected library card with deferred Collections/Overlays placeholders.
  - `/library_fragment/<library_id>/section/<section_name>` loads Collections or Overlays only when the user opens that section.
  - Lazy placeholders still show existing override counts so users can see whether deferred sections have custom values.

- Preserve saved data during partial/lazy autosaves:
  - Autosave now tracks which lazy sections were actually loaded.
  - Unloaded Collections/Overlays values are preserved instead of being wiped by incomplete form payloads.
  - Stale `__loaded_sections` markers are ignored unless matching form fields are present.
  - Mirror/copy now preserves unloaded source sections before copying, preventing missing collection/overlay output.

- Improve Libraries page validation with lazy cards:
  - Validation now uses configured library picker options when library cards are not loaded.
  - Stale hidden inputs no longer reselect libraries that the picker says are unconfigured.
  - Prevents the Libraries page from flipping red on return just because no card is currently loaded.

- Reduce frontend work and duplicate event binding:
  - Library event listeners are scoped to the mounted card instead of rescanning the full document.
  - Fixed select listener attachment so select scanning is not nested inside every input loop.
  - Mutation observer reattaches listeners only within relevant scopes.
  - Lookup-label autosave now sends a narrow metadata-only payload instead of full library data.

- Add backend performance caching:
  - Quickstart JSON config loads are cached by file mtime/size.
  - Overlay config enrichment is cached and deep-copied for caller isolation.
  - Cache invalidates when the source JSON changes.

- Fix import and validation edge cases:
  - Apprise import now maps `apprise.config` to Quickstart’s internal `apprise.location` while marking the original source line as imported in the report.
  - Imported managed overlay paths like `config/<config_name>/overlay_files/...` now resolve correctly for validation.
  - Import confirm button is guarded against duplicate submissions/in-flight double-clicks.

- Fix final YAML output issues:
  - `content_rating_*` overlays no longer emit `color: false` unless the user explicitly supplied the color field.
  - Settings output now emits blank keys for `auto_sort_hubs` and `playlist_exclude_users` to avoid Kometa missing-subattribute warnings.
  - Existing ID lookup-label output behavior is preserved.

- Fix MAL token persistence:
  - MAL hidden authorization fields now preserve their distinct values instead of incorrectly reusing `access_token` for `token_type`, `expires_in`, and `refresh_token`.

- Fix Apprise UI:
  - Apprise path/URL field is now treated as visible text, not a masked password field.

## Testing

Added/updated coverage for:

- Lazy library fragment rendering and section loading.
- Autosave preserving unloaded lazy Collections/Overlays.
- Mirror/copy preserving unloaded source data.
- Lookup-label-only autosave skipping expensive file validators.
- Libraries validation using configured picker state before cards are loaded.
- Scoped event listener attachment.
- Duplicate import confirm prevention.
- Quickstart JSON config cache reuse and invalidation.
- Managed imported overlay path validation.
- Apprise import report annotation.
- MAL distinct authorization hidden fields.
- Content rating color output behavior.
- Settings blank default output for Kometa warning suppression.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
