### PR TITLE
fixes for several issues

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -204,6 +204,16 @@ def _library_fragment_context(library_id, *, include_attributes=True, include_co
         "configured_ids": configured_ids,
         "legacy_playlist_libraries": legacy_playlist_libraries,
         "lazy_section_override_counts": _lazy_section_override_counts(library, data.get("libraries", {}), telemetry_data),
+        "collection_group_override_counts": (
+            _collection_group_override_counts_for_library(
+                library,
+                data.get("libraries", {}),
+                collection_config,
+                telemetry_data,
+            )
+            if include_collections
+            else {}
+        ),
     }
 
 
@@ -215,6 +225,22 @@ def _coerce_loaded_library_sections(raw_value):
     if isinstance(raw_value, str):
         return {item.strip() for item in raw_value.split(",") if item.strip()}
     return set()
+
+
+def _coerce_loaded_collection_groups(raw_value):
+    values = raw_value
+    if isinstance(raw_value, str):
+        values = raw_value.split(",")
+    if not isinstance(values, (list, tuple, set)):
+        return set()
+
+    loaded = set()
+    for item in values:
+        try:
+            loaded.add(int(str(item).strip()))
+        except (TypeError, ValueError):
+            continue
+    return loaded
 
 
 def _loaded_sections_with_payload_evidence(library_id, incoming_libraries, loaded_sections):
@@ -339,6 +365,19 @@ def _count_collection_overrides_for_library(library, libraries_data, collection_
     return count
 
 
+def _count_collection_group_overrides_for_library(library, libraries_data, group):
+    return _count_collection_overrides_for_library(library, libraries_data, [group] if isinstance(group, dict) else [])
+
+
+def _collection_group_override_counts_for_library(library, libraries_data, collection_config, telemetry_data=None):
+    if not isinstance(collection_config, list):
+        return {}
+    library_with_plex = dict(library or {})
+    telemetry_data = telemetry_data if isinstance(telemetry_data, dict) else {}
+    library_with_plex["plex_pass"] = bool(telemetry_data.get("plex_pass"))
+    return {index: _count_collection_group_overrides_for_library(library_with_plex, libraries_data, group) for index, group in enumerate(collection_config)}
+
+
 def _iter_overlay_template_items(template_variables):
     if isinstance(template_variables, dict):
         for key, details in template_variables.items():
@@ -350,6 +389,152 @@ def _iter_overlay_template_items(template_variables):
                 key = item.get("key")
                 if key:
                     yield key, item
+
+
+def _overlay_template_defaults_map(template_variables):
+    defaults = {}
+    for key, details in _iter_overlay_template_items(template_variables):
+        defaults[key] = details.get("default") if isinstance(details, dict) else None
+    return defaults
+
+
+def _meaningful_overlay_value(value):
+    if value is None or value is False:
+        return False
+    if isinstance(value, str):
+        stripped = value.strip()
+        return bool(stripped) and stripped.lower() != "none"
+    return True
+
+
+def _overlay_template_value(libraries_data, template_name, key, defaults):
+    value = libraries_data.get(f"{template_name}[{key}]")
+    return value if value is not None else defaults.get(key)
+
+
+def _rating_axis_positions(axis, position, count):
+    safe_count = max(1, min(3, int(count or 1)))
+    constants = {
+        "edge_inset": 30,
+        "center": 0,
+        "v2": 235,
+        "v3": 440,
+        "cv2": 105,
+        "cv3": 205,
+        "h2": 345,
+        "h3": 660,
+        "ch2": 160,
+        "ch3": 335,
+    }
+    if axis == "horizontal":
+        if position == "center":
+            if safe_count == 1:
+                return [constants["center"]]
+            if safe_count == 2:
+                return [-constants["ch2"], constants["ch2"]]
+            return [-constants["ch3"], constants["center"], constants["ch3"]]
+        if position == "right":
+            if safe_count == 1:
+                return [-constants["edge_inset"]]
+            if safe_count == 2:
+                return [-constants["h2"], -constants["edge_inset"]]
+            return [-constants["h3"], -constants["h2"], -constants["edge_inset"]]
+        if safe_count == 1:
+            return [constants["edge_inset"]]
+        if safe_count == 2:
+            return [constants["edge_inset"], constants["h2"]]
+        return [constants["edge_inset"], constants["h2"], constants["h3"]]
+
+    if position == "center":
+        if safe_count == 1:
+            return [constants["center"]]
+        if safe_count == 2:
+            return [-constants["cv2"], constants["cv2"]]
+        return [-constants["cv3"], constants["center"], constants["cv3"]]
+    if position == "bottom":
+        if safe_count == 1:
+            return [-constants["edge_inset"]]
+        if safe_count == 2:
+            return [-constants["v2"], -constants["edge_inset"]]
+        return [-constants["v3"], -constants["v2"], -constants["edge_inset"]]
+    if safe_count == 1:
+        return [constants["edge_inset"]]
+    if safe_count == 2:
+        return [constants["edge_inset"], constants["v2"]]
+    return [constants["edge_inset"], constants["v2"], constants["v3"]]
+
+
+def _rating_overlay_dynamic_defaults(libraries_data, template_name, defaults):
+    alignment = str(_overlay_template_value(libraries_data, template_name, "rating_alignment", defaults) or "vertical").strip().lower()
+    alignment = "horizontal" if alignment == "horizontal" else "vertical"
+    h_pos = str(_overlay_template_value(libraries_data, template_name, "horizontal_position", defaults) or "left").strip().lower()
+    h_pos = h_pos if h_pos in {"left", "center", "right"} else "left"
+    v_pos = str(_overlay_template_value(libraries_data, template_name, "vertical_position", defaults) or "center").strip().lower()
+    v_pos = v_pos if v_pos in {"top", "center", "bottom"} else "center"
+
+    active_slots = []
+    for idx in (1, 2, 3):
+        rating = _overlay_template_value(libraries_data, template_name, f"rating{idx}", defaults)
+        image = _overlay_template_value(libraries_data, template_name, f"rating{idx}_image", defaults)
+        if _meaningful_overlay_value(rating) and _meaningful_overlay_value(image):
+            active_slots.append(idx)
+
+    dynamic = {
+        "back_width": 270 if alignment == "horizontal" else 160,
+        "back_height": 80 if alignment == "horizontal" else 160,
+        "addon_position": "left" if alignment == "horizontal" else "top",
+        "horizontal_offset": 0 if h_pos == "center" else 15,
+        "vertical_offset": 0 if v_pos == "center" else 15,
+    }
+    if not active_slots:
+        return dynamic
+
+    if alignment == "horizontal":
+        h_positions = _rating_axis_positions("horizontal", h_pos, len(active_slots))
+        shared_v = 0 if v_pos == "center" else (-30 if v_pos == "bottom" else 30)
+        for position, idx in enumerate(active_slots):
+            dynamic[f"rating{idx}_horizontal_offset"] = h_positions[position]
+            dynamic[f"rating{idx}_vertical_offset"] = shared_v
+        return dynamic
+
+    v_positions = _rating_axis_positions("vertical", v_pos, len(active_slots))
+    shared_h = 0 if h_pos == "center" else (-30 if h_pos == "right" else 30)
+    for position, idx in enumerate(active_slots):
+        dynamic[f"rating{idx}_horizontal_offset"] = shared_h
+        dynamic[f"rating{idx}_vertical_offset"] = v_positions[position]
+    return dynamic
+
+
+def _overlay_template_effective_default(overlay, key, details, libraries_data, template_name):
+    if overlay.get("id") == "overlay_ratings":
+        defaults = _overlay_template_defaults_map(overlay.get("template_variables"))
+        dynamic_defaults = _rating_overlay_dynamic_defaults(libraries_data, template_name, defaults)
+        if key in dynamic_defaults:
+            return dynamic_defaults[key]
+    return details.get("default")
+
+
+def _overlay_template_key_counts_as_override(overlay, key, details):
+    if key == "builder_level":
+        return False
+    if details.get("input_type") == "hidden" and details.get("default") is None:
+        return False
+    if key == "text" and overlay.get("id") in {"overlay_aspect", "overlay_video_format"}:
+        return False
+    return True
+
+
+def _overlay_group_is_active(library_id, render_type, group, overlay, libraries_data):
+    input_type = str(group.get("input_type") or "checkbox").strip().lower()
+    if input_type == "radio":
+        radio_group_name = str(group.get("radio_group_name") or "").strip()
+        if not radio_group_name:
+            return False
+        field_name = f"{library_id}-{render_type}-{radio_group_name}"
+        return str(libraries_data.get(field_name, "")).strip() == str(overlay.get("value", "")).strip()
+
+    field_name = f"{library_id}-{render_type}-{overlay.get('id')}"
+    return _coerce_bool(libraries_data.get(field_name))
 
 
 def _count_overlay_overrides_for_library(library, libraries_data, overlay_config):
@@ -365,15 +550,18 @@ def _count_overlay_overrides_for_library(library, libraries_data, overlay_config
                 media_types = overlay.get("media_types") or []
                 if media_types and render_type not in media_types:
                     continue
+                if not _overlay_group_is_active(library_id, render_type, group, overlay, libraries_data):
+                    continue
                 template_name = f"{library_id}-{render_type}-template_{overlay.get('id')}"
                 for key, details in _iter_overlay_template_items(overlay.get("template_variables")):
-                    if key == "builder_level":
+                    if not _overlay_template_key_counts_as_override(overlay, key, details):
                         continue
                     var_media_types = details.get("media_types") or []
                     if var_media_types and render_type not in var_media_types:
                         continue
                     field_name = f"{template_name}[{key}]"
-                    if _template_value_is_configured(libraries_data.get(field_name), details.get("default"), details.get("input_type")):
+                    effective_default = _overlay_template_effective_default(overlay, key, details, libraries_data, template_name)
+                    if _template_value_is_configured(libraries_data.get(field_name), effective_default, details.get("input_type")):
                         count += 1
     return count
 
@@ -391,11 +579,50 @@ def _lazy_section_override_counts(library, libraries_data, telemetry_data=None):
     }
 
 
-def _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections):
+def _collection_key_group_indexes(library_id, collection_config, library_type):
+    indexes_by_key = {}
+    if not library_id or not isinstance(collection_config, list):
+        return indexes_by_key
+    for group_index, group in enumerate(collection_config):
+        for collection in group.get("collections", []) if isinstance(group, dict) else []:
+            if library_type not in collection.get("media_types", []):
+                continue
+            collection_id = str(collection.get("id", "")).strip()
+            if not collection_id:
+                continue
+            clean_id = collection_id.replace("collection_", "")
+            indexes_by_key[f"{library_id}-{collection_id}"] = group_index
+            indexes_by_key[f"{library_id}-template_collection_{clean_id}_"] = group_index
+    return indexes_by_key
+
+
+def _collection_key_belongs_to_unloaded_group(key, collection_key_indexes, loaded_collection_groups):
+    if loaded_collection_groups is None:
+        return False
+    for prefix, group_index in collection_key_indexes.items():
+        if (key == prefix or key.startswith(prefix)) and group_index not in loaded_collection_groups:
+            return True
+    return False
+
+
+def _is_collection_default_key(library_id, key):
+    if not isinstance(key, str) or key == f"{library_id}-collection_files":
+        return False
+    return key.startswith(f"{library_id}-collection_") or key.startswith(f"{library_id}-template_collection_")
+
+
+def _drop_collection_default_keys(library_id, libraries_data):
+    if not isinstance(libraries_data, dict):
+        return {}
+    return {key: value for key, value in libraries_data.items() if not _is_collection_default_key(library_id, key)}
+
+
+def _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections, loaded_collection_groups=None):
     """Keep persisted collection/overlay values when those lazy sections were never opened."""
     incoming_libraries = incoming_libraries if isinstance(incoming_libraries, dict) else {}
     unloaded_sections = {"collections", "overlays"} - set(loaded_sections or set())
-    if not unloaded_sections:
+    should_preserve_unloaded_collection_groups = "collections" in set(loaded_sections or set()) and loaded_collection_groups is not None
+    if not unloaded_sections and not should_preserve_unloaded_collection_groups:
         return incoming_libraries
 
     settings = persistence.retrieve_settings("025-libraries")
@@ -405,11 +632,21 @@ def _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loade
 
     preserved = dict(incoming_libraries)
     prefix = f"{library_id}-"
+    library_type = "movie" if str(library_id).startswith("mov-") else "show"
+    collection_key_indexes = {}
+    if should_preserve_unloaded_collection_groups:
+        collection_key_indexes = _collection_key_group_indexes(
+            library_id,
+            helpers.load_quickstart_config("quickstart_collections.json"),
+            library_type,
+        )
 
     def should_preserve(key):
         if not isinstance(key, str) or not key.startswith(prefix):
             return False
-        if "collections" in unloaded_sections and (f"{library_id}-collection_" in key or f"{library_id}-template_collection_" in key or key == f"{library_id}-collection_files"):
+        if should_preserve_unloaded_collection_groups and _collection_key_belongs_to_unloaded_group(key, collection_key_indexes, loaded_collection_groups):
+            return True
+        if "collections" in unloaded_sections and (_is_collection_default_key(library_id, key) or key == f"{library_id}-collection_files"):
             return True
         if "overlays" in unloaded_sections and (
             f"{library_id}-overlay_" in key
@@ -512,6 +749,28 @@ def library_fragment_section(library_id, section_name):
     return render_template(template_name, **context)
 
 
+@bp.route("/library_fragment/<library_id>/section/collections/group/<int:group_index>")
+def library_fragment_collection_group(library_id, group_index):
+    """Return one collection group fragment on demand."""
+    context = _library_fragment_context(
+        library_id,
+        include_attributes=False,
+        include_collections=True,
+        include_overlays=False,
+    )
+
+    if not context:
+        return jsonify({"error": "Library not found"}), 404
+
+    collection_config = context.get("collection_config") or []
+    if group_index < 0 or group_index >= len(collection_config):
+        return jsonify({"error": "Collection group not found"}), 404
+
+    context = dict(context)
+    context["group"] = collection_config[group_index]
+    return render_template("partials/_collection_group_fragment.html", **context)
+
+
 @bp.route("/autosave_library/<library_id>", methods=["POST"])
 def autosave_library(library_id):
     """Merge-save a single library when switching cards without requiring full navigation submit."""
@@ -524,6 +783,9 @@ def autosave_library(library_id):
         if isinstance(incoming, dict) and helpers.booler(incoming.get("__lookup_labels_only")):
             return _save_lookup_label_only_library_payload(library_id, incoming)
         loaded_sections = _coerce_loaded_library_sections(incoming.get("__loaded_sections") if hasattr(incoming, "get") else None)
+        loaded_collection_groups_raw = incoming.get("__loaded_collection_groups") if hasattr(incoming, "get") else None
+        loaded_collection_groups = _coerce_loaded_collection_groups(loaded_collection_groups_raw) if loaded_collection_groups_raw is not None else None
+        reset_collection_defaults = helpers.booler(incoming.get("__reset_collection_defaults") if hasattr(incoming, "get") else None)
         config_name = persistence.resolve_request_config_name(incoming if isinstance(incoming, dict) else {})
         errors = path_validation.validate_payload(incoming)
         if errors:
@@ -531,10 +793,17 @@ def autosave_library(library_id):
         clean_source = dict(incoming) if isinstance(incoming, dict) else incoming
         if isinstance(clean_source, dict):
             clean_source.pop("__loaded_sections", None)
+            clean_source.pop("__loaded_collection_groups", None)
+            clean_source.pop("__reset_collection_defaults", None)
         clean_payload = persistence.clean_form_data(MultiDict(clean_source))
         incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
         loaded_sections = _loaded_sections_with_payload_evidence(library_id, incoming_libraries, loaded_sections)
-        incoming_libraries = _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections)
+        if reset_collection_defaults:
+            loaded_sections.add("collections")
+            incoming_libraries = _drop_collection_default_keys(library_id, incoming_libraries)
+        incoming_libraries = _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections, loaded_collection_groups)
+        if reset_collection_defaults:
+            incoming_libraries = _drop_collection_default_keys(library_id, incoming_libraries)
         selected_library_ids = _qs._selected_library_ids_from_libraries_data(incoming_libraries)
         collection_errors = _qs._validate_library_collection_files(incoming_libraries, selected_library_ids)
         metadata_errors = _qs._validate_library_metadata_files(incoming_libraries, selected_library_ids)
@@ -556,6 +825,11 @@ def autosave_library(library_id):
         if normalization_errors:
             return jsonify({"success": False, "error": "Unable to organize library files.", "errors": normalization_errors}), 400
         save_payload = dict(incoming) if isinstance(incoming, dict) else {}
+        save_payload.pop("__loaded_sections", None)
+        save_payload.pop("__loaded_collection_groups", None)
+        save_payload.pop("__reset_collection_defaults", None)
+        if reset_collection_defaults:
+            save_payload = _drop_collection_default_keys(library_id, save_payload)
         save_payload.update(normalized_libraries)
         save_payload["config_name"] = config_name
         persistence.save_settings("025-libraries", save_payload)
@@ -704,6 +978,8 @@ def copy_library_settings():
         if isinstance(source_payload, dict) and source_payload:
             source_payload_for_merge = dict(source_payload)
             loaded_sections = _coerce_loaded_library_sections(source_payload_for_merge.pop("__loaded_sections", []))
+            loaded_collection_groups_raw = source_payload_for_merge.pop("__loaded_collection_groups", None)
+            loaded_collection_groups = _coerce_loaded_collection_groups(loaded_collection_groups_raw) if loaded_collection_groups_raw is not None else None
             payload_errors = path_validation.validate_payload(source_payload_for_merge)
             if payload_errors:
                 return (
@@ -736,7 +1012,12 @@ def copy_library_settings():
                         400,
                     )
                 loaded_sections = _loaded_sections_with_payload_evidence(source_prefix, normalized_incoming, loaded_sections)
-                incoming_dict = _preserve_unloaded_lazy_section_values(source_prefix, normalized_incoming, loaded_sections)
+                incoming_dict = _preserve_unloaded_lazy_section_values(
+                    source_prefix,
+                    normalized_incoming,
+                    loaded_sections,
+                    loaded_collection_groups,
+                )
 
                 merged = libraries_data.copy()
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2042,7 +2042,8 @@ fieldset:disabled .btn {
 
 .collection-variable-section,
 .overlay-variable-section,
-.template-toggle-group {
+.template-toggle-group,
+.accordion-item.template-variable-section-has-overrides {
     position: relative;
     transition: background-color 0.2s ease, border-color 0.2s ease;
 }
@@ -2067,6 +2068,10 @@ fieldset:disabled .btn {
     border-radius: 0 4px 4px 0;
     background: var(--theme-primary);
     box-shadow: 0 0 10px rgba(var(--accent-color), 0.35);
+}
+
+.accordion-item.template-variable-section-has-overrides > .accordion-header {
+    border-left: 4px solid var(--theme-primary) !important;
 }
 
 .accordion-header.template-variable-section-has-overrides {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -505,7 +505,7 @@ function setButtonIconAndText (button, iconClasses, text) {
 function showToast (type, message) {
   const toastId = `toast-${Date.now()}` // Unique ID for each toast
   const toastContainer = document.querySelector('.toast-container')
-  const safeMessage = escapeHtml(message)
+  const safeMessage = escapeHtml(message).replace(/\r?\n/g, '<br>')
 
   // Define Bootstrap colors, icons, and progress bar styles per type
   const toastConfig = {
@@ -2558,7 +2558,7 @@ function restoreBlankCacheExpirations () {
           ? `${item.label} was blank. Set to minimum: ${item.value}.`
           : `${item.label} was blank. Restored to default: ${item.value}.`
       ))
-      .join('<br>')
+      .join('\n')
     showToast('info', message)
   }
 }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2069,6 +2069,26 @@ function initPlaylistFilesEditors (scope) {
   })
 }
 
+function renderLibraryFileEditorForHiddenInput (input) {
+  if (!input || input.type !== 'hidden') return false
+
+  const editorConfigs = [
+    { selector: '[data-metadata-files-editor]', render: renderMetadataFilesEditor },
+    { selector: '[data-collection-files-editor]', render: renderCollectionFilesEditor },
+    { selector: '[data-overlay-files-editor]', render: renderOverlayFilesEditor },
+    { selector: '[data-playlist-files-editor]', render: renderPlaylistFilesEditor }
+  ]
+
+  for (const config of editorConfigs) {
+    const editor = input.closest(config.selector)
+    if (!editor) continue
+    config.render(editor)
+    return true
+  }
+
+  return false
+}
+
 document.addEventListener('click', async event => {
   const addButton = event.target.closest('[data-add-playlist-file]')
   if (addButton) {
@@ -5385,7 +5405,9 @@ function initializeLibraryCardControls (card, libraryId) {
   wireOverlayVariableSections(card)
   wireCollectionVariableSections(card)
   wireLibraryOverrideScopes(card)
+  wireLazyCollectionGroups(card)
   updateLazySectionOverrideSummaries(card)
+  refreshTemplateOverrideState(card)
   wireOffsetReset(card)
   if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
     OverlayHandler.initializeOverlayBoards(card)
@@ -5462,6 +5484,127 @@ function wireLazyLibrarySections (card) {
   card.dataset.lazyLibrarySectionsBound = 'true'
 }
 
+function loadedCollectionGroupMarker (card) {
+  if (!card) return null
+  let marker = card.querySelector('input[type="hidden"][name="__loaded_collection_groups"]')
+  if (marker) return marker
+
+  marker = document.createElement('input')
+  marker.type = 'hidden'
+  marker.name = '__loaded_collection_groups'
+  marker.value = ''
+  card.appendChild(marker)
+  return marker
+}
+
+function resetCollectionDefaultsMarker (card) {
+  if (!card) return null
+  let marker = card.querySelector('input[type="hidden"][name="__reset_collection_defaults"]')
+  if (marker) return marker
+
+  marker = document.createElement('input')
+  marker.type = 'hidden'
+  marker.name = '__reset_collection_defaults'
+  marker.value = 'false'
+  card.appendChild(marker)
+  return marker
+}
+
+function markCollectionDefaultsReset (card) {
+  const marker = resetCollectionDefaultsMarker(card)
+  if (marker) marker.value = 'true'
+}
+
+function markLazyCollectionGroupLoaded (card, groupIndex) {
+  const marker = loadedCollectionGroupMarker(card)
+  if (!marker) return
+  const values = new Set(String(marker.value || '').split(',').map(value => value.trim()).filter(Boolean))
+  values.add(String(groupIndex))
+  marker.value = Array.from(values).sort((a, b) => Number(a) - Number(b)).join(',')
+}
+
+function loadLazyCollectionGroup (collapse, card) {
+  if (!collapse || collapse.dataset?.collectionGroupLazyCollapse !== 'true') {
+    return Promise.resolve(collapse?.closest('[data-collection-group-shell="true"]') || null)
+  }
+  if (collapse.dataset.lazyState === 'loading') {
+    return Promise.reject(new Error('Collection group is already loading.'))
+  }
+
+  const libraryId = collapse.dataset.libraryId || card?.dataset?.libraryId || activeLibraryId
+  const groupIndex = collapse.dataset.collectionGroupIndex
+  if (!libraryId || groupIndex === undefined) {
+    return Promise.reject(new Error('Missing collection group identifiers.'))
+  }
+
+  const shell = collapse.closest('[data-collection-group-shell="true"]')
+  const placeholder = collapse.querySelector('[data-collection-group-lazy-placeholder]')
+  const spinner = placeholder?.querySelector('.spinner-border')
+  const status = placeholder?.querySelector('span')
+  collapse.dataset.lazyState = 'loading'
+  spinner?.classList.remove('d-none')
+  if (status) status.textContent = 'Loading collection group settings...'
+
+  return fetch(`/library_fragment/${encodeURIComponent(libraryId)}/section/collections/group/${encodeURIComponent(groupIndex)}`, {
+    credentials: 'same-origin'
+  })
+    .then(res => {
+      if (!res.ok) throw new Error(`Failed to load collection group (${res.status})`)
+      return res.text()
+    })
+    .then(html => {
+      if (!shell) return null
+      const template = document.createElement('template')
+      template.innerHTML = String(html || '').trim()
+      const replacement = template.content.firstElementChild
+      if (!replacement) throw new Error('Empty collection group fragment')
+      shell.replaceWith(replacement)
+      replacement.dataset.collectionGroupLoaded = 'true'
+      replacement.dataset.collectionGroupIndex = String(groupIndex)
+      const replacementCollapse = replacement.querySelector('.accordion-collapse')
+      const replacementButton = replacement.querySelector('.accordion-button')
+      if (replacementCollapse) {
+        replacementCollapse.classList.add('show')
+        replacementCollapse.dataset.collectionGroupLoaded = 'true'
+        replacementCollapse.dataset.collectionGroupIndex = String(groupIndex)
+      }
+      if (replacementButton) {
+        replacementButton.classList.remove('collapsed')
+        replacementButton.setAttribute('aria-expanded', 'true')
+      }
+      markLazyCollectionGroupLoaded(card, groupIndex)
+      initializeLibraryCardControls(card, libraryId)
+      refreshTemplateOverrideState(card)
+      return replacement
+    })
+}
+
+function wireLazyCollectionGroups (card) {
+  if (!card || card.dataset.lazyCollectionGroupsBound === 'true') return
+
+  card.addEventListener('shown.bs.collapse', event => {
+    const collapse = event.target
+    if (!collapse || collapse.dataset?.collectionGroupLazyCollapse !== 'true') return
+    if (collapse.dataset.lazyState === 'loaded' || collapse.dataset.lazyState === 'loading') return
+    const placeholder = collapse.querySelector('[data-collection-group-lazy-placeholder]')
+    const spinner = placeholder?.querySelector('.spinner-border')
+    const status = placeholder?.querySelector('span')
+
+    loadLazyCollectionGroup(collapse, card)
+      .catch(err => {
+        console.error('[Libraries] Failed to load lazy collection group', err)
+        collapse.dataset.lazyState = 'error'
+        spinner?.classList.add('d-none')
+        if (status) status.textContent = 'Unable to load this collection group. Close and reopen it to retry.'
+        if (typeof showToast === 'function') {
+          showToast('error', 'Unable to load collection group settings. Try again.')
+        }
+      })
+  })
+
+  card.dataset.lazyCollectionGroupsBound = 'true'
+}
+
 function mountCard (card, libraryId) {
   libraryContainer.replaceChildren()
   setCachedCardFormSubmission(card, false)
@@ -5517,6 +5660,22 @@ function buildPayloadFromCard (card) {
     }
   })
   payload.__loaded_sections = loadedLazySections
+  const loadedCollectionGroups = new Set()
+  const collectionGroupMarker = card.querySelector('input[type="hidden"][name="__loaded_collection_groups"]')
+  String(collectionGroupMarker?.value || '').split(',').forEach(value => {
+    const trimmed = value.trim()
+    if (trimmed) loadedCollectionGroups.add(trimmed)
+  })
+  card.querySelectorAll('[data-collection-group-loaded="true"][data-collection-group-index]').forEach(group => {
+    loadedCollectionGroups.add(String(group.dataset.collectionGroupIndex || '').trim())
+  })
+  payload.__loaded_collection_groups = Array.from(loadedCollectionGroups)
+    .filter(Boolean)
+    .sort((a, b) => Number(a) - Number(b))
+  const resetCollectionDefaults = card.querySelector('input[type="hidden"][name="__reset_collection_defaults"]')
+  if (resetCollectionDefaults && resetCollectionDefaults.value === 'true') {
+    payload.__reset_collection_defaults = 'true'
+  }
   const checkboxNames = new Set(
     Array.from(card.querySelectorAll('input[type="checkbox"][name]'))
       .map(el => String(el.name || '').trim())
@@ -5535,6 +5694,7 @@ function buildPayloadFromCard (card) {
   })
   card.querySelectorAll('input, select, textarea').forEach(el => {
     if (!el.name || el.disabled) return
+    if (el.name === '__loaded_collection_groups' || el.name === '__reset_collection_defaults') return
     if (el.dataset && el.dataset.skipYaml === 'true') return
     if (el.type === 'file') return
 
@@ -5595,34 +5755,11 @@ function initLibraryAssetDirectoryInputs (card) {
     const inputName = container.dataset.inputName
     const addBtnSelector = `[data-add-asset-directory="${container.id}"]`
     const addBtn = card.querySelector(addBtnSelector)
-    let counter = container.querySelectorAll(`input[name="${inputName}"]`).length
-
-    const buildRow = (value = '') => {
-      counter += 1
-      const row = document.createElement('div')
-      row.className = 'input-group mb-2'
-
-      const input = document.createElement('input')
-      input.type = 'text'
-      input.className = 'form-control'
-      input.name = inputName
-      input.id = `${container.id}_${counter}`
-      input.placeholder = 'Add Asset Directory'
-      input.dataset.pathRule = 'asset_directory'
-      input.value = value
-
-      const removeBtn = document.createElement('button')
-      removeBtn.className = 'btn btn-danger library-remove-asset-directory'
-      removeBtn.type = 'button'
-      removeBtn.textContent = 'Remove'
-
-      row.append(input, removeBtn)
-      return row
-    }
+    container.dataset.assetDirectoryCounter = String(container.querySelectorAll(`input[name="${inputName}"]`).length)
 
     if (addBtn) {
       addBtn.addEventListener('click', () => {
-        const row = buildRow('')
+        const row = buildLibraryAssetDirectoryRow(container, inputName, '')
         container.appendChild(row)
         if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
           PathValidation.attach(row)
@@ -5643,6 +5780,75 @@ function initLibraryAssetDirectoryInputs (card) {
       container.removeChild(fieldGroup)
     })
   })
+}
+
+function buildLibraryAssetDirectoryRow (container, inputName, value = '') {
+  const current = Number(container?.dataset?.assetDirectoryCounter || '0') || 0
+  const next = current + 1
+  if (container) {
+    container.dataset.assetDirectoryCounter = String(next)
+  }
+
+  const row = document.createElement('div')
+  row.className = 'input-group mb-2'
+
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.className = 'form-control'
+  input.name = inputName
+  input.id = `${container?.id || 'asset_directory'}_${next}`
+  input.placeholder = 'Add Asset Directory'
+  input.dataset.pathRule = 'asset_directory'
+  input.value = value
+
+  const removeBtn = document.createElement('button')
+  removeBtn.className = 'btn btn-danger library-remove-asset-directory'
+  removeBtn.type = 'button'
+  removeBtn.textContent = 'Remove'
+
+  row.append(input, removeBtn)
+  return row
+}
+
+function resetLibraryAssetDirectoryContainers (scope, changes) {
+  if (!scope) return []
+  const changedInputs = []
+
+  scope.querySelectorAll('[data-library-asset-directory-container]').forEach(container => {
+    const inputName = container.dataset.inputName
+    if (!inputName) return
+
+    const rows = Array.from(container.querySelectorAll('.input-group'))
+    const values = Array.from(container.querySelectorAll(`input[name="${inputName}"]`))
+      .map(input => String(input.value || '').trim())
+    const populated = values.filter(Boolean)
+    const needsReset = populated.length > 0 || rows.length !== 1
+    if (!needsReset) return
+
+    if (Array.isArray(changes)) {
+      changes.push({
+        label: 'Asset Directory',
+        from: populated.length ? populated.join(', ') : `${rows.length} blank rows`,
+        to: 'Default'
+      })
+    }
+
+    container.replaceChildren()
+    container.dataset.assetDirectoryCounter = '0'
+    const row = buildLibraryAssetDirectoryRow(container, inputName, '')
+    container.appendChild(row)
+    if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
+      PathValidation.attach(row)
+    }
+    const input = row.querySelector(`input[name="${inputName}"]`)
+    if (input) {
+      changedInputs.push(input)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+  })
+
+  return changedInputs
 }
 
 function scheduleLookupLabelAutosave (delayMs = 900) {
@@ -5868,6 +6074,7 @@ function openCopyModal (sourceId, sourceName, sourceType) {
         if (libraryPicker && libraryPicker.value) {
           loadLibrary(libraryPicker.value)
         }
+        refreshTemplateOverrideState(libraryContainer?.firstElementChild || document)
         if (typeof showToast === 'function') {
           const label = filtered.length === 1 ? 'library' : 'libraries'
           showToast('success', `Mirrored settings to ${filtered.length} ${label}.`)
@@ -6637,7 +6844,7 @@ function setupMappingListHandlers (prefix, scope) {
   })
 }
 
-async function runCollectionGroupReset (btn, group) {
+async function runCollectionGroupReset (btn, group, options = {}) {
   if (!btn || !group || btn.dataset.resetBusy === 'true') return
 
   const idleLabel = btn.dataset.resetIdleLabel || btn.textContent.trim() || 'Reset to Defaults'
@@ -6649,12 +6856,6 @@ async function runCollectionGroupReset (btn, group) {
     await new Promise(resolve => requestAnimationFrame(() => resolve()))
     await new Promise(resolve => window.setTimeout(resolve, 0))
   }
-  const escapeHtml = (value) => String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
   const getInputLabel = (input) => {
     if (!input) return 'Field'
     const describedBy = input.getAttribute('aria-describedby')
@@ -6715,11 +6916,11 @@ async function runCollectionGroupReset (btn, group) {
       return
     }
     const preview = changes.slice(0, 12)
-      .map(change => `${escapeHtml(change.label)}: ${escapeHtml(change.from)} → ${escapeHtml(change.to)}`)
-      .join('<br>')
+      .map(change => `${change.label}: ${change.from} -> ${change.to}`)
+      .join('\n')
     const extraCount = changes.length - 12
-    const suffix = extraCount > 0 ? `<br>...and ${extraCount} more field${extraCount === 1 ? '' : 's'}.` : ''
-    showToast('info', `Reset to defaults (${changes.length} field${changes.length === 1 ? '' : 's'}):<br>${preview}${suffix}`)
+    const suffix = extraCount > 0 ? `\n...and ${extraCount} more field${extraCount === 1 ? '' : 's'}.` : ''
+    showToast('info', `Reset to defaults (${changes.length} field${changes.length === 1 ? '' : 's'}):\n${preview}${suffix}`)
   }
 
   try {
@@ -6736,11 +6937,19 @@ async function runCollectionGroupReset (btn, group) {
       const from = getDisplayValue(input)
       const to = getDefaultDisplayValue(input, defaultValue)
       if (from !== to) {
-        changes.push({ label: getInputLabel(input), from, to })
+        const scheduleEquivalent = input.closest('[data-schedule-builder]') &&
+          normalizeScheduleOverrideValue(from) === normalizeScheduleOverrideValue(to)
+        if (!scheduleEquivalent) {
+          changes.push({ label: getInputLabel(input), from, to })
+        }
         return true
       }
       return false
     }
+
+    resetLibraryAssetDirectoryContainers(group, changes).forEach(input => {
+      pendingChangeInputs.add(input)
+    })
 
     const inputs = Array.from(group.querySelectorAll('input[data-default], select[data-default], textarea[data-default]'))
     for (let index = 0; index < inputs.length; index += 1) {
@@ -6758,7 +6967,10 @@ async function runCollectionGroupReset (btn, group) {
         if (changed) input.checked = nextChecked
       } else {
         changed = recordReset(input, defaultValue)
-        if (changed) input.value = defaultValue
+        if (changed) {
+          input.value = defaultValue
+          renderLibraryFileEditorForHiddenInput(input)
+        }
       }
 
       if (changed) {
@@ -6789,7 +7001,9 @@ async function runCollectionGroupReset (btn, group) {
     if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
       ValidationHandler.updateValidationState()
     }
-    finalizeToast(changes)
+    if (!options.suppressToast) {
+      finalizeToast(changes)
+    }
   } finally {
     delete group.dataset.resetting
     btn.dataset.resetBusy = 'false'
@@ -6802,6 +7016,75 @@ function wireOffsetReset (scope) {
   root.querySelectorAll('.reset-offset-btn').forEach(btn => {
     if (btn.dataset.listenerAdded) return
     btn.addEventListener('click', async () => {
+      if (btn.dataset.collectionAllReset === 'true') {
+        const sectionBody = btn.closest('.accordion-body')
+        if (sectionBody) {
+          const card = btn.closest('.library-settings-card')
+          try {
+            markCollectionDefaultsReset(card)
+            clearLazyCollectionShellOverrideSummaries(sectionBody)
+            await runCollectionGroupReset(btn, sectionBody, { suppressToast: true })
+            setLibrariesButtonPersistentBusy(btn, true, 'Saving...')
+            refreshTemplateOverrideState(sectionBody.closest('.accordion-collapse') || sectionBody)
+            await autosaveActiveLibrary({ quiet: true })
+            if (typeof showToast === 'function') {
+              showToast('info', 'Collections reset to defaults.')
+            }
+          } catch (error) {
+            console.error('[collections reset failed]', error)
+            if (typeof showToast === 'function') {
+              showToast('error', 'Collections reset to defaults failed.')
+            }
+          } finally {
+            const marker = card?.querySelector('input[type="hidden"][name="__reset_collection_defaults"]')
+            if (marker) marker.value = 'false'
+            setLibrariesButtonPersistentBusy(btn, false)
+          }
+          return
+        }
+      }
+
+      if (btn.dataset.collectionParentReset === 'true') {
+        let sectionBody = btn.closest('.accordion-body')
+        if (!sectionBody) {
+          const groupShell = btn.closest('[data-collection-group-shell="true"]')
+          const lazyCollapse = groupShell?.querySelector('[data-collection-group-lazy-collapse="true"]')
+          if (lazyCollapse) {
+            try {
+              setLibrariesButtonPersistentBusy(btn, true)
+              const card = btn.closest('.library-settings-card')
+              const replacement = await loadLazyCollectionGroup(lazyCollapse, card)
+              const resetBtn = replacement?.querySelector('[data-collection-parent-reset="true"]')
+              sectionBody = replacement?.querySelector('.accordion-body')
+              if (sectionBody && resetBtn) {
+                await runCollectionGroupReset(resetBtn, sectionBody)
+                refreshTemplateOverrideState(sectionBody.closest('.accordion-collapse') || sectionBody)
+              }
+            } catch (error) {
+              console.error('[collection parent reset failed]', error)
+              if (typeof showToast === 'function') {
+                showToast('error', 'Collection group reset to defaults failed.')
+              }
+            } finally {
+              setLibrariesButtonPersistentBusy(btn, false)
+            }
+            return
+          }
+          sectionBody = btn.closest('.accordion')?.querySelector(':scope > .accordion-item > .accordion-collapse > .accordion-body')
+        }
+        if (sectionBody) {
+          runCollectionGroupReset(btn, sectionBody).then(() => {
+            refreshTemplateOverrideState(sectionBody.closest('.accordion-collapse') || sectionBody)
+          }).catch(error => {
+            console.error('[collection parent reset failed]', error)
+            if (typeof showToast === 'function') {
+              showToast('error', 'Collection group reset to defaults failed.')
+            }
+          })
+          return
+        }
+      }
+
       if (btn.dataset.collectionVariableSectionReset === 'true') {
         const section = btn.closest('[data-collection-variable-section="true"]')
         const sectionBody = section?.querySelector('.collection-variable-section-body') || section
@@ -6880,12 +7163,6 @@ function wireOffsetReset (scope) {
         const changes = []
         const touched = new Set()
         const isRatingsOverlay = group?.dataset?.overlayId === 'overlay_ratings'
-        const escapeHtml = (value) => String(value ?? '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;')
       const getInputLabel = (input) => {
         if (!input) return 'Field'
         const describedBy = input.getAttribute('aria-describedby')
@@ -6998,6 +7275,7 @@ function wireOffsetReset (scope) {
           const changed = recordReset(input, defaultValue)
           if (changed) {
             input.value = defaultValue
+            renderLibraryFileEditorForHiddenInput(input)
             input.dispatchEvent(new Event('change', { bubbles: true }))
           }
         }
@@ -7017,7 +7295,10 @@ function wireOffsetReset (scope) {
             if (changed) input.checked = nextChecked
           } else {
             const changed = recordReset(input, defaultValue)
-            if (changed) input.value = defaultValue
+            if (changed) {
+              input.value = defaultValue
+              renderLibraryFileEditorForHiddenInput(input)
+            }
           }
           if (changes.length && touched.has(input)) {
             input.dispatchEvent(new Event('input', { bubbles: true }))
@@ -7058,9 +7339,9 @@ function wireOffsetReset (scope) {
       const finalizeToast = () => {
         if (changes.length && typeof showToast === 'function') {
           const details = changes
-            .map(change => `${escapeHtml(change.label)}: ${escapeHtml(change.from)} → ${escapeHtml(change.to)}`)
-            .join('<br>')
-          showToast('info', `Reset to defaults:<br>${details}`)
+            .map(change => `${change.label}: ${change.from} -> ${change.to}`)
+            .join('\n')
+          showToast('info', `Reset to defaults:\n${details}`)
         } else if (!changes.length && typeof showToast === 'function') {
           showToast('info', 'Already at defaults (no changes).')
         }
@@ -7616,6 +7897,7 @@ function wireRatingsOffsetSync (scope) {
     if (metricInputs.backPadding) metricInputs.backPadding.addEventListener('change', refreshDerivedOffsets)
 
     updateAdjustedIndicators()
+    refreshTemplateOverrideState(group)
     group.dataset.ratingsOffsetSyncBound = 'true'
   })
 }
@@ -7762,11 +8044,43 @@ function parseCollectionSectionStoredMapping (rawValue) {
   return {}
 }
 
+function normalizeScheduleOverrideValue (rawValue) {
+  const raw = String(rawValue || '').trim().toLowerCase()
+  if (!raw) return ''
+  const normalizeMonthDay = value => {
+    const match = String(value || '').trim().match(/^0*(\d{1,2})\/0*(\d{1,2})$/)
+    if (!match) return String(value || '').trim().toLowerCase()
+    return `${Number(match[1])}/${Number(match[2])}`
+  }
+  const normalizeDate = value => {
+    const match = String(value || '').trim().match(/^0*(\d{1,2})\/0*(\d{1,2})\/(\d{4})$/)
+    if (!match) return String(value || '').trim().toLowerCase()
+    return `${Number(match[1])}/${Number(match[2])}/${match[3]}`
+  }
+
+  const wrapperMatch = raw.match(/^([a-z_]+)\((.*)\)$/)
+  if (!wrapperMatch) return raw.replace(/\s+/g, '')
+  const mode = wrapperMatch[1]
+  const inner = wrapperMatch[2].trim()
+  if (mode === 'range' && !inner.includes('|')) {
+    const parts = inner.split('-').map(value => value.trim())
+    return `range(${normalizeMonthDay(parts[0])}-${normalizeMonthDay(parts[1])})`
+  }
+  if (mode === 'yearly') return `yearly(${normalizeMonthDay(inner)})`
+  if (mode === 'date') return `date(${normalizeDate(inner)})`
+  if (mode === 'weekly') {
+    return `weekly(${inner.split('|').map(value => value.trim().toLowerCase()).filter(Boolean).join('|')})`
+  }
+  return `${mode}(${inner.replace(/\s+/g, '')})`
+}
+
 function isInternalTemplateMetadataField (field) {
   if (!field) return false
   const name = String(field.name || '').trim()
   return field.dataset?.skipOverrideCount === 'true' ||
+    field.dataset?.skipYaml === 'true' ||
     field.dataset?.templateMetadata === 'lookup-labels' ||
+    name.includes('-library_service_') ||
     name.endsWith('_hidden') ||
     name.endsWith('__lookup_labels')
 }
@@ -7796,6 +8110,10 @@ function isCollectionSectionFieldConfigured (fields) {
   const primaryField = visibleFields[0] || enabledFields[0]
   if (!primaryField) return false
 
+  if (String(primaryField.name || '').endsWith('-attribute_asset_directory')) {
+    return visibleFields.some(field => String(field.value ?? '').trim())
+  }
+
   if (primaryField.closest('[data-template-string-list]')) {
     const values = parseCollectionSectionStoredStringList(primaryField.value)
     const defaults = parseCollectionSectionStoredStringList(primaryField.dataset.default || '[]')
@@ -7810,6 +8128,9 @@ function isCollectionSectionFieldConfigured (fields) {
 
   const value = String(primaryField.value ?? '').trim()
   const defaultValue = String(primaryField.dataset.default || '').trim()
+  if (primaryField.closest('[data-schedule-builder]')) {
+    return normalizeScheduleOverrideValue(value) !== normalizeScheduleOverrideValue(defaultValue)
+  }
   if (!value) return false
   return defaultValue ? value !== defaultValue : true
 }
@@ -7827,6 +8148,12 @@ function setOverrideSummaryBadge (badge, count) {
 function findTemplateVariableFieldRow (field) {
   if (!field) return null
   return field.closest(
+    '[data-playlist-files-editor], ' +
+    '[data-collection-files-editor], ' +
+    '[data-metadata-files-editor], ' +
+    '[data-overlay-files-editor], ' +
+    '[data-playlist-key-toggle-group], ' +
+    '[data-playlist-user-picker], ' +
     '[data-template-string-list], ' +
     '[data-template-mapping-list], ' +
     '[data-overlay-language-weight-builder], ' +
@@ -7905,9 +8232,7 @@ function updateAncestorOverrideSummaries (element) {
     seen.add(collapse)
     const accordionItem = collapse.closest('.accordion-item')
     const header = accordionItem?.querySelector('.accordion-header')
-    const count = Array.from(collapse.querySelectorAll('.template-toggle-group')).reduce((total, group) => {
-      return total + (Number(group.dataset.overrideCount || '0') || 0)
-    }, 0)
+    const count = getAccordionCollapseOverrideCount(collapse)
 
     accordionItem?.classList.toggle('template-variable-section-has-overrides', count > 0)
     header?.classList.toggle('template-variable-section-has-overrides', count > 0)
@@ -7915,6 +8240,7 @@ function updateAncestorOverrideSummaries (element) {
 
     collapse = accordionItem?.parentElement?.closest('.accordion-collapse')
   }
+  updateLibraryAggregateOverrideSummaries(element?.closest('.library-settings-card'))
 }
 
 function updateLazySectionOverrideSummaries (scope) {
@@ -7929,6 +8255,84 @@ function updateLazySectionOverrideSummaries (scope) {
     header?.classList.toggle('template-variable-section-has-overrides', count > 0)
     setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
   })
+  root.querySelectorAll?.('[data-collection-group-lazy-collapse][data-lazy-override-count]').forEach(collapse => {
+    const count = Number(collapse.dataset.lazyOverrideCount || '0') || 0
+    const item = collapse.closest('.accordion-item')
+    const header = item?.querySelector(':scope > .accordion-header') || item?.querySelector('.accordion-header')
+
+    item?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    header?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
+  })
+}
+
+function clearLazyCollectionShellOverrideSummaries (scope) {
+  const root = scope || document
+  root.querySelectorAll?.('[data-collection-group-lazy-collapse][data-lazy-override-count]').forEach(collapse => {
+    collapse.dataset.lazyOverrideCount = '0'
+    const item = collapse.closest('.accordion-item')
+    const header = item?.querySelector(':scope > .accordion-header') || item?.querySelector('.accordion-header')
+
+    item?.classList.remove('template-variable-section-has-overrides')
+    header?.classList.remove('template-variable-section-has-overrides')
+    setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), 0)
+  })
+}
+
+function isOverlayTemplateGroupActiveForCounts (group) {
+  const toggle = group?.querySelector('.overlay-toggle')
+  return !toggle || toggle.checked
+}
+
+function getDirectChildAccordionItems (collapse) {
+  return Array.from(collapse?.querySelectorAll?.(':scope > .accordion-body > .accordion > .accordion-item') || [])
+}
+
+function getAccordionCollapseOverrideCount (collapse) {
+  const explicitCount = Number(collapse?.dataset?.overrideCount || '')
+  if (Number.isFinite(explicitCount) && explicitCount > 0) return explicitCount
+
+  const lazyCount = Number(collapse?.querySelector?.('[data-library-lazy-section][data-lazy-override-count]')?.dataset?.lazyOverrideCount || '')
+  if (Number.isFinite(lazyCount) && lazyCount > 0) return lazyCount
+
+  const lazyGroupCount = Number(collapse?.dataset?.lazyOverrideCount || '')
+  if (collapse?.dataset?.collectionGroupLazyCollapse === 'true' && Number.isFinite(lazyGroupCount) && lazyGroupCount > 0) return lazyGroupCount
+
+  const childItems = getDirectChildAccordionItems(collapse)
+  if (childItems.length) {
+    return childItems.reduce((total, item) => total + getAccordionItemOverrideCount(item), 0)
+  }
+
+  return Array.from(collapse?.querySelectorAll?.('.template-toggle-group') || []).reduce((total, group) => {
+    if (!isOverlayTemplateGroupActiveForCounts(group)) return total
+    return total + (Number(group.dataset.overrideCount || '0') || 0)
+  }, 0)
+}
+
+function getAccordionItemOverrideCount (item) {
+  if (!item) return 0
+  const collapse = Array.from(item.children).find(child => child.classList?.contains('accordion-collapse'))
+  return getAccordionCollapseOverrideCount(collapse)
+}
+
+function getLibrarySectionOverrideTotal (card, advanced) {
+  if (!card) return 0
+  const accordion = card.querySelector('.accordion')
+  const items = Array.from(accordion?.children || []).filter(item => item.classList?.contains('accordion-item'))
+  return items.reduce((total, item) => {
+    const isAdvanced = item.classList.contains('library-advanced-section')
+    if (advanced !== isAdvanced) return total
+    return total + getAccordionItemOverrideCount(item)
+  }, 0)
+}
+
+function updateLibraryAggregateOverrideSummaries (card) {
+  if (!card) return
+  const coreCount = getLibrarySectionOverrideTotal(card, false)
+  const advancedCount = getLibrarySectionOverrideTotal(card, true)
+  setOverrideSummaryBadge(card.querySelector('[data-library-core-summary]'), coreCount)
+  setOverrideSummaryBadge(card.querySelector('[data-library-advanced-summary]'), advancedCount)
+  setOverrideSummaryBadge(card.querySelector('[data-library-total-summary]'), coreCount + advancedCount)
 }
 
 function updateTemplateGroupOverrideSummary (section) {
@@ -7936,9 +8340,11 @@ function updateTemplateGroupOverrideSummary (section) {
   if (!group) return
 
   const sections = group.querySelectorAll('[data-collection-variable-section="true"], [data-overlay-variable-section="true"]')
-  const count = Array.from(sections).reduce((total, item) => {
-    return total + (Number(item.dataset.overrideCount || '0') || 0)
-  }, 0)
+  const count = isOverlayTemplateGroupActiveForCounts(group)
+    ? Array.from(sections).reduce((total, item) => {
+        return total + (Number(item.dataset.overrideCount || '0') || 0)
+      }, 0)
+    : 0
 
   group.dataset.overrideCount = String(count)
   group.classList.toggle('template-variable-section-has-overrides', count > 0)
@@ -7959,6 +8365,12 @@ function refreshTemplateOverrideState (scope) {
   getLibraryOverrideScopes(root).forEach(section => {
     updateLibraryOverrideScopeSummary(section)
   })
+  root.querySelectorAll?.('.library-settings-card').forEach(card => {
+    updateLibraryAggregateOverrideSummaries(card)
+  })
+  if (root.matches?.('.library-settings-card')) {
+    updateLibraryAggregateOverrideSummaries(root)
+  }
 }
 
 function getLibraryOverrideScopes (root) {
@@ -8032,6 +8444,7 @@ function updateLibraryOverrideScopeSummary (scope) {
   item?.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
   header?.classList.toggle('template-variable-section-has-overrides', configuredCount > 0)
   setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), configuredCount)
+  updateLibraryAggregateOverrideSummaries(scope.closest('.library-settings-card'))
 }
 
 function wireLibraryOverrideScopes (scope) {
@@ -8085,6 +8498,8 @@ function updateOverlayVariableSectionSummary (section) {
   const summary = section.querySelector('[data-overlay-section-summary]')
   const body = section.querySelector('.overlay-variable-section-body')
   if (!summary || !body) return
+  const group = section.closest('.template-toggle-group')
+  const activeGroup = isOverlayTemplateGroupActiveForCounts(group)
 
   const fieldsByName = new Map()
   body.querySelectorAll('[name]').forEach(field => {
@@ -8097,11 +8512,15 @@ function updateOverlayVariableSectionSummary (section) {
   })
 
   let configuredCount = 0
-  fieldsByName.forEach(fields => {
-    if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
-  })
+  if (activeGroup) {
+    fieldsByName.forEach(fields => {
+      if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
+    })
+  }
 
-  updateTemplateVariableFieldOverrideStates(body, fieldsByName)
+  if (activeGroup) {
+    updateTemplateVariableFieldOverrideStates(body, fieldsByName)
+  }
 
   summary.textContent = configuredCount === 0
     ? 'Defaults'

--- a/templates/partials/_collection_group_fragment.html
+++ b/templates/partials/_collection_group_fragment.html
@@ -1,0 +1,2 @@
+{% import 'partials/_macros.html' as macros %}
+{{ macros.collection_group_section(library, data, version_info, group, telemetry) }}

--- a/templates/partials/_library_card.html
+++ b/templates/partials/_library_card.html
@@ -7,6 +7,7 @@
 
     <h4 class="mb-0 text-white">
       <i class="bi bi-film text-muted me-2" title="Movie"></i>{{ library.name }}
+      <span class="small accordion-override-summary ms-2 d-none" data-library-total-summary></span>
     </h4>
     {% set include_checked = data.get('libraries', {}).get(library.id ~ '-library') %}
     {% set playlist_checked = data.get('libraries', {}).get(library.id ~ '-playlist') or (legacy_playlist_libraries is defined and library.name in legacy_playlist_libraries) %}
@@ -48,6 +49,7 @@
 
     <h4 class="mb-0 text-white">
       <i class="bi bi-tv text-muted me-2" title="TV Show"></i>{{ library.name }}
+      <span class="small accordion-override-summary ms-2 d-none" data-library-total-summary></span>
     </h4>
     {% set include_checked = data.get('libraries', {}).get(library.id ~ '-library') %}
     {% set playlist_checked = data.get('libraries', {}).get(library.id ~ '-playlist') or (legacy_playlist_libraries is defined and library.name in legacy_playlist_libraries) %}

--- a/templates/partials/_library_collection_files.html
+++ b/templates/partials/_library_collection_files.html
@@ -12,7 +12,7 @@
     <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
         <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
         <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
-            value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
+            value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}" data-default="[]">
         <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
         <div class="d-flex justify-content-between align-items-center mt-3">
             <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>

--- a/templates/partials/_library_collection_files_accordion.html
+++ b/templates/partials/_library_collection_files_accordion.html
@@ -5,7 +5,8 @@
             Collection Files
         </button>
     </h2>
-    <div id="{{ library.id }}-collection-files" class="accordion-collapse collapse">
+    <div id="{{ library.id }}-collection-files" class="accordion-collapse collapse"
+        data-library-override-scope="true" data-library-override-label="Collection Files">
         <div class="accordion-body">
             <div class="alert alert-info small mb-3" role="alert">
                 Leave these entries blank unless you want explicit library-level <code>collection_files</code>.

--- a/templates/partials/_library_core_separator.html
+++ b/templates/partials/_library_core_separator.html
@@ -1,8 +1,8 @@
-<div class="library-advanced-section d-none px-2 pt-3 pb-1" data-advanced-section>
+<div class="px-2 pb-1" data-library-core-section>
     <div class="d-flex align-items-center gap-3 small fw-semibold text-muted">
         <span class="flex-grow-1 border-top border-secondary-subtle"></span>
-        <span>Advanced Library Options</span>
-        <span class="small accordion-override-summary d-none" data-library-advanced-summary></span>
+        <span>Library Defaults</span>
+        <span class="small accordion-override-summary d-none" data-library-core-summary></span>
         <span class="flex-grow-1 border-top border-secondary-subtle"></span>
     </div>
 </div>

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -5,7 +5,8 @@
             Metadata Files
         </button>
     </h2>
-    <div id="{{ library.id }}-metadata-files" class="accordion-collapse collapse">
+    <div id="{{ library.id }}-metadata-files" class="accordion-collapse collapse"
+        data-library-override-scope="true" data-library-override-label="Metadata Files">
         <div class="accordion-body">
             <div class="d-flex flex-column gap-3">
                 <div class="alert alert-warning small mb-0" role="alert">
@@ -21,7 +22,7 @@
                 <div class="metadata-files-editor" data-metadata-files-editor data-library-id="{{ library.id }}">
                 <div class="alert small mb-4" role="alert" data-metadata-custom-repo-status></div>
                 <input type="hidden" name="{{ library.id }}-metadata_files" id="{{ library.id }}-metadata_files"
-                    value="{{ data['libraries'].get(library.id ~ '-metadata_files', '[]') }}">
+                    value="{{ data['libraries'].get(library.id ~ '-metadata_files', '[]') }}" data-default="[]">
                 <div class="metadata-files-list d-flex flex-column gap-3 mt-1" data-metadata-files-list></div>
                 <div class="d-flex justify-content-between align-items-center mt-3">
                     <button type="button" class="btn btn-outline-secondary btn-sm" data-add-metadata-file>

--- a/templates/partials/_library_overlay_files.html
+++ b/templates/partials/_library_overlay_files.html
@@ -5,7 +5,8 @@
             Overlay Files
         </button>
     </h2>
-    <div id="{{ library.id }}-overlay-files" class="accordion-collapse collapse">
+    <div id="{{ library.id }}-overlay-files" class="accordion-collapse collapse"
+        data-library-override-scope="true" data-library-override-label="Overlay Files">
         <div class="accordion-body">
             <div class="d-flex flex-column gap-3">
                 <div class="alert alert-warning small mb-0" role="alert">
@@ -21,7 +22,7 @@
                 <div class="overlay-files-editor" data-overlay-files-editor data-library-id="{{ library.id }}">
                 <div class="alert small mb-4" role="alert" data-overlay-custom-repo-status></div>
                 <input type="hidden" name="{{ library.id }}-overlay_files" id="{{ library.id }}-overlay_files"
-                    value="{{ data['libraries'].get(library.id ~ '-overlay_files', '[]') }}">
+                    value="{{ data['libraries'].get(library.id ~ '-overlay_files', '[]') }}" data-default="[]">
                 <div class="overlay-files-list d-flex flex-column gap-3 mt-1" data-overlay-files-list></div>
                 <div class="d-flex justify-content-between align-items-center mt-3">
                     <button type="button" class="btn btn-outline-secondary btn-sm" data-add-overlay-file>

--- a/templates/partials/_library_playlist_template_variables.html
+++ b/templates/partials/_library_playlist_template_variables.html
@@ -210,52 +210,73 @@ playlist-template_variables[{{ field_key }}]
 </div>
 {%- endmacro %}
 
-<div class="alert alert-secondary small mb-3" role="alert">
-  These playlist defaults are shared across all libraries you enable for playlists on this page.
+<div class="accordion-item">
+  <h3 class="accordion-header">
+    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+      data-bs-target="#{{ library.id }}-playlist-shared-defaults" aria-expanded="false"
+      aria-controls="{{ library.id }}-playlist-shared-defaults">
+      Shared Playlist Defaults
+    </button>
+  </h3>
+  <div id="{{ library.id }}-playlist-shared-defaults" class="accordion-collapse collapse"
+    data-library-override-scope="true" data-library-override-label="Shared Playlist Defaults">
+    <div class="accordion-body">
+      <div class="alert alert-secondary small mb-3" role="alert">
+        These playlist defaults are shared across all libraries you enable for playlists on this page.
+      </div>
+      {{ playlist_user_picker('sync_to_users', 'Sync To Users', library.id ~ '-playlist-sync-users-modal', 'Select Plex usernames', 'Sets the users to sync all playlists to.', true) }}
+      {{ playlist_user_picker('exclude_users', 'Exclude Users', library.id ~ '-playlist-exclude-users-modal', 'Select Plex usernames to exclude', 'Sets the users to exclude from sync for all playlists.') }}
+      {{ playlist_toggle_input('delete_playlist', 'Delete Playlists', 'Delete all playlists for the users defined by sync_to_users.') }}
+      {{ playlist_string_list_input('ignore_ids', 'Ignore IDs', 'Add TMDb or TVDb ID', 'Set TMDb or TVDb IDs to ignore in all playlists.', 'numeric_id') }}
+      {{ playlist_string_list_input('ignore_imdb_ids', 'Ignore IMDb IDs', 'Add IMDb ID (e.g. tt1234567)', 'Set IMDb IDs to ignore in all playlists.', 'imdb_id_plex') }}
+      {{ playlist_toggle_input('radarr_add_missing', 'Radarr Add Missing', 'Override Radarr add_missing for all playlists in this defaults file.') }}
+      {{ playlist_text_input('radarr_folder', 'Radarr Folder', 'Set Radarr root folder path', 'Override Radarr root_folder_path for all playlists in this defaults file.') }}
+      {{ playlist_string_list_input('radarr_tag', 'Radarr Tags', 'Add Radarr tag', 'Override Radarr tags for all playlists in this defaults file.') }}
+      {{ playlist_toggle_input('sonarr_add_missing', 'Sonarr Add Missing', 'Override Sonarr add_missing for all playlists in this defaults file.') }}
+      {{ playlist_text_input('sonarr_folder', 'Sonarr Folder', 'Set Sonarr root folder path', 'Override Sonarr root_folder_path for all playlists in this defaults file.') }}
+      {{ playlist_string_list_input('sonarr_tag', 'Sonarr Tags', 'Add Sonarr tag', 'Override Sonarr tags for all playlists in this defaults file.') }}
+      {{ playlist_string_list_input('item_radarr_tag', 'Item Radarr Tags', 'Add item Radarr tag', 'Append a Radarr tag to every movie found by all playlists in this defaults file.') }}
+      {{ playlist_string_list_input('item_sonarr_tag', 'Item Sonarr Tags', 'Add item Sonarr tag', 'Append a Sonarr tag to every series found by all playlists in this defaults file.') }}
+      {{ playlist_string_list_input('trakt_list', 'Default Trakt Lists', 'Add Trakt list URL', 'Default Trakt list URLs used when a playlist key does not provide its own builder list.') }}
+      {{ playlist_string_list_input('imdb_list', 'Default IMDb Lists', 'Add IMDb list URL', 'Default IMDb list URLs used when a playlist key does not provide its own builder list.') }}
+      {{ playlist_string_list_input('mdblist_list', 'Default MDBList Lists', 'Add MDBList URL', 'Default MDBList URLs used when a playlist key does not provide its own builder list.') }}
+    </div>
+  </div>
 </div>
 
-<div class="mb-3">
-  <h6 class="text-uppercase text-muted small mb-2">Shared Playlist Defaults</h6>
-  {{ playlist_user_picker('sync_to_users', 'Sync To Users', library.id ~ '-playlist-sync-users-modal', 'Select Plex usernames', 'Sets the users to sync all playlists to.', true) }}
-  {{ playlist_user_picker('exclude_users', 'Exclude Users', library.id ~ '-playlist-exclude-users-modal', 'Select Plex usernames to exclude', 'Sets the users to exclude from sync for all playlists.') }}
-  {{ playlist_toggle_input('delete_playlist', 'Delete Playlists', 'Delete all playlists for the users defined by sync_to_users.') }}
-  {{ playlist_string_list_input('ignore_ids', 'Ignore IDs', 'Add TMDb or TVDb ID', 'Set TMDb or TVDb IDs to ignore in all playlists.', 'numeric_id') }}
-  {{ playlist_string_list_input('ignore_imdb_ids', 'Ignore IMDb IDs', 'Add IMDb ID (e.g. tt1234567)', 'Set IMDb IDs to ignore in all playlists.', 'imdb_id_plex') }}
-  {{ playlist_toggle_input('radarr_add_missing', 'Radarr Add Missing', 'Override Radarr add_missing for all playlists in this defaults file.') }}
-  {{ playlist_text_input('radarr_folder', 'Radarr Folder', 'Set Radarr root folder path', 'Override Radarr root_folder_path for all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('radarr_tag', 'Radarr Tags', 'Add Radarr tag', 'Override Radarr tags for all playlists in this defaults file.') }}
-  {{ playlist_toggle_input('sonarr_add_missing', 'Sonarr Add Missing', 'Override Sonarr add_missing for all playlists in this defaults file.') }}
-  {{ playlist_text_input('sonarr_folder', 'Sonarr Folder', 'Set Sonarr root folder path', 'Override Sonarr root_folder_path for all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('sonarr_tag', 'Sonarr Tags', 'Add Sonarr tag', 'Override Sonarr tags for all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('item_radarr_tag', 'Item Radarr Tags', 'Add item Radarr tag', 'Append a Radarr tag to every movie found by all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('item_sonarr_tag', 'Item Sonarr Tags', 'Add item Sonarr tag', 'Append a Sonarr tag to every series found by all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('trakt_list', 'Default Trakt Lists', 'Add Trakt list URL', 'Default Trakt list URLs used when a playlist key does not provide its own builder list.') }}
-  {{ playlist_string_list_input('imdb_list', 'Default IMDb Lists', 'Add IMDb list URL', 'Default IMDb list URLs used when a playlist key does not provide its own builder list.') }}
-  {{ playlist_string_list_input('mdblist_list', 'Default MDBList Lists', 'Add MDBList URL', 'Default MDBList URLs used when a playlist key does not provide its own builder list.') }}
-</div>
-
-<div class="mb-2">
-  <h6 class="text-uppercase text-muted small mb-2">Per-Playlist Overrides</h6>
-  {% if playlist_default_entries %}
-  {{ playlist_use_toggle_group('use_', 'Playlist Toggles', playlist_default_entries, 'Turn bundled default playlists on or off by key.') }}
-  {% else %}
-  {{ playlist_mapping_input('use_', 'Use Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Turn an individual playlist on or off by key.', '', 'Use override', 'string') }}
-  {% endif %}
-  {{ playlist_mapping_input('name_', 'Name Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist name', 'Override the playlist name for a specific key.', '', 'Custom playlist name', 'string') }}
-  {{ playlist_mapping_input('summary_', 'Summary Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist summary', 'Override the playlist summary for a specific key.', '', 'Custom playlist summary', 'string') }}
-  {{ playlist_mapping_input('url_poster_', 'Poster URL Overrides', 'Playlist key (e.g. mcu)', 'https://example.com/poster.jpg', 'Override the poster URL for a specific playlist key.', '', 'Poster URL', 'string') }}
-  {{ playlist_mapping_input('delete_playlist_', 'Delete Playlist Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Delete a specific playlist for the users defined by sync_to_users.', '', 'Delete playlist', 'string') }}
-  {{ playlist_mapping_input('sync_to_users_', 'Sync To Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override synced users for a specific playlist key.', '', 'Users', 'string_list') }}
-  {{ playlist_mapping_input('exclude_users_', 'Exclude Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override excluded users for a specific playlist key.', '', 'Excluded users', 'string_list') }}
-  {{ playlist_mapping_input('radarr_add_missing_', 'Radarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Radarr add_missing for a specific playlist key.', '', 'Radarr add missing', 'boolean') }}
-  {{ playlist_mapping_input('radarr_folder_', 'Radarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Radarr root folder path', 'Override Radarr root_folder_path for a specific playlist key.', '', 'Radarr folder', 'string') }}
-  {{ playlist_mapping_input('radarr_tag_', 'Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Radarr tags', 'Override Radarr tags for a specific playlist key.', '', 'Radarr tags', 'string_list') }}
-  {{ playlist_mapping_input('sonarr_add_missing_', 'Sonarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Sonarr add_missing for a specific playlist key.', '', 'Sonarr add missing', 'boolean') }}
-  {{ playlist_mapping_input('sonarr_folder_', 'Sonarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Sonarr root folder path', 'Override Sonarr root_folder_path for a specific playlist key.', '', 'Sonarr folder', 'string') }}
-  {{ playlist_mapping_input('sonarr_tag_', 'Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Sonarr tags', 'Override Sonarr tags for a specific playlist key.', '', 'Sonarr tags', 'string_list') }}
-  {{ playlist_mapping_input('trakt_list_', 'Trakt List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Trakt list URLs', 'Override the Trakt list URLs for a specific playlist key.', '', 'Trakt URLs', 'string_list') }}
-  {{ playlist_mapping_input('imdb_list_', 'IMDb List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated IMDb list URLs', 'Override the IMDb list URLs for a specific playlist key.', '', 'IMDb URLs', 'string_list') }}
-  {{ playlist_mapping_input('mdblist_list_', 'MDBList Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated MDBList URLs', 'Override the MDBList URLs for a specific playlist key.', '', 'MDBList URLs', 'string_list') }}
-  {{ playlist_mapping_input('item_radarr_tag_', 'Item Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Radarr tags', 'Override item Radarr tags for a specific playlist key.', '', 'Item Radarr tags', 'string_list') }}
-  {{ playlist_mapping_input('item_sonarr_tag_', 'Item Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Sonarr tags', 'Override item Sonarr tags for a specific playlist key.', '', 'Item Sonarr tags', 'string_list') }}
+<div class="accordion-item">
+  <h3 class="accordion-header">
+    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+      data-bs-target="#{{ library.id }}-playlist-overrides" aria-expanded="false"
+      aria-controls="{{ library.id }}-playlist-overrides">
+      Per-Playlist Overrides
+    </button>
+  </h3>
+  <div id="{{ library.id }}-playlist-overrides" class="accordion-collapse collapse"
+    data-library-override-scope="true" data-library-override-label="Per-Playlist Overrides">
+    <div class="accordion-body">
+      {% if playlist_default_entries %}
+      {{ playlist_use_toggle_group('use_', 'Playlist Toggles', playlist_default_entries, 'Turn bundled default playlists on or off by key.') }}
+      {% else %}
+      {{ playlist_mapping_input('use_', 'Use Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Turn an individual playlist on or off by key.', '', 'Use override', 'string') }}
+      {% endif %}
+      {{ playlist_mapping_input('name_', 'Name Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist name', 'Override the playlist name for a specific key.', '', 'Custom playlist name', 'string') }}
+      {{ playlist_mapping_input('summary_', 'Summary Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist summary', 'Override the playlist summary for a specific key.', '', 'Custom playlist summary', 'string') }}
+      {{ playlist_mapping_input('url_poster_', 'Poster URL Overrides', 'Playlist key (e.g. mcu)', 'https://example.com/poster.jpg', 'Override the poster URL for a specific playlist key.', '', 'Poster URL', 'string') }}
+      {{ playlist_mapping_input('delete_playlist_', 'Delete Playlist Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Delete a specific playlist for the users defined by sync_to_users.', '', 'Delete playlist', 'string') }}
+      {{ playlist_mapping_input('sync_to_users_', 'Sync To Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override synced users for a specific playlist key.', '', 'Users', 'string_list') }}
+      {{ playlist_mapping_input('exclude_users_', 'Exclude Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override excluded users for a specific playlist key.', '', 'Excluded users', 'string_list') }}
+      {{ playlist_mapping_input('radarr_add_missing_', 'Radarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Radarr add_missing for a specific playlist key.', '', 'Radarr add missing', 'boolean') }}
+      {{ playlist_mapping_input('radarr_folder_', 'Radarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Radarr root folder path', 'Override Radarr root_folder_path for a specific playlist key.', '', 'Radarr folder', 'string') }}
+      {{ playlist_mapping_input('radarr_tag_', 'Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Radarr tags', 'Override Radarr tags for a specific playlist key.', '', 'Radarr tags', 'string_list') }}
+      {{ playlist_mapping_input('sonarr_add_missing_', 'Sonarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Sonarr add_missing for a specific playlist key.', '', 'Sonarr add missing', 'boolean') }}
+      {{ playlist_mapping_input('sonarr_folder_', 'Sonarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Sonarr root folder path', 'Override Sonarr root_folder_path for a specific playlist key.', '', 'Sonarr folder', 'string') }}
+      {{ playlist_mapping_input('sonarr_tag_', 'Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Sonarr tags', 'Override Sonarr tags for a specific playlist key.', '', 'Sonarr tags', 'string_list') }}
+      {{ playlist_mapping_input('trakt_list_', 'Trakt List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Trakt list URLs', 'Override the Trakt list URLs for a specific playlist key.', '', 'Trakt URLs', 'string_list') }}
+      {{ playlist_mapping_input('imdb_list_', 'IMDb List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated IMDb list URLs', 'Override the IMDb list URLs for a specific playlist key.', '', 'IMDb URLs', 'string_list') }}
+      {{ playlist_mapping_input('mdblist_list_', 'MDBList Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated MDBList URLs', 'Override the MDBList URLs for a specific playlist key.', '', 'MDBList URLs', 'string_list') }}
+      {{ playlist_mapping_input('item_radarr_tag_', 'Item Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Radarr tags', 'Override item Radarr tags for a specific playlist key.', '', 'Item Radarr tags', 'string_list') }}
+      {{ playlist_mapping_input('item_sonarr_tag_', 'Item Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Sonarr tags', 'Override item Sonarr tags for a specific playlist key.', '', 'Item Sonarr tags', 'string_list') }}
+    </div>
+  </div>
 </div>

--- a/templates/partials/_library_playlists.html
+++ b/templates/partials/_library_playlists.html
@@ -8,29 +8,44 @@
   <div id="{{ library.id }}-playlists" class="accordion-collapse collapse"
     data-library-override-scope="true" data-library-override-label="Playlists">
     <div class="accordion-body">
-      <div class="alert alert-info mb-3" role="alert">
-        <h6><b>Playlist files</b></h6>
-        Use this library as a source for generated Defaults Playlist files.
-        This writes to the top-level <code>playlist_files</code> section and does not count as a library default,
-        overlay, or attribute selection.
-        <br><br><a href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/defaults/playlist/" target="_blank">Click
-          Here</a> to go to the Defaults wiki page to see examples of the playlists that will be created.
-      </div>
-      <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
-        <input class="form-check-input playlist-library-toggle" type="checkbox" id="{{ library.id }}-playlist"
-          name="{{ library.id }}-playlist" value="true" data-include-toggle="{{ library.id }}-include"
-          data-default="false" {% if playlist_checked %}checked{% endif %}>
-        <label class="form-check-label mb-0" for="{{ library.id }}-playlist">
-          Include {{ library.name }}
-        </label>
-      </div>
-      <div class="form-text text-muted mt-2">
-        This requires the library to also be included in YAML, but by itself it is not enough to complete the Libraries page.
-      </div>
-      <div class="mt-3">
-        {% include "partials/_library_playlist_files.html" %}
-      </div>
-      <div class="mt-3">
+      <div class="accordion" id="{{ library.id }}-playlist-accordion">
+        <div class="accordion-item">
+          <h3 class="accordion-header">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+              data-bs-target="#{{ library.id }}-playlist-files-section" aria-expanded="false"
+              aria-controls="{{ library.id }}-playlist-files-section">
+              Playlist Files
+            </button>
+          </h3>
+          <div id="{{ library.id }}-playlist-files-section" class="accordion-collapse collapse"
+            data-library-override-scope="true" data-library-override-label="Playlist Files">
+            <div class="accordion-body">
+              <div class="alert alert-info mb-3" role="alert">
+                <h6><b>Playlist files</b></h6>
+                Use this library as a source for generated Defaults Playlist files.
+                This writes to the top-level <code>playlist_files</code> section and does not count as a library default,
+                overlay, or attribute selection.
+                <br><br><a href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/defaults/playlist/" target="_blank">Click
+                  Here</a> to go to the Defaults wiki page to see examples of the playlists that will be created.
+              </div>
+              <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
+                <input class="form-check-input playlist-library-toggle" type="checkbox" id="{{ library.id }}-playlist"
+                  name="{{ library.id }}-playlist" value="true" data-include-toggle="{{ library.id }}-include"
+                  data-default="false" {% if playlist_checked %}checked{% endif %}>
+                <label class="form-check-label mb-0" for="{{ library.id }}-playlist">
+                  Include {{ library.name }}
+                </label>
+              </div>
+              <div class="form-text text-muted mt-2">
+                This requires the library to also be included in YAML, but by itself it is not enough to complete the Libraries page.
+              </div>
+              <div class="mt-3">
+                {% include "partials/_library_playlist_files.html" %}
+              </div>
+            </div>
+          </div>
+        </div>
+
         {% include "partials/_library_playlist_template_variables.html" %}
       </div>
     </div>

--- a/templates/partials/_library_radarr_overrides.html
+++ b/templates/partials/_library_radarr_overrides.html
@@ -5,7 +5,8 @@
             Radarr Overrides
         </button>
     </h2>
-    <div id="{{ library.id }}-radarr-overrides" class="accordion-collapse collapse">
+    <div id="{{ library.id }}-radarr-overrides" class="accordion-collapse collapse"
+        data-library-override-scope="true" data-library-override-label="Radarr Overrides">
         <div class="accordion-body">
             <div class="alert alert-success small mb-3" role="alert">
                 Enter your Radarr URL and token override only if this library should use a different Radarr instance than the global
@@ -27,10 +28,10 @@
             </div>
             <input type="hidden" name="{{ library.id }}-library_service_radarr_validated"
                 value="{{ data['libraries'].get(library.id ~ '-library_service_radarr_validated', '') }}"
-                data-library-service-validated="radarr">
+                data-default="" data-library-service-validated="radarr">
             <input type="hidden" name="{{ library.id }}-library_service_radarr_validated_at"
                 value="{{ data['libraries'].get(library.id ~ '-library_service_radarr_validated_at', '') }}"
-                data-library-service-validated-at="radarr">
+                data-default="" data-library-service-validated-at="radarr">
             <div class="alert d-none small mb-3" role="alert" data-library-service-status="radarr"></div>
             <div class="input-group mb-2">
                 <span class="input-group-text" id="{{ library.id }}-attribute_radarr_url_text"
@@ -44,7 +45,7 @@
                 <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_url"
                     name="{{ library.id }}-attribute_radarr_url"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_url', '') | default('', true) }}"
-                    placeholder="Leave blank to use global Radarr URL"
+                    data-default="" placeholder="Leave blank to use global Radarr URL"
                     aria-describedby="{{ library.id }}-attribute_radarr_url_text">
             </div>
 
@@ -60,7 +61,7 @@
                 <input type="password" class="form-control" id="{{ library.id }}-attribute_radarr_token"
                     name="{{ library.id }}-attribute_radarr_token"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_token', '') | default('', true) }}"
-                    placeholder="Leave blank to use global Radarr token"
+                    data-default="" placeholder="Leave blank to use global Radarr token"
                     aria-describedby="{{ library.id }}-attribute_radarr_token_text">
                 <button class="btn btn-outline-secondary" type="button"
                     data-toggle-secret-visibility
@@ -83,6 +84,7 @@
                     id="{{ library.id }}-attribute_radarr_root_folder_path"
                     name="{{ library.id }}-attribute_radarr_root_folder_path"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_root_folder_path', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_radarr_root_folder_path_text">
                 <datalist id="{{ library.id }}-radarr-root-folders"></datalist>
             </div>
@@ -100,6 +102,7 @@
                     id="{{ library.id }}-attribute_radarr_quality_profile"
                     name="{{ library.id }}-attribute_radarr_quality_profile"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_quality_profile', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_radarr_quality_profile_text">
                 <datalist id="{{ library.id }}-radarr-quality-profiles"></datalist>
             </div>
@@ -116,6 +119,7 @@
                 {% set radarr_availability = data['libraries'].get(library.id ~ '-attribute_radarr_availability', '') %}
                 <select class="form-select" id="{{ library.id }}-attribute_radarr_availability"
                     name="{{ library.id }}-attribute_radarr_availability"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_radarr_availability_text">
                     <option value="" {% if not radarr_availability %}selected{% endif %}>Inherit</option>
                     <option value="announced" {% if radarr_availability == 'announced' %}selected{% endif %}>Announced (default)</option>
@@ -137,6 +141,7 @@
                 <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_tag"
                     name="{{ library.id }}-attribute_radarr_tag"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_tag', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_radarr_tag_text">
             </div>
 
@@ -153,6 +158,7 @@
                     id="{{ library.id }}-attribute_radarr_radarr_path"
                     name="{{ library.id }}-attribute_radarr_radarr_path"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_radarr_path', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_radarr_radarr_path_text">
             </div>
 
@@ -169,6 +175,7 @@
                     id="{{ library.id }}-attribute_radarr_plex_path"
                     name="{{ library.id }}-attribute_radarr_plex_path"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_plex_path', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_radarr_plex_path_text">
             </div>
 
@@ -192,6 +199,7 @@
                     </span>
                 </span>
                 <select class="form-select" id="{{ field_name }}" name="{{ field_name }}"
+                    data-default=""
                     aria-describedby="{{ field_name }}_text">
                     <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
                     <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>

--- a/templates/partials/_library_sonarr_overrides.html
+++ b/templates/partials/_library_sonarr_overrides.html
@@ -5,7 +5,8 @@
             Sonarr Overrides
         </button>
     </h2>
-    <div id="{{ library.id }}-sonarr-overrides" class="accordion-collapse collapse">
+    <div id="{{ library.id }}-sonarr-overrides" class="accordion-collapse collapse"
+        data-library-override-scope="true" data-library-override-label="Sonarr Overrides">
         <div class="accordion-body">
             <div class="alert alert-success small mb-3" role="alert">
                 Enter your Sonarr URL and token override only if this library should use a different Sonarr instance than the global
@@ -27,10 +28,10 @@
             </div>
             <input type="hidden" name="{{ library.id }}-library_service_sonarr_validated"
                 value="{{ data['libraries'].get(library.id ~ '-library_service_sonarr_validated', '') }}"
-                data-library-service-validated="sonarr">
+                data-default="" data-library-service-validated="sonarr">
             <input type="hidden" name="{{ library.id }}-library_service_sonarr_validated_at"
                 value="{{ data['libraries'].get(library.id ~ '-library_service_sonarr_validated_at', '') }}"
-                data-library-service-validated-at="sonarr">
+                data-default="" data-library-service-validated-at="sonarr">
             <div class="alert d-none small mb-3" role="alert" data-library-service-status="sonarr"></div>
             <div class="input-group mb-2">
                 <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_url_text"
@@ -44,7 +45,7 @@
                 <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_url"
                     name="{{ library.id }}-attribute_sonarr_url"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_url', '') | default('', true) }}"
-                    placeholder="Leave blank to use global Sonarr URL"
+                    data-default="" placeholder="Leave blank to use global Sonarr URL"
                     aria-describedby="{{ library.id }}-attribute_sonarr_url_text">
             </div>
 
@@ -60,7 +61,7 @@
                 <input type="password" class="form-control" id="{{ library.id }}-attribute_sonarr_token"
                     name="{{ library.id }}-attribute_sonarr_token"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_token', '') | default('', true) }}"
-                    placeholder="Leave blank to use global Sonarr token"
+                    data-default="" placeholder="Leave blank to use global Sonarr token"
                     aria-describedby="{{ library.id }}-attribute_sonarr_token_text">
                 <button class="btn btn-outline-secondary" type="button"
                     data-toggle-secret-visibility
@@ -83,6 +84,7 @@
                     id="{{ library.id }}-attribute_sonarr_root_folder_path"
                     name="{{ library.id }}-attribute_sonarr_root_folder_path"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_root_folder_path', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_root_folder_path_text">
                 <datalist id="{{ library.id }}-sonarr-root-folders"></datalist>
             </div>
@@ -100,6 +102,7 @@
                     id="{{ library.id }}-attribute_sonarr_quality_profile"
                     name="{{ library.id }}-attribute_sonarr_quality_profile"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_quality_profile', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_quality_profile_text">
                 <datalist id="{{ library.id }}-sonarr-quality-profiles"></datalist>
             </div>
@@ -117,6 +120,7 @@
                     id="{{ library.id }}-attribute_sonarr_language_profile"
                     name="{{ library.id }}-attribute_sonarr_language_profile"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_language_profile', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_language_profile_text">
                 <datalist id="{{ library.id }}-sonarr-language-profiles"></datalist>
             </div>
@@ -133,6 +137,7 @@
                 {% set sonarr_series_type = data['libraries'].get(library.id ~ '-attribute_sonarr_series_type', '') %}
                 <select class="form-select" id="{{ library.id }}-attribute_sonarr_series_type"
                     name="{{ library.id }}-attribute_sonarr_series_type"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_series_type_text">
                     <option value="" {% if not sonarr_series_type %}selected{% endif %}>Inherit</option>
                     <option value="standard" {% if sonarr_series_type == 'standard' %}selected{% endif %}>Standard (default)</option>
@@ -178,6 +183,7 @@
                 <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_tag"
                     name="{{ library.id }}-attribute_sonarr_tag"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_tag', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_tag_text">
             </div>
 
@@ -194,6 +200,7 @@
                     id="{{ library.id }}-attribute_sonarr_sonarr_path"
                     name="{{ library.id }}-attribute_sonarr_sonarr_path"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_sonarr_path', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_sonarr_path_text">
             </div>
 
@@ -210,6 +217,7 @@
                     id="{{ library.id }}-attribute_sonarr_plex_path"
                     name="{{ library.id }}-attribute_sonarr_plex_path"
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_plex_path', '') | default('', true) }}"
+                    data-default=""
                     aria-describedby="{{ library.id }}-attribute_sonarr_plex_path_text">
             </div>
 
@@ -234,6 +242,7 @@
                     </span>
                 </span>
                 <select class="form-select" id="{{ field_name }}" name="{{ field_name }}"
+                    data-default=""
                     aria-describedby="{{ field_name }}_text">
                     <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
                     <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -295,7 +295,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
 
 {% macro select_section(library, data, prefix, title, description, wiki, options,
 preview_image=False, tooltip_variant="info", container_class="border rounded p-3 mb-2",
-yml_location="attribute", telemetry=None, requires_plex_pass=False) %}
+yml_location="attribute", telemetry=None, requires_plex_pass=False, default_value=None) %}
 
 {# raw_prefix can contain brackets for name, but needs cleaning for id #}
 {% set raw_prefix =
@@ -307,6 +307,7 @@ prefix if yml_location == "top_level" else
 {% set field_id = (library.id ~ "-" ~ raw_prefix).replace("[", "_").replace("]", "") %}
 {% set field_name = library.id ~ "-" ~ raw_prefix %}
 {% set selected = data.libraries.get(field_name, '') %}
+{% set select_default = default_value if default_value is not none else (options[0][0] if options else '') %}
 {% set has_plex_pass = false %}
 {% if telemetry is mapping and telemetry.get("plex_pass") is sameas true %}
 {% set has_plex_pass = true %}
@@ -325,7 +326,7 @@ prefix if yml_location == "top_level" else
                     </span>
                 </span>
                 <select class="form-select" id="{{ field_id }}" {% if not disable_for_plex_pass %}name="{{ field_name }}"{% endif %}
-                    data-default=""
+                    data-default="{{ select_default }}"
                     aria-describedby="{{ field_id }}_text" {% if preview_image %}data-preview="true" {% endif %}{% if disable_for_plex_pass %} disabled aria-disabled="true"{% endif %}>
                     {% for value, label in options %}
                     <option value="{{ value }}" {% if selected==value %}selected{% endif %}>{{ label }}</option>
@@ -1120,7 +1121,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
 {% set accordion_safe = group.accordion | replace(' ', '') %}
 <!-- Plex Pass: {{ telemetry.plex_pass }} -->
 <!-- {{ group.accordion }} Collection Accordion -->
-<div class="accordion mt-3" id="{{ library.id }}-{{ accordion_safe }}Accordion">
+<div class="accordion mt-3" id="{{ library.id }}-{{ accordion_safe }}Accordion"
+    data-collection-group-shell="true" data-library-id="{{ library.id }}">
     <div class="accordion-item">
         <h2 class="accordion-header overlay-accordion-header d-flex align-items-center">
             <button class="accordion-button collapsed flex-grow-1" type="button" data-bs-toggle="collapse"
@@ -1132,6 +1134,13 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
         <div id="{{ library.id }}-{{ accordion_safe }}" class="accordion-collapse collapse"
             data-bs-parent="#{{ library.id }}-{{ accordion_safe }}Accordion">
             <div class="accordion-body">
+                <div class="d-flex justify-content-end mb-3 collection-parent-reset-actions">
+                    <button type="button"
+                        class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn"
+                        data-collection-parent-reset="true">
+                        Reset {{ group.accordion }}
+                    </button>
+                </div>
 
                 {% set lib_meta = telemetry.libraries[library.name] if telemetry.libraries and library.name in
                 telemetry.libraries else {} %}
@@ -2345,7 +2354,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                     <input type="hidden"
                                                         id="{{ template_name }}-{{ var_name }}"
                                                         name="{{ template_name }}[{{ var_name }}]"
-                                                        value="{{ hidden_value if hidden_value != '' else var_details.default }}">
+                                                        value="{{ hidden_value if hidden_value != '' else var_details.default }}"
+                                                        data-default="{{ var_details.default }}">
                                                     {% elif var_details.input_type == "number" %}
                                                     {% if var_name in ['horizontal_offset', 'initial_horizontal_offset'] %}{% set ns.has_offsets = true %}{% set ns.h_id = template_name ~ '-' ~ var_name %}{% endif %}
                                                     {% if var_name in ['vertical_offset', 'initial_vertical_offset'] %}{% set ns.has_offsets = true %}{% set ns.v_id = template_name ~ '-' ~ var_name %}{% endif %}
@@ -2488,7 +2498,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                             aria-describedby="{{ input_id }}_text"
                                                             value="{{ safe_text_value }}"
                                                             data-default="{{ var_details.default }}"
-                                                            {% if var_name == 'text' and overlay.id in ['overlay_aspect', 'overlay_video_format'] %}data-skip-yaml="true"{% endif %}>
+                                                            {% if var_name == 'text' and overlay.id in ['overlay_aspect', 'overlay_video_format'] %}data-skip-yaml="true" data-skip-override-count="true"{% endif %}>
                                                     </div>
                                                         {% endif %}
                                                     {% elif var_details.input_type == "multiselect" %}

--- a/templates/partials/_movie_collections.html
+++ b/templates/partials/_movie_collections.html
@@ -6,11 +6,45 @@
     data-collection-section-modal-trigger data-library-id="{{ library.id }}">
     <i class="bi bi-arrows-move me-1"></i>Reorder Collection Sections
   </button>
+  <button type="button" class="btn btn-outline-secondary btn-sm reset-offset-btn"
+    data-collection-all-reset="true" data-library-id="{{ library.id }}">
+    Reset Collections
+  </button>
   <span class="small text-muted">Drag enabled collection defaults into the order you want. Quickstart will rewrite their <code>collection_section</code> values.</span>
 </div>
 {% include "partials/_collection_section_modal.html" %}
-{% import 'partials/_macros.html' as macros %}
 
 {% for group in collection_config %}
-{{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
+{% set accordion_safe = group.accordion | replace(' ', '') %}
+{% set group_count = collection_group_override_counts.get(loop.index0, 0) if collection_group_override_counts is defined else 0 %}
+<div class="accordion mt-3" id="{{ library.id }}-{{ accordion_safe }}Accordion"
+  data-collection-group-shell="true" data-library-id="{{ library.id }}" data-collection-group-index="{{ loop.index0 }}">
+  <div class="accordion-item{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
+    <h2 class="accordion-header overlay-accordion-header d-flex align-items-center{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
+      <button class="accordion-button collapsed flex-grow-1" type="button" data-bs-toggle="collapse"
+        data-bs-target="#{{ library.id }}-{{ accordion_safe }}" aria-expanded="false"
+        aria-controls="{{ library.id }}-{{ accordion_safe }}">
+        {{ group.accordion }}
+        <span class="small accordion-override-summary ms-3{% if group_count <= 0 %} d-none{% endif %}"
+          data-accordion-override-summary>
+          {{ group_count }} {{ 'override' if group_count == 1 else 'overrides' }}
+        </span>
+      </button>
+    </h2>
+    <div id="{{ library.id }}-{{ accordion_safe }}" class="accordion-collapse collapse"
+      data-bs-parent="#{{ library.id }}-{{ accordion_safe }}Accordion"
+      data-collection-group-lazy-collapse="true"
+      data-library-id="{{ library.id }}"
+      data-collection-group-index="{{ loop.index0 }}"
+      data-lazy-override-count="{{ group_count }}">
+      <div class="accordion-body">
+        <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
+          data-collection-group-lazy-placeholder="true">
+          <div class="spinner-border spinner-border-sm text-info d-none" role="status" aria-hidden="true"></div>
+          <span>Open this group to load {{ group.accordion }} settings.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endfor %}

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -2,6 +2,8 @@
 
     <!-- Accordion for Movie Settings -->
     <div class="accordion" id="{{ library.id }}-accordion">
+        {% include "partials/_library_core_separator.html" %}
+
         <!-- Movie Collections -->
         <div class="accordion-item">
             <h2 class="accordion-header">

--- a/templates/partials/_show_collections.html
+++ b/templates/partials/_show_collections.html
@@ -6,11 +6,45 @@
     data-collection-section-modal-trigger data-library-id="{{ library.id }}">
     <i class="bi bi-arrows-move me-1"></i>Reorder Collection Sections
   </button>
+  <button type="button" class="btn btn-outline-secondary btn-sm reset-offset-btn"
+    data-collection-all-reset="true" data-library-id="{{ library.id }}">
+    Reset Collections
+  </button>
   <span class="small text-muted">Drag enabled collection defaults into the order you want. Quickstart will rewrite their <code>collection_section</code> values.</span>
 </div>
 {% include "partials/_collection_section_modal.html" %}
-{% import 'partials/_macros.html' as macros %}
 
 {% for group in collection_config %}
-{{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
+{% set accordion_safe = group.accordion | replace(' ', '') %}
+{% set group_count = collection_group_override_counts.get(loop.index0, 0) if collection_group_override_counts is defined else 0 %}
+<div class="accordion mt-3" id="{{ library.id }}-{{ accordion_safe }}Accordion"
+  data-collection-group-shell="true" data-library-id="{{ library.id }}" data-collection-group-index="{{ loop.index0 }}">
+  <div class="accordion-item{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
+    <h2 class="accordion-header overlay-accordion-header d-flex align-items-center{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
+      <button class="accordion-button collapsed flex-grow-1" type="button" data-bs-toggle="collapse"
+        data-bs-target="#{{ library.id }}-{{ accordion_safe }}" aria-expanded="false"
+        aria-controls="{{ library.id }}-{{ accordion_safe }}">
+        {{ group.accordion }}
+        <span class="small accordion-override-summary ms-3{% if group_count <= 0 %} d-none{% endif %}"
+          data-accordion-override-summary>
+          {{ group_count }} {{ 'override' if group_count == 1 else 'overrides' }}
+        </span>
+      </button>
+    </h2>
+    <div id="{{ library.id }}-{{ accordion_safe }}" class="accordion-collapse collapse"
+      data-bs-parent="#{{ library.id }}-{{ accordion_safe }}Accordion"
+      data-collection-group-lazy-collapse="true"
+      data-library-id="{{ library.id }}"
+      data-collection-group-index="{{ loop.index0 }}"
+      data-lazy-override-count="{{ group_count }}">
+      <div class="accordion-body">
+        <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
+          data-collection-group-lazy-placeholder="true">
+          <div class="spinner-border spinner-border-sm text-info d-none" role="status" aria-hidden="true"></div>
+          <span>Open this group to load {{ group.accordion }} settings.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endfor %}

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -2,6 +2,8 @@
 
     <!-- Accordion for Show Settings -->
     <div class="accordion" id="{{ library.id }}-accordion">
+        {% include "partials/_library_core_separator.html" %}
+
         <!-- Show Collections -->
         <div class="accordion-item">
             <h2 class="accordion-header">

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -11,6 +11,15 @@ START_JS_PATH = ROOT / "static" / "local-js" / "001-start.js"
 OVERLAYS_PATH = ROOT / "static" / "json" / "quickstart_overlays.json"
 LIBRARIES_TEMPLATE_PATH = ROOT / "templates" / "025-libraries.html"
 PLAYLIST_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_playlists.html"
+LIBRARY_CARD_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_card.html"
+CORE_SEPARATOR_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_core_separator.html"
+ADVANCED_SEPARATOR_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_advanced_separator.html"
+COLLECTION_FILES_ACCORDION_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_collection_files_accordion.html"
+COLLECTION_FILES_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_collection_files.html"
+METADATA_FILES_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_metadata_files.html"
+OVERLAY_FILES_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_overlay_files.html"
+RADARR_OVERRIDES_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_radarr_overrides.html"
+SONARR_OVERRIDES_PARTIAL_PATH = ROOT / "templates" / "partials" / "_library_sonarr_overrides.html"
 
 
 def test_collection_macros_render_collapsible_detail_section():
@@ -18,6 +27,8 @@ def test_collection_macros_render_collapsible_detail_section():
 
     assert "collection-details-toggle" in macros
     assert "collection-detail-actions" in macros
+    assert 'data-collection-parent-reset="true"' in macros
+    assert "Reset {{ group.accordion }}" in macros
     assert 'class="collection-template-section mt-2"' in macros
     assert 'data-detail-section="true"' in macros
     assert 'data-collection-variable-section="true"' in macros
@@ -93,6 +104,19 @@ def test_libraries_script_wires_overlay_variable_sections():
     assert "data-accordion-override-summary" in script
     assert "findTemplateVariableFieldRow(field)" in script
     assert "refreshTemplateOverrideState(group)" in script
+    assert "function isOverlayTemplateGroupActiveForCounts" in script
+    assert "if (!isOverlayTemplateGroupActiveForCounts(group)) return total" in script
+    assert "const activeGroup = isOverlayTemplateGroupActiveForCounts(group)" in script
+
+
+def test_schedule_override_comparison_normalizes_month_day_padding():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "function normalizeScheduleOverrideValue" in script
+    assert "normalizeMonthDay" in script
+    assert "primaryField.closest('[data-schedule-builder]')" in script
+    assert "normalizeScheduleOverrideValue(value) !== normalizeScheduleOverrideValue(defaultValue)" in script
+    assert "const scheduleEquivalent = input.closest('[data-schedule-builder]')" in script
 
 
 def test_libraries_script_replaces_mirror_confirm_handler():
@@ -213,11 +237,24 @@ def test_libraries_lazy_loads_heavy_collection_and_overlay_sections():
     routes = (ROOT / "blueprints" / "library_routes.py").read_text(encoding="utf-8")
 
     assert "function wireLazyLibrarySections" in script
+    assert "function wireLazyCollectionGroups" in script
+    assert "function loadLazyCollectionGroup" in script
+    assert "function markLazyCollectionGroupLoaded" in script
+    assert "function markCollectionDefaultsReset" in script
+    assert "function clearLazyCollectionShellOverrideSummaries" in script
     assert "function updateLazySectionOverrideSummaries" in script
     assert "shown.bs.collapse" in script
     assert "/section/${encodeURIComponent(sectionName)}" in script
+    assert "/section/collections/group/${encodeURIComponent(groupIndex)}" in script
+    assert "__loaded_collection_groups" in script
+    assert "__reset_collection_defaults" in script
+    assert "clearLazyCollectionShellOverrideSummaries(sectionBody)" in script
+    assert "await autosaveActiveLibrary({ quiet: true })" in script
+    assert "await loadAllLazyCollectionGroups(sectionBody, card)" not in script
+    assert "await loadLazyCollectionGroup(lazyCollapse, card)" in script
     assert "initializeLibraryCardControls(card, libraryId)" in script
     assert "wireLazyLibrarySections(card)" in script
+    assert "wireLazyCollectionGroups(card)" in script
     assert "updateLazySectionOverrideSummaries(card)" in script
     assert "data-lazy-override-count" in movie_settings
     assert "data-lazy-override-count" in show_settings
@@ -227,6 +264,27 @@ def test_libraries_lazy_loads_heavy_collection_and_overlay_sections():
     assert 'data-library-lazy-section="overlays"' in show_settings
     assert "defer_heavy_sections=True" in routes
     assert '@bp.route("/library_fragment/<library_id>/section/<section_name>")' in routes
+    assert '@bp.route("/library_fragment/<library_id>/section/collections/group/<int:group_index>")' in routes
+
+
+def test_collection_section_partials_lazy_load_parent_groups():
+    movie_collections = (ROOT / "templates" / "partials" / "_movie_collections.html").read_text(encoding="utf-8")
+    show_collections = (ROOT / "templates" / "partials" / "_show_collections.html").read_text(encoding="utf-8")
+    group_fragment = (ROOT / "templates" / "partials" / "_collection_group_fragment.html").read_text(encoding="utf-8")
+
+    for partial in (movie_collections, show_collections):
+        assert "data-collection-group-shell" in partial
+        assert "data-collection-group-lazy-collapse" in partial
+        assert "data-collection-group-lazy-placeholder" in partial
+        assert 'data-collection-all-reset="true"' in partial
+        assert "Reset Collections" in partial
+        assert 'data-collection-parent-reset="true"' not in partial
+        assert "Reset {{ group.accordion }}" not in partial
+        assert "collection_group_override_counts.get(loop.index0, 0)" in partial
+        assert "Open this group to load" in partial
+        assert "macros.collection_group_section" not in partial
+
+    assert "macros.collection_group_section(library, data, version_info, group, telemetry)" in group_fragment
 
 
 def test_cached_library_cards_do_not_submit_stale_form_fields():
@@ -273,6 +331,10 @@ def test_attributes_and_playlists_have_override_scope_counts_and_resets():
     assert 'data-library-override-label="Attributes"' in movie_settings
     assert 'data-library-override-label="Attributes"' in show_settings
     assert 'data-library-override-label="Playlists"' in playlists
+    assert 'data-library-override-label="Playlist Files"' in playlists
+    assert 'id="{{ library.id }}-playlist-accordion"' in playlists
+    assert 'data-library-override-label="Shared Playlist Defaults"' in playlist_vars
+    assert 'data-library-override-label="Per-Playlist Overrides"' in playlist_vars
     for label in ("Separators", "Overlay Operations", "Library Operations", "Miscellaneous"):
         assert f'data-library-override-label="{label}"' in movie_attributes
         assert f'data-library-override-label="{label}"' in show_attributes
@@ -281,6 +343,53 @@ def test_attributes_and_playlists_have_override_scope_counts_and_resets():
     assert 'data-default="false"' in macros
     assert 'data-default="false"' in playlists
     assert 'data-default="false"' in playlist_vars
+
+
+def test_advanced_library_sections_have_override_scope_counts_and_defaults():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    library_card = LIBRARY_CARD_PARTIAL_PATH.read_text(encoding="utf-8")
+    core_separator = CORE_SEPARATOR_PARTIAL_PATH.read_text(encoding="utf-8")
+    advanced_separator = ADVANCED_SEPARATOR_PARTIAL_PATH.read_text(encoding="utf-8")
+    movie_settings = (ROOT / "templates" / "partials" / "_movie_library_settings.html").read_text(encoding="utf-8")
+    show_settings = (ROOT / "templates" / "partials" / "_show_library_settings.html").read_text(encoding="utf-8")
+    collection_files_accordion = COLLECTION_FILES_ACCORDION_PARTIAL_PATH.read_text(encoding="utf-8")
+    collection_files = COLLECTION_FILES_PARTIAL_PATH.read_text(encoding="utf-8")
+    metadata_files = METADATA_FILES_PARTIAL_PATH.read_text(encoding="utf-8")
+    overlay_files = OVERLAY_FILES_PARTIAL_PATH.read_text(encoding="utf-8")
+    radarr_overrides = RADARR_OVERRIDES_PARTIAL_PATH.read_text(encoding="utf-8")
+    sonarr_overrides = SONARR_OVERRIDES_PARTIAL_PATH.read_text(encoding="utf-8")
+
+    assert "function updateLibraryAggregateOverrideSummaries" in script
+    assert "function getLibrarySectionOverrideTotal" in script
+    assert "data-library-core-summary" in script
+    assert "refreshTemplateOverrideState(card)" in script
+    assert "refreshTemplateOverrideState(libraryContainer?.firstElementChild || document)" in script
+    assert "[data-playlist-files-editor]" in script
+    assert "[data-collection-files-editor]" in script
+    assert "[data-metadata-files-editor]" in script
+    assert "[data-overlay-files-editor]" in script
+    assert "[data-playlist-key-toggle-group]" in script
+    assert "[data-playlist-user-picker]" in script
+    assert "name.includes('-library_service_')" in script
+
+    assert "data-library-total-summary" in library_card
+    assert "Library Defaults" in core_separator
+    assert "data-library-core-summary" in core_separator
+    assert "data-library-advanced-summary" in advanced_separator
+    assert '{% include "partials/_library_core_separator.html" %}' in movie_settings
+    assert '{% include "partials/_library_core_separator.html" %}' in show_settings
+    assert 'data-library-override-label="Collection Files"' in collection_files_accordion
+    assert 'data-library-override-label="Metadata Files"' in metadata_files
+    assert 'data-library-override-label="Overlay Files"' in overlay_files
+    assert 'data-library-override-label="Radarr Overrides"' in radarr_overrides
+    assert 'data-library-override-label="Sonarr Overrides"' in sonarr_overrides
+    assert radarr_overrides.count('data-default=""') >= 10
+    assert sonarr_overrides.count('data-default=""') >= 10
+    assert 'data-library-service-validated="radarr"' in radarr_overrides
+    assert 'data-library-service-validated="sonarr"' in sonarr_overrides
+    assert 'data-default="[]"' in collection_files
+    assert 'data-default="[]"' in metadata_files
+    assert 'data-default="[]"' in overlay_files
 
 
 def test_analytics_page_checks_reingest_status_before_loading_trends():
@@ -301,6 +410,7 @@ def test_template_variable_sections_show_override_rail():
     assert ".collection-variable-section.template-variable-section-has-overrides" in styles
     assert ".overlay-variable-section.template-variable-section-has-overrides" in styles
     assert ".template-toggle-group.template-variable-section-has-overrides" in styles
+    assert ".accordion-item.template-variable-section-has-overrides > .accordion-header" in styles
     assert ".accordion-header.template-variable-section-has-overrides" in styles
     assert ".template-variable-field-has-override" in styles
     assert "[data-template-string-list].template-variable-field-has-override" in styles

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -389,6 +389,162 @@ def test_autosave_library_ignores_lazy_loaded_marker_without_collection_payload(
     assert libraries["mov-library_movies-collection_files"] == '[{"type":"folder","location":"config/test/collection_files/movies"}]'
 
 
+def test_autosave_library_preserves_unopened_lazy_collection_groups(
+    client,
+    isolated_config_dir,
+    qs_module,
+    library_routes_module,
+    monkeypatch,
+):
+    from modules import database
+
+    config_name = "pytest_lazy_collection_group_autosave"
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_award": "true",
+                "mov-library_movies-template_collection_award_style": "signature",
+                "mov-library_movies-collection_chart": "true",
+                "mov-library_movies-template_collection_chart_style": "compact",
+            },
+            "validated": True,
+        },
+    )
+
+    monkeypatch.setattr(
+        library_routes_module.helpers,
+        "load_quickstart_config",
+        lambda filename: (
+            [
+                {
+                    "accordion": "Award Collections",
+                    "collections": [
+                        {
+                            "id": "collection_award",
+                            "media_types": ["movie"],
+                            "template_variables": [{"key": "style", "type": "text_input", "default": ""}],
+                        }
+                    ],
+                },
+                {
+                    "accordion": "Chart Collections",
+                    "collections": [
+                        {
+                            "id": "collection_chart",
+                            "media_types": ["movie"],
+                            "template_variables": [{"key": "style", "type": "text_input", "default": ""}],
+                        }
+                    ],
+                },
+            ]
+            if filename == "quickstart_collections.json"
+            else {}
+        ),
+    )
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: {"mov-library_movies"})
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_library_file_entries_payload",
+        lambda libs, config_name, **kw: (libs, [], False),
+    )
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": ["collections"],
+            "__loaded_collection_groups": [0],
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-collection_award": "true",
+            "mov-library_movies-template_collection_award_style": "updated",
+        },
+    )
+
+    assert resp.status_code == 200
+    _validated, _user_entered, saved = database.retrieve_section_data(config_name, "libraries")
+    libraries = saved["libraries"]
+    assert libraries["mov-library_movies-template_collection_award_style"] == "updated"
+    assert libraries["mov-library_movies-collection_chart"] is True
+    assert libraries["mov-library_movies-template_collection_chart_style"] == "compact"
+
+
+def test_autosave_library_reset_collections_drops_unloaded_collection_defaults(
+    client,
+    isolated_config_dir,
+    qs_module,
+    monkeypatch,
+):
+    from modules import database
+
+    config_name = "pytest_reset_lazy_collections"
+    collection_files = '[{"type":"folder","location":"config/test/collection_files/movies"}]'
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_language": "English",
+                "mov-library_movies-collection_award": "true",
+                "mov-library_movies-template_collection_award_style": "signature",
+                "mov-library_movies-collection_chart": "true",
+                "mov-library_movies-template_collection_chart_style": "compact",
+                "mov-library_movies-collection_files": collection_files,
+                "mov-library_movies-overlay_resolution": "true",
+            },
+            "validated": True,
+        },
+    )
+
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: {"mov-library_movies"})
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_library_file_entries_payload",
+        lambda libs, config_name, **kw: (libs, [], False),
+    )
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": ["collections"],
+            "__loaded_collection_groups": [],
+            "__reset_collection_defaults": "true",
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_language": "English",
+            "mov-library_movies-collection_award": "false",
+            "mov-library_movies-template_collection_award_style": "",
+            "mov-library_movies-collection_files": collection_files,
+            "mov-library_movies-overlay_resolution": "true",
+        },
+    )
+
+    assert resp.status_code == 200
+    _validated, _user_entered, saved = database.retrieve_section_data(config_name, "libraries")
+    libraries = saved["libraries"]
+    assert "mov-library_movies-collection_award" not in libraries
+    assert "mov-library_movies-template_collection_award_style" not in libraries
+    assert "mov-library_movies-collection_chart" not in libraries
+    assert "mov-library_movies-template_collection_chart_style" not in libraries
+    assert libraries["mov-library_movies-collection_files"] == collection_files
+    assert libraries["mov-library_movies-overlay_resolution"] is True
+
+
 # ===========================================================================
 # /autosave-imagemaid
 # ===========================================================================

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -293,6 +293,7 @@ def test_library_fragment_defers_heavy_collection_and_overlay_sections(client, m
                 "libraries": {
                     "mov-library_movies-library": "Movies",
                     "mov-library_movies-template_collection_award_style": "custom",
+                    "mov-library_movies-movie-overlay_resolution": "true",
                     "mov-library_movies-movie-template_overlay_resolution[style]": "custom",
                 }
             }
@@ -311,6 +312,141 @@ def test_library_fragment_defers_heavy_collection_and_overlay_sections(client, m
     assert "Open this section to load overlay settings." in html
 
 
+def test_library_fragment_lazy_overlay_count_ignores_inactive_overlay_values(client, monkeypatch, qs_module, library_routes_module):
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: ([{"id": "mov-library_movies", "name": "Movies", "type": "movie"}], [], {"plex_pass": True}),
+    )
+    monkeypatch.setattr(library_routes_module, "_migrate_legacy_playlist_libraries_to_library_toggles", lambda *_args: set())
+    monkeypatch.setattr(library_routes_module.helpers, "load_quickstart_config", lambda _filename: [])
+    monkeypatch.setattr(
+        library_routes_module.helpers,
+        "load_quickstart_overlay_config",
+        lambda: [
+            {
+                "accordion": "Media Overlays",
+                "overlays": [
+                    {
+                        "id": "overlay_content_rating_commonsense",
+                        "media_types": ["movie"],
+                        "template_variables": {
+                            "style": {"input_type": "select", "default": "default"},
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_preview_image_data",
+        lambda: (_ for _ in ()).throw(AssertionError("Initial library fragment should defer preview image data")),
+    )
+
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "025-libraries":
+            return {
+                "libraries": {
+                    "mov-library_movies-library": "Movies",
+                    "mov-library_movies-movie-overlay_content_rating_commonsense": "false",
+                    "mov-library_movies-movie-template_overlay_content_rating_commonsense[style]": "custom",
+                }
+            }
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/library_fragment/mov-library_movies")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert 'data-library-lazy-section="overlays"' in html
+    assert 'data-lazy-override-count="0"' in html
+
+
+def test_lazy_overlay_count_uses_rendered_ratings_defaults(library_routes_module):
+    library = {"id": "mov-library_movies", "name": "Movies", "type": "movie"}
+    libraries_data = {
+        "mov-library_movies-movie-overlay_ratings": "true",
+        "mov-library_movies-movie-template_overlay_ratings[rating1]": "user",
+        "mov-library_movies-movie-template_overlay_ratings[rating1_image]": "rt_tomato",
+        "mov-library_movies-movie-template_overlay_ratings[rating1_font]": "LibreFranklin-Bold.ttf",
+        "mov-library_movies-movie-template_overlay_ratings[rating1_horizontal_offset]": "-30",
+        "mov-library_movies-movie-template_overlay_ratings[rating1_vertical_offset]": "-205",
+        "mov-library_movies-movie-template_overlay_ratings[rating2]": "critic",
+        "mov-library_movies-movie-template_overlay_ratings[rating2_image]": "imdb",
+        "mov-library_movies-movie-template_overlay_ratings[rating2_font]": "Roboto-Medium.ttf",
+        "mov-library_movies-movie-template_overlay_ratings[rating2_horizontal_offset]": "-30",
+        "mov-library_movies-movie-template_overlay_ratings[rating2_vertical_offset]": "0",
+        "mov-library_movies-movie-template_overlay_ratings[rating3]": "audience",
+        "mov-library_movies-movie-template_overlay_ratings[rating3_image]": "tmdb",
+        "mov-library_movies-movie-template_overlay_ratings[rating3_font]": "Consensus-SemiBold.otf",
+        "mov-library_movies-movie-template_overlay_ratings[rating3_horizontal_offset]": "-30",
+        "mov-library_movies-movie-template_overlay_ratings[rating3_vertical_offset]": "205",
+        "mov-library_movies-movie-template_overlay_ratings[horizontal_position]": "right",
+        "mov-library_movies-movie-template_overlay_ratings[vertical_position]": "center",
+        "mov-library_movies-movie-template_overlay_ratings[rating_alignment]": "vertical",
+        "mov-library_movies-movie-overlay_aspect": "true",
+        "mov-library_movies-movie-template_overlay_aspect[text]": "1.78",
+        "mov-library_movies-movie-template_overlay_aspect[horizontal_offset]": "-332",
+        "mov-library_movies-movie-template_overlay_aspect[vertical_offset]": "510",
+        "mov-library_movies-movie-overlay_languages_subtitles": "true",
+        "mov-library_movies-movie-template_overlay_languages_subtitles[use_subtitles]": True,
+    }
+    overlay_config = [
+        {
+            "accordion": "Media Overlays",
+            "overlays": [
+                {
+                    "id": "overlay_ratings",
+                    "media_types": ["movie"],
+                    "template_variables": {
+                        "rating1": {"input_type": "select", "default": "user"},
+                        "rating1_image": {"input_type": "select", "default": "rt_tomato"},
+                        "rating1_font": {"input_type": "text", "default": "Inter-Medium.ttf"},
+                        "rating1_horizontal_offset": {"input_type": "number", "default": 15},
+                        "rating1_vertical_offset": {"input_type": "number", "default": 0},
+                        "rating2": {"input_type": "select", "default": "critic"},
+                        "rating2_image": {"input_type": "select", "default": "imdb"},
+                        "rating2_font": {"input_type": "text", "default": "Inter-Medium.ttf"},
+                        "rating2_horizontal_offset": {"input_type": "number", "default": 15},
+                        "rating2_vertical_offset": {"input_type": "number", "default": 0},
+                        "rating3": {"input_type": "select", "default": "audience"},
+                        "rating3_image": {"input_type": "select", "default": "tmdb"},
+                        "rating3_font": {"input_type": "text", "default": "Inter-Medium.ttf"},
+                        "rating3_horizontal_offset": {"input_type": "number", "default": 15},
+                        "rating3_vertical_offset": {"input_type": "number", "default": 0},
+                        "horizontal_position": {"input_type": "select", "default": "left"},
+                        "vertical_position": {"input_type": "select", "default": "center"},
+                        "rating_alignment": {"input_type": "select", "default": "vertical"},
+                    },
+                },
+                {
+                    "id": "overlay_aspect",
+                    "media_types": ["movie"],
+                    "template_variables": [
+                        {"key": "text", "input_type": "text"},
+                        {"key": "horizontal_offset", "input_type": "number", "default": 0},
+                        {"key": "vertical_offset", "input_type": "number", "default": 150},
+                    ],
+                },
+                {
+                    "id": "overlay_languages_subtitles",
+                    "media_types": ["movie"],
+                    "template_variables": {
+                        "use_subtitles": {"input_type": "hidden", "default": True},
+                    },
+                },
+            ],
+        }
+    ]
+
+    assert library_routes_module._count_overlay_overrides_for_library(library, libraries_data, overlay_config) == 6
+
+
 def test_library_fragment_section_renders_requested_heavy_section(client, monkeypatch, qs_module, library_routes_module):
     monkeypatch.setattr(
         library_routes_module,
@@ -324,7 +460,22 @@ def test_library_fragment_section_renders_requested_heavy_section(client, monkey
 
     def fake_load_quickstart_config(filename):
         if filename == "quickstart_collections.json":
-            return []
+            return [
+                {
+                    "accordion": "Award Collections",
+                    "collections": [
+                        {
+                            "id": "collection_award",
+                            "label": "Awards Default Row",
+                            "url": "https://example.com/award",
+                            "media_types": ["movie"],
+                            "template_variables": [
+                                {"key": "style", "label": "Style", "type": "text_input", "default": ""},
+                            ],
+                        }
+                    ],
+                }
+            ]
         return original_load_quickstart_config(filename)
 
     monkeypatch.setattr(library_routes_module.helpers, "load_quickstart_config", fake_load_quickstart_config)
@@ -340,10 +491,16 @@ def test_library_fragment_section_renders_requested_heavy_section(client, monkey
     monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
 
     collections = client.get("/library_fragment/mov-library_movies/section/collections")
+    collection_group = client.get("/library_fragment/mov-library_movies/section/collections/group/0")
     overlays = client.get("/library_fragment/mov-library_movies/section/overlays")
 
     assert collections.status_code == 200
     assert "Reorder Collection Sections" in collections.get_data(as_text=True)
+    assert "data-collection-group-lazy-collapse" in collections.get_data(as_text=True)
+    assert "Awards Default Row" not in collections.get_data(as_text=True)
+    assert collection_group.status_code == 200
+    assert "Awards Default Row" in collection_group.get_data(as_text=True)
+    assert 'data-template-variable-key="style"' in collection_group.get_data(as_text=True)
     assert overlays.status_code == 200
     assert "Preview Overlays" in overlays.get_data(as_text=True)
 


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```md
## Summary

This PR improves the Libraries page performance and fixes several reset, mirror, override-count, and lazy-loading issues.

### Libraries page performance

- Stops loading every library’s heavy settings on initial page load.
- Defers heavy Collections and Overlays content until the selected library/section is opened.
- Adds lazy loading for individual collection parent groups so expanding Collections does not render every collection group at once.
- Preserves unloaded lazy section/group values during autosave so switching libraries does not accidentally drop settings.

### Override counts and reset behavior

- Adds consistent override rollups for:
  - Library total
  - Library Defaults
  - Advanced Library Options
  - Collections
  - Overlays
  - Attributes
  - Playlists
  - Advanced file/Arr override sections
- Adds reset controls for parent collection groups and advanced library sections.
- Fixes reset behavior so file/editor-backed fields actually reset their stored values, not just their visual indicators.
- Fixes top-level `Reset Collections` so it does not try to load every lazy collection group and hang indefinitely.
- Ensures collection reset clears collection defaults while preserving advanced `collection_files`.

### Mirror fixes

- Refreshes override state after mirror operations.
- Fixes mirrored content/rating and library settings so counters and UI state are recalculated after copying.
- Preserves unloaded/lazy values correctly during mirror/autosave flows.

### Overlay and content-rating count fixes

- Improves overlay override counting so disabled overlay groups do not contribute false-positive counts.
- Adds dynamic default handling for rating overlays so calculated defaults are not counted as overrides.
- Keeps overlay detail-level override indicators consistent with collection detail indicators.

### UX cleanup

- Adds visible reset spinners/status for library reset actions.
- Removes raw HTML from reset toast messages.
- Normalizes schedule reset comparison so equivalent values like padded and unpadded date ranges do not show false changes.

## Testing

- `npm run lint:eslint -- static/local-js/025-libraries.js`
- `venv\Scripts\python.exe -m pytest tests\test_collection_details_contract.py tests\test_config_and_library_routes.py::test_autosave_library_preserves_unloaded_lazy_collection_and_overlay_values tests\test_config_and_library_routes.py::test_autosave_library_ignores_lazy_loaded_marker_without_collection_payload tests\test_config_and_library_routes.py::test_autosave_library_preserves_unopened_lazy_collection_groups tests\test_config_and_library_routes.py::test_autosave_library_reset_collections_drops_unloaded_collection_defaults tests\test_core_backend.py::test_library_fragment_defers_heavy_collection_and_overlay_sections tests\test_core_backend.py::test_library_fragment_section_renders_requested_heavy_section`

Result: `31 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
