### PR TITLE
fix the emitted config

### DIFF
--- a/blueprints/import_config_bundle.py
+++ b/blueprints/import_config_bundle.py
@@ -101,24 +101,23 @@ def _extract_zip_bundle(raw_text: bytes) -> BundleExtractionResult:
 
     try:
         with zipfile.ZipFile(BytesIO(raw_text)) as archive:
-            archive_members = archive.namelist()
+            archive_members = _normalized_archive_members(archive.namelist())
             unexpected_members = []
             bundled_library_files = []
             bundled_overlay_images = []
             config_files = []
             font_files = []
 
-            for member_name in archive_members:
-                normalized_member = bundle_artifacts.normalize_bundle_member_name(member_name)
+            for member_name, normalized_member in archive_members:
                 if not normalized_member:
                     continue
                 if not bundle_artifacts.is_allowed_bundle_member(normalized_member):
                     unexpected_members.append(normalized_member)
                     continue
                 if _is_bundled_library_archive_member(normalized_member):
-                    bundled_library_files.append(member_name)
+                    bundled_library_files.append((member_name, normalized_member))
                 elif bundle_artifacts.is_bundled_overlay_image_archive_member(normalized_member):
-                    bundled_overlay_images.append(member_name)
+                    bundled_overlay_images.append((member_name, normalized_member))
                 elif bundle_artifacts.yaml_path_suffix(normalized_member):
                     config_files.append(member_name)
                 elif normalized_member.lower().endswith((".ttf", ".otf")):
@@ -157,6 +156,40 @@ def _extract_zip_bundle(raw_text: bytes) -> BundleExtractionResult:
         extracted_dir=extracted_dir,
         extracted_fonts=extracted_fonts,
     )
+
+
+def _normalized_archive_members(member_names):
+    """Return ``(archive_name, bundle_relative_name)`` pairs.
+
+    Windows Explorer commonly zips an exported bundle by wrapping the
+    original contents in one top-level folder. Strip that single common
+    wrapper so ``wrapper/config.yml`` and ``wrapper/<config>/...`` import
+    the same way as the original Quickstart bundle.
+    """
+    normalized = []
+    for member_name in member_names:
+        if str(member_name or "").replace("\\", "/").endswith("/"):
+            continue
+        member = bundle_artifacts.normalize_bundle_member_name(member_name)
+        if member:
+            normalized.append((member_name, member))
+    if not normalized:
+        return []
+
+    roots = {member.split("/", 1)[0] for _member_name, member in normalized}
+    if len(roots) != 1:
+        return normalized
+
+    root = next(iter(roots))
+    stripped = []
+    for member_name, member in normalized:
+        if member == root:
+            stripped.append((member_name, ""))
+        elif member.startswith(f"{root}/"):
+            stripped.append((member_name, member[len(root) + 1 :]))
+        else:
+            stripped.append((member_name, member))
+    return stripped
 
 
 def _extract_fonts(archive, font_files, extracted_dir: Path, extracted_fonts: list) -> None:
@@ -201,8 +234,13 @@ def _extract_bundled_files(archive, member_names, extracted_dir: Path) -> None:
     skipped.  Empty and directory members are also skipped.
     """
     resolved_root = extracted_dir.resolve()
-    for member_name in member_names:
-        normalized_member = str(member_name).replace("\\", "/").lstrip("/")
+    for member in member_names:
+        if isinstance(member, tuple):
+            member_name, archive_path = member
+        else:
+            member_name = member
+            archive_path = member
+        normalized_member = str(archive_path).replace("\\", "/").lstrip("/")
         if not normalized_member or normalized_member.endswith("/"):
             continue
         target = (extracted_dir / Path(normalized_member)).resolve()

--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -617,12 +617,56 @@ def _drop_collection_default_keys(library_id, libraries_data):
     return {key: value for key, value in libraries_data.items() if not _is_collection_default_key(library_id, key)}
 
 
+def _merge_active_library_payload_with_saved_libraries(library_id, incoming_libraries, existing_libraries):
+    """Merge one active-card autosave with the full persisted libraries map.
+
+    The browser only posts the mounted library card during lazy switching. The
+    backend must validate and save against the whole libraries map or unrelated
+    libraries lose their ``*-library`` selection flags and disappear from final
+    output.
+    """
+    incoming_libraries = incoming_libraries if isinstance(incoming_libraries, dict) else {}
+    existing_libraries = existing_libraries if isinstance(existing_libraries, dict) else {}
+    merged = dict(existing_libraries)
+
+    prefixes = set()
+    if library_id:
+        prefixes.add(library_id)
+    for key in incoming_libraries:
+        prefix = _library_prefix_from_key(key)
+        if prefix:
+            prefixes.add(prefix)
+
+    for prefix in prefixes:
+        for existing_key in list(merged.keys()):
+            if existing_key == f"{prefix}-library" or existing_key.startswith(prefix + "-"):
+                merged.pop(existing_key, None)
+
+    for key, value in incoming_libraries.items():
+        if (key.endswith("-library") or key.endswith("-playlist")) and not _is_truthy_setting_value(value):
+            continue
+        merged[key] = value
+
+    return merged
+
+
+def _is_library_file_entry_key(library_id, key):
+    return key in {
+        f"{library_id}-collection_files",
+        f"{library_id}-metadata_files",
+        f"{library_id}-overlay_files",
+    }
+
+
 def _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections, loaded_collection_groups=None):
-    """Keep persisted collection/overlay values when those lazy sections were never opened."""
+    """Keep persisted values for omitted lazy/partial library sections."""
     incoming_libraries = incoming_libraries if isinstance(incoming_libraries, dict) else {}
     unloaded_sections = {"collections", "overlays"} - set(loaded_sections or set())
     should_preserve_unloaded_collection_groups = "collections" in set(loaded_sections or set()) and loaded_collection_groups is not None
-    if not unloaded_sections and not should_preserve_unloaded_collection_groups:
+    missing_partial_fields = {
+        f"{library_id}-{suffix}" for suffix in ("collection_files", "metadata_files", "overlay_files", "playlist") if f"{library_id}-{suffix}" not in incoming_libraries
+    }
+    if not unloaded_sections and not should_preserve_unloaded_collection_groups and not missing_partial_fields:
         return incoming_libraries
 
     settings = persistence.retrieve_settings("025-libraries")
@@ -644,13 +688,14 @@ def _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loade
     def should_preserve(key):
         if not isinstance(key, str) or not key.startswith(prefix):
             return False
+        if key in missing_partial_fields and (_is_library_file_entry_key(library_id, key) or key == f"{library_id}-playlist"):
+            return True
         if should_preserve_unloaded_collection_groups and _collection_key_belongs_to_unloaded_group(key, collection_key_indexes, loaded_collection_groups):
             return True
-        if "collections" in unloaded_sections and (_is_collection_default_key(library_id, key) or key == f"{library_id}-collection_files"):
+        if "collections" in unloaded_sections and _is_collection_default_key(library_id, key):
             return True
         if "overlays" in unloaded_sections and (
             f"{library_id}-overlay_" in key
-            or key == f"{library_id}-overlay_files"
             or f"{library_id}-movie-overlay_" in key
             or f"{library_id}-show-overlay_" in key
             or f"{library_id}-season-overlay_" in key
@@ -804,11 +849,14 @@ def autosave_library(library_id):
         incoming_libraries = _preserve_unloaded_lazy_section_values(library_id, incoming_libraries, loaded_sections, loaded_collection_groups)
         if reset_collection_defaults:
             incoming_libraries = _drop_collection_default_keys(library_id, incoming_libraries)
-        selected_library_ids = _qs._selected_library_ids_from_libraries_data(incoming_libraries)
-        collection_errors = _qs._validate_library_collection_files(incoming_libraries, selected_library_ids)
-        metadata_errors = _qs._validate_library_metadata_files(incoming_libraries, selected_library_ids)
-        overlay_errors = _qs._validate_library_overlay_files(incoming_libraries, selected_library_ids)
-        auto_sort_hubs_errors = _qs._validate_library_auto_sort_hubs(incoming_libraries, selected_library_ids)
+        settings = persistence.retrieve_settings("025-libraries")
+        existing_libraries = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+        merged_libraries = _merge_active_library_payload_with_saved_libraries(library_id, incoming_libraries, existing_libraries)
+        selected_library_ids = _qs._selected_library_ids_from_libraries_data(merged_libraries)
+        collection_errors = _qs._validate_library_collection_files(merged_libraries, selected_library_ids)
+        metadata_errors = _qs._validate_library_metadata_files(merged_libraries, selected_library_ids)
+        overlay_errors = _qs._validate_library_overlay_files(merged_libraries, selected_library_ids)
+        auto_sort_hubs_errors = _qs._validate_library_auto_sort_hubs(merged_libraries, selected_library_ids)
         if collection_errors:
             return jsonify({"success": False, "error": "Invalid collection files.", "errors": collection_errors}), 400
         if metadata_errors:
@@ -818,19 +866,13 @@ def autosave_library(library_id):
         if auto_sort_hubs_errors:
             return jsonify({"success": False, "error": "Invalid library settings.", "errors": auto_sort_hubs_errors}), 400
         normalized_libraries, normalization_errors, changed = _qs._normalize_library_file_entries_payload(
-            incoming_libraries,
+            merged_libraries,
             config_name,
             validate_local=False,
         )
         if normalization_errors:
             return jsonify({"success": False, "error": "Unable to organize library files.", "errors": normalization_errors}), 400
-        save_payload = dict(incoming) if isinstance(incoming, dict) else {}
-        save_payload.pop("__loaded_sections", None)
-        save_payload.pop("__loaded_collection_groups", None)
-        save_payload.pop("__reset_collection_defaults", None)
-        if reset_collection_defaults:
-            save_payload = _drop_collection_default_keys(library_id, save_payload)
-        save_payload.update(normalized_libraries)
+        save_payload = dict(normalized_libraries)
         save_payload["config_name"] = config_name
         persistence.save_settings("025-libraries", save_payload)
         return jsonify({"success": True, "normalized": bool(changed), "libraries": normalized_libraries})

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -569,6 +569,52 @@ def _is_collectionless_entry(item):
     return default_name in {"collectionless", "collection_collectionless"} or default_name.endswith("collectionless")
 
 
+def _collection_default_order_map(library_type):
+    """Return the canonical collection default order from quickstart_collections.json."""
+    media_type = {"mov": "movie", "sho": "show"}.get(library_type)
+    order_map = {}
+    try:
+        groups = helpers.load_quickstart_config("quickstart_collections.json")
+    except Exception as exc:
+        helpers.ts_log(f"Failed to load quickstart_collections.json for collection order: {exc}", level="ERROR")
+        return order_map
+
+    for group in groups or []:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []) or []:
+            if not isinstance(collection, dict):
+                continue
+            collection_id = str(collection.get("id") or "").strip()
+            if not collection_id:
+                continue
+            raw_id = collection_id.replace("collection_", "", 1)
+            if raw_id in order_map:
+                continue
+            media_types = collection.get("media_types") or []
+            if media_type and media_types and media_type not in media_types:
+                continue
+            order_map[raw_id] = len(order_map)
+    return order_map
+
+
+def _sort_generated_collection_entries(collection_files, library_type):
+    """Sort generated collection defaults canonically while preserving unknown-key order."""
+    order_map = _collection_default_order_map(library_type)
+    fallback_start = len(order_map)
+
+    def sort_key(indexed_item):
+        index, item = indexed_item
+        default_name = str(item.get("default", "")).strip()
+        return (
+            1 if _is_collectionless_entry(item) else 0,
+            order_map.get(default_name, fallback_start + index),
+            index,
+        )
+
+    collection_files[:] = [item for _index, item in sorted(enumerate(collection_files), key=sort_key)]
+
+
 def _build_child_prefix(library_key, raw_id):
     """Compute the template-child-key prefix for a collection.
 
@@ -606,8 +652,10 @@ def build_collection_files(
     parsed out of ``<library_prefix>-collection_files`` from the raw
     collection group; user-authored ordering wins for those.
 
-    The returned list is stably sorted so 'collectionless' sinks to
-    the end (Kometa expects it last within a library).
+    Generated defaults are sorted by quickstart_collections.json so
+    imported/saved insertion order does not affect final YAML diffs.
+    'collectionless' still sinks to the end of generated defaults
+    (Kometa expects it last within a library).
     """
     collection_key = helpers.extract_library_name(library_key)
     if debug:
@@ -670,7 +718,7 @@ def build_collection_files(
     raw_collection_entries = _parse_collection_file_block_entries(raw_collection_group.get(f"{library_prefix}-collection_files"))
 
     if collection_files:
-        collection_files.sort(key=_is_collectionless_entry)
+        _sort_generated_collection_entries(collection_files, library_type)
 
     if raw_collection_entries:
         collection_files.extend(raw_collection_entries)

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -360,6 +360,38 @@ def _apply_trakt_reorder(cleaned_data):
     cleaned_data["trakt"] = ordered_section
 
 
+def _has_nonblank_oauth_value(value):
+    if value is None:
+        return False
+    text = str(value).strip()
+    return bool(text) and text.lower() not in {"none", "null", "false"}
+
+
+def _drop_unusable_trakt_section(cleaned_data):
+    """Drop token-only Trakt residue left after a user clears visible inputs.
+
+    Imported bundles can leave ``authorization`` tokens behind after the Trakt
+    page is visually cleared. Without a client identity, those tokens cannot be
+    validated as a configured Trakt setup and should not keep being emitted.
+    """
+    section = cleaned_data.get("trakt")
+    if not isinstance(section, dict):
+        return
+    auth = section.get("authorization") if isinstance(section.get("authorization"), dict) else {}
+    has_visible_identity = any(
+        _has_nonblank_oauth_value(value)
+        for value in (
+            section.get("client_id"),
+            section.get("client_secret"),
+            section.get("pin"),
+            auth.get("client_id"),
+            auth.get("client_secret"),
+        )
+    )
+    if not has_visible_identity:
+        cleaned_data.pop("trakt", None)
+
+
 def _apply_settings_normalization(cleaned_data):
     """Normalize settings-block values, mirroring the schema shapes expected
     by Kometa.  ``asset_directory`` in particular can arrive as a multi-line
@@ -499,6 +531,9 @@ def dump_section(title, dump_name, data, header_style, config_name):
         _apply_mal_trakt_int_coercions(cleaned_data, dump_name)
 
     if dump_name == "trakt":
+        _drop_unusable_trakt_section(cleaned_data)
+        if "trakt" not in cleaned_data:
+            return ""
         _apply_trakt_reorder(cleaned_data)
 
     if dump_name == "settings":

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -258,26 +258,43 @@ def save_settings(raw_source, form_data):
             def _library_prefix(key):
                 if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
                     return None
-                if "-template_" in key:
-                    return key.split("-template_", 1)[0]
-                if "-attribute_" in key:
-                    return key.split("-attribute_", 1)[0]
-                if "-collection_" in key:
-                    return key.split("-collection_", 1)[0]
-                if "-overlay_" in key:
-                    return key.split("-overlay_", 1)[0]
-                if "-top_level_" in key:
-                    return key.split("-top_level_", 1)[0]
+                for marker in (
+                    "-movie-template_",
+                    "-show-template_",
+                    "-season-template_",
+                    "-episode-template_",
+                    "-movie-overlay_",
+                    "-show-overlay_",
+                    "-season-overlay_",
+                    "-episode-overlay_",
+                    "-template_",
+                    "-attribute_",
+                    "-collection_",
+                    "-overlay_",
+                    "-top_level_",
+                    "-library_service_",
+                ):
+                    if marker in key:
+                        return key.split(marker, 1)[0]
                 if key.endswith("-library"):
                     return key[: -len("-library")]
+                for suffix in ("-playlist", "-collection_files", "-metadata_files", "-overlay_files"):
+                    if key.endswith(suffix):
+                        return key[: -len(suffix)]
                 return None
 
             # Identify library prefixes present in this payload (e.g., mov-library_xxx, sho-library_yyy)
             prefixes = set()
-            for key in incoming_libraries:
+            for key, value in incoming_libraries.items():
                 prefix = _library_prefix(key)
-                if prefix:
-                    prefixes.add(prefix)
+                if not prefix:
+                    continue
+                # Lazy library cards can leave disabled/hidden false toggles in
+                # form payloads. A false include/playlist toggle alone is not
+                # enough evidence that this prefix was intentionally submitted.
+                if key in (f"{prefix}-library", f"{prefix}-playlist") and value in [None, False, "", "false"]:
+                    continue
+                prefixes.add(prefix)
 
             # Remove existing entries for the affected prefixes so we can replace them cleanly
             for prefix in prefixes:

--- a/modules/workspace_step_status.py
+++ b/modules/workspace_step_status.py
@@ -118,32 +118,60 @@ def _has_meaningful_optional_input(template_key, payload):
         if not isinstance(trakt, dict):
             return False
         auth = trakt.get("authorization", {}) if isinstance(trakt.get("authorization"), dict) else {}
-        return any(
+        visible_inputs = (
+            trakt.get("client_id"),
+            trakt.get("client_secret"),
+            trakt.get("pin"),
+        )
+        if any(_is_meaningful_optional_status_input(value) for value in visible_inputs):
+            return True
+        has_authorization_token = any(
             _is_meaningful_optional_status_input(value)
             for value in (
-                trakt.get("client_id"),
-                trakt.get("client_secret"),
-                trakt.get("pin"),
                 auth.get("access_token"),
                 auth.get("refresh_token"),
             )
         )
+        has_client_identity = any(
+            _is_meaningful_optional_status_input(value)
+            for value in (
+                trakt.get("client_id"),
+                trakt.get("client_secret"),
+                auth.get("client_id"),
+                auth.get("client_secret"),
+            )
+        )
+        return has_authorization_token and has_client_identity
 
     if template_key == "140-mal":
         mal = payload.get("mal", {})
         if not isinstance(mal, dict):
             return False
         auth = mal.get("authorization", {}) if isinstance(mal.get("authorization"), dict) else {}
-        return any(
+        visible_inputs = (
+            mal.get("client_id"),
+            mal.get("client_secret"),
+            mal.get("localhost_url"),
+        )
+        if any(_is_meaningful_optional_status_input(value) for value in visible_inputs):
+            return True
+        has_authorization_token = any(
             _is_meaningful_optional_status_input(value)
             for value in (
-                mal.get("client_id"),
-                mal.get("client_secret"),
-                mal.get("localhost_url"),
                 auth.get("access_token"),
                 auth.get("refresh_token"),
             )
         )
+        has_client_identity = any(
+            _is_meaningful_optional_status_input(value)
+            for value in (
+                mal.get("client_id"),
+                mal.get("client_secret"),
+                auth.get("client_id"),
+                auth.get("client_secret"),
+            )
+        )
+        return has_authorization_token and has_client_identity
 
     # For unknown validation-backed optional steps, keep prior behavior.
     return True

--- a/quickstart.py
+++ b/quickstart.py
@@ -1071,6 +1071,41 @@ def _normalize_shared_playlist_file_entries_payload(libraries_data, config_name,
     return normalized, errors
 
 
+def _library_save_prefix_from_key(key):
+    prefix = _library_prefix_from_key(key)
+    if prefix:
+        return prefix
+    if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
+        return None
+    for suffix in ("-playlist", "-collection_files", "-metadata_files", "-overlay_files"):
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    return None
+
+
+def _merge_libraries_payload_for_partial_step_save(incoming_libraries):
+    """Merge the submitted active library card into the full persisted map."""
+    incoming_libraries = incoming_libraries if isinstance(incoming_libraries, dict) else {}
+    settings = persistence.retrieve_settings("025-libraries")
+    existing_libraries = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+    existing_libraries = existing_libraries if isinstance(existing_libraries, dict) else {}
+    merged_libraries = dict(existing_libraries)
+
+    for key, value in incoming_libraries.items():
+        prefix = _library_save_prefix_from_key(key)
+        if prefix and key in (f"{prefix}-library", f"{prefix}-playlist") and not _is_truthy_setting_value(value):
+            continue
+        merged_libraries[key] = value
+
+    for shared in ("mov-template_variables", "sho-template_variables"):
+        if shared in incoming_libraries:
+            merged_libraries[shared] = incoming_libraries[shared]
+        elif shared in existing_libraries and shared not in merged_libraries:
+            merged_libraries[shared] = existing_libraries[shared]
+
+    return merged_libraries
+
+
 DOTENV = os.path.relpath(os.path.join(helpers.CONFIG_DIR, ".env"))
 load_dotenv(DOTENV, override=True)
 
@@ -1973,6 +2008,7 @@ def step(name):
         if save_source_name == "libraries":
             clean_payload = persistence.clean_form_data(request.form)
             incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
+            incoming_libraries = _merge_libraries_payload_for_partial_step_save(incoming_libraries)
             selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
             validation_errors += _validate_library_collection_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -285,7 +285,8 @@ const EventHandler = {
           const isHidden = !input.offsetParent
           const min = parseFloat(input.dataset.minSaved || '0')
           const max = parseFloat(input.dataset.maxSaved || '10')
-          const val = parseFloat(input.value)
+          const rawValue = String(input.value || '').trim()
+          const val = parseFloat(rawValue)
           if (isHidden) {
             const feedback = input.parentElement?.querySelector('.invalid-feedback')
             input.setCustomValidity('')
@@ -294,7 +295,7 @@ const EventHandler = {
             return
           }
           const feedback = input.parentElement?.querySelector('.invalid-feedback')
-          const invalid = Number.isNaN(val) || val < min || val > max
+          const invalid = rawValue !== '' && (Number.isNaN(val) || val < min || val > max)
           if (invalid) {
             input.setCustomValidity(`Enter a value between ${min} and ${max}`)
             input.classList.add('is-invalid')
@@ -515,8 +516,9 @@ function installRatingSubmitGuard () {
       if (!input.offsetParent) return false
       const min = parseFloat(input.dataset.minSaved || input.getAttribute('min') || '0')
       const max = parseFloat(input.dataset.maxSaved || input.getAttribute('max') || '10')
-      const val = parseFloat(input.value)
-      return Number.isNaN(val) || val < min || val > max
+      const rawValue = String(input.value || '').trim()
+      const val = parseFloat(rawValue)
+      return rawValue !== '' && (Number.isNaN(val) || val < min || val > max)
     })
     if (invalid.length) {
       evt.preventDefault()

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -545,6 +545,253 @@ def test_autosave_library_reset_collections_drops_unloaded_collection_defaults(
     assert libraries["mov-library_movies-overlay_resolution"] is True
 
 
+def test_final_libraries_output_survives_lazy_library_switch_autosaves(
+    client,
+    isolated_config_dir,
+    qs_module,
+    app,
+    monkeypatch,
+):
+    """Partial lazy autosaves must not drop persisted library output data."""
+    import copy
+    import json
+
+    from flask import session
+    from modules import database, output
+
+    config_name = "pytest_lazy_final_output"
+    collection_files = json.dumps([{"type": "url", "location": "https://example.com/movies.yml"}])
+    overlay_files = json.dumps([{"type": "url", "location": "https://example.com/overlays.yml"}])
+    metadata_files = json.dumps([{"type": "url", "location": "https://example.com/metadata.yml"}])
+    saved_libraries = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-playlist": True,
+        "mov-library_movies-collection_actor": True,
+        "mov-library_movies-template_collection_actor_include": '["Tom Hanks"]',
+        "mov-library_movies-template_collection_actor_exclude": '["Morgan Freeman"]',
+        "mov-library_movies-movie-overlay_resolution": True,
+        "mov-library_movies-movie-template_overlay_resolution[use_edition]": False,
+        "mov-library_movies-attribute_language": "English",
+        "mov-library_movies-collection_files": collection_files,
+        "mov-library_movies-overlay_files": overlay_files,
+        "mov-library_movies-metadata_files": metadata_files,
+        "sho-library_tv-library": "TV Shows",
+        "sho-library_tv-playlist": True,
+        "sho-library_tv-collection_actor": True,
+        "sho-library_tv-template_collection_actor_include": '["Patrick Stewart"]',
+        "sho-library_tv-show-overlay_resolution": True,
+        "sho-library_tv-show-template_overlay_resolution[use_edition]": False,
+        "sho-library_tv-attribute_language": "English",
+    }
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={"libraries": copy.deepcopy(saved_libraries), "validated": True, "validated_at": "2026-07-22T00:00:00Z"},
+    )
+
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: {"mov-library_movies", "sho-library_tv"})
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_library_file_entries_payload",
+        lambda libs, config_name, **kw: (libs, [], False),
+    )
+    monkeypatch.setattr(output.helpers, "ensure_json_schema", lambda: None)
+    monkeypatch.setattr(output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(output.helpers, "get_library_summaries", lambda _names: "Library summary unavailable")
+    monkeypatch.setattr(output.jsonschema.Draft7Validator, "iter_errors", lambda self, parsed: [])
+
+    def build_libraries_snapshot():
+        with app.test_request_context("/step/900-kometa"):
+            session["config_name"] = config_name
+            validated, validation_error, config_data, yaml_content, validation_errors = output.build_config(
+                "single line",
+                config_name=config_name,
+            )
+        assert validated is True
+        assert validation_error is None
+        assert validation_errors == []
+        assert "Movies:" in yaml_content
+        assert "TV Shows:" in yaml_content
+        return copy.deepcopy(config_data["libraries"])
+
+    before_libraries = build_libraries_snapshot()
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    movie_resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": ["collections", "overlays"],
+            "__loaded_collection_groups": [],
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_language": "English",
+        },
+    )
+    show_resp = client.post(
+        "/autosave_library/sho-library_tv",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": [],
+            "sho-library_tv-library": "TV Shows",
+            "sho-library_tv-attribute_language": "English",
+        },
+    )
+
+    assert movie_resp.status_code == 200
+    assert show_resp.status_code == 200
+    after_libraries = build_libraries_snapshot()
+
+    assert after_libraries == before_libraries
+    assert len(after_libraries) == 2
+    assert any(entry.get("default") == "actor" for entry in after_libraries["Movies"]["collection_files"])
+    assert any(entry.get("default") == "resolution" for entry in after_libraries["Movies"]["overlay_files"])
+    _validated, _user_entered, persisted = database.retrieve_section_data(config_name, "libraries")
+    for key, value in saved_libraries.items():
+        assert persisted["libraries"][key] == value
+
+
+def test_autosave_library_switching_preserves_other_selected_libraries(
+    client,
+    isolated_config_dir,
+    qs_module,
+    monkeypatch,
+):
+    """Switch-only lazy autosaves must not deselect libraries that are not mounted."""
+    import copy
+    import json
+
+    from modules import database
+
+    config_name = "pytest_lazy_switch_preserves_all"
+    collection_files = json.dumps([{"type": "url", "location": "https://example.com/movies.yml"}])
+    overlay_files = json.dumps([{"type": "url", "location": "https://example.com/overlays.yml"}])
+    saved_libraries = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_actor": True,
+        "mov-library_movies-template_collection_actor_include": '["Tom Hanks"]',
+        "mov-library_movies-movie-overlay_resolution": True,
+        "mov-library_movies-collection_files": collection_files,
+        "mov-library_movies-overlay_files": overlay_files,
+        "mov-library_test_movie_lib-library": "test_movie_lib",
+        "mov-library_test_movie_lib-collection_actor": True,
+        "mov-library_test_movie_lib-template_collection_actor_include": '["Morgan Freeman"]',
+        "sho-library_tv-library": "TV Shows",
+        "sho-library_tv-collection_actor": True,
+        "sho-library_tv-show-overlay_resolution": True,
+    }
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={"libraries": copy.deepcopy(saved_libraries), "validated": True, "validated_at": "2026-07-22T00:00:00Z"},
+    )
+
+    monkeypatches = [
+        ("_validate_library_collection_files", lambda libs, ids: []),
+        ("_validate_library_metadata_files", lambda libs, ids: []),
+        ("_validate_library_overlay_files", lambda libs, ids: []),
+        ("_validate_library_auto_sort_hubs", lambda libs, ids: []),
+        ("_normalize_library_file_entries_payload", lambda libs, config_name, **kw: (libs, [], False)),
+    ]
+    for attr, replacement in monkeypatches:
+        monkeypatch.setattr(qs_module, attr, replacement)
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    for library_id, library_name in (
+        ("mov-library_movies", "Movies"),
+        ("mov-library_test_movie_lib", "test_movie_lib"),
+        ("sho-library_tv", "TV Shows"),
+        ("mov-library_movies", "Movies"),
+    ):
+        resp = client.post(
+            f"/autosave_library/{library_id}",
+            json={
+                "config_name": config_name,
+                "__loaded_sections": [],
+                f"{library_id}-library": library_name,
+                f"{library_id}-attribute_language": "English",
+            },
+        )
+        assert resp.status_code == 200
+
+    _validated, _user_entered, persisted = database.retrieve_section_data(config_name, "libraries")
+    libraries = persisted["libraries"]
+    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_test_movie_lib-library"] == "test_movie_lib"
+    assert libraries["sho-library_tv-library"] == "TV Shows"
+    assert libraries["mov-library_movies-collection_actor"] is True
+    assert libraries["mov-library_movies-template_collection_actor_include"] == '["Tom Hanks"]'
+    assert libraries["mov-library_movies-movie-overlay_resolution"] is True
+    assert libraries["mov-library_movies-collection_files"] == collection_files
+    assert libraries["mov-library_movies-overlay_files"] == overlay_files
+    assert libraries["mov-library_test_movie_lib-collection_actor"] is True
+    assert libraries["sho-library_tv-collection_actor"] is True
+
+
+def test_libraries_save_ignores_false_only_hidden_toggles_for_unmounted_libraries(
+    app,
+    isolated_config_dir,
+    qs_module,
+):
+    """Regular step saves must merge partial active-card payloads before validation."""
+    import copy
+    import json
+
+    from flask import session
+    from modules import database
+
+    config_name = "pytest_lazy_navigation_preserves_all"
+    collection_files = json.dumps([{"type": "url", "location": "https://example.com/movies.yml"}])
+    saved_libraries = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_actor": True,
+        "mov-library_movies-collection_files": collection_files,
+        "mov-library_test_movie_lib-library": "test_movie_lib",
+        "mov-library_test_movie_lib-collection_actor": True,
+        "sho-library_tv-library": "TV Shows",
+        "sho-library_tv-collection_actor": True,
+    }
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={"libraries": copy.deepcopy(saved_libraries), "validated": True, "validated_at": "2026-07-22T00:00:00Z"},
+    )
+
+    with app.test_request_context("/step/900-kometa"):
+        session["config_name"] = config_name
+        libraries = qs_module._merge_libraries_payload_for_partial_step_save(
+            {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_language": "English",
+                "mov-library_test_movie_lib-library": "false",
+                "sho-library_tv-library": "false",
+            }
+        )
+
+    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-attribute_language"] == "English"
+    assert libraries["mov-library_movies-collection_actor"] is True
+    assert libraries["mov-library_movies-collection_files"] == collection_files
+    assert libraries["mov-library_test_movie_lib-library"] == "test_movie_lib"
+    assert libraries["mov-library_test_movie_lib-collection_actor"] is True
+    assert libraries["sho-library_tv-library"] == "TV Shows"
+    assert libraries["sho-library_tv-collection_actor"] is True
+
+
 # ===========================================================================
 # /autosave-imagemaid
 # ===========================================================================

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4653,6 +4653,47 @@ def test_import_config_preview_rejects_zip_with_unsupported_entries(client):
     assert "unexpected.exe" in payload["message"]
 
 
+def test_import_config_preview_accepts_windows_wrapped_bundle_directories(client):
+    import io
+    import zipfile
+    from pathlib import Path
+
+    bundle = io.BytesIO()
+    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/", b"")
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/", b"")
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/collection_files/", b"")
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/collection_files/mov-library_movies/", b"")
+        archive.writestr(
+            "bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/collection_files/mov-library_movies/config_collection_files_a8a07b81df/",
+            b"",
+        )
+        archive.writestr(
+            "bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/collection_files/mov-library_movies/config_collection_files_a8a07b81df/movies_refresh.yml",
+            "collections: {}\n",
+        )
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/fonts/", b"")
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/bullmoose20_prod9/fonts/Poster.ttf", b"font")
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/config.yml", "settings:\n  cache: true\n")
+        archive.writestr("bullmoose20_prod9_config_bundle (test)/README.txt", "Quickstart config bundle\n")
+    bundle.seek(0)
+
+    resp = client.post(
+        "/import-config/preview",
+        data={"config_name": "pytest_wrapped_bundle", "file": (bundle, "bundle.zip")},
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    payload = resp.get_json()
+    assert payload["success"] is True
+
+    with client.session_transaction() as sess:
+        bundle_dir = Path(sess["import_preview_bundle_dir"])
+
+    assert (bundle_dir / "bullmoose20_prod9" / "collection_files" / "mov-library_movies" / "config_collection_files_a8a07b81df" / "movies_refresh.yml").exists()
+
+
 def test_import_config_preview_handles_yaml_date_scalars_in_cache(client):
     import io
     import json

--- a/tests/test_output_collection_order.py
+++ b/tests/test_output_collection_order.py
@@ -1,0 +1,48 @@
+import json
+
+from modules.output_collections import build_collection_files
+
+
+def _defaults(entries):
+    return [entry.get("default") or next(iter(entry.keys())) for entry in entries]
+
+
+def test_build_collection_files_uses_quickstart_json_order_not_saved_key_order():
+    collections = {
+        "movies": {
+            "mov-library_movies-collection_studio": True,
+            "mov-library_movies-collection_folder": True,
+            "mov-library_movies-collection_collectionless": True,
+            "mov-library_movies-collection_basic": True,
+            "mov-library_movies-collection_oscars": True,
+            "mov-library_movies-collection_separator_award": True,
+        }
+    }
+    raw_collection_entries = json.dumps(
+        [
+            {
+                "type": "file",
+                "location": "config/custom_collections.yml",
+            }
+        ]
+    )
+
+    collection_files, has_collectionless = build_collection_files(
+        "mov-library_movies-library",
+        "mov",
+        collections,
+        {},
+        {"movies": {"mov-library_movies-collection_files": raw_collection_entries}},
+        {},
+    )
+
+    assert has_collectionless is True
+    assert _defaults(collection_files) == [
+        "separator_award",
+        "oscars",
+        "basic",
+        "studio",
+        "folder",
+        "collectionless",
+        "file",
+    ]

--- a/tests/test_output_id_list_annotations.py
+++ b/tests/test_output_id_list_annotations.py
@@ -138,3 +138,26 @@ def test_library_placeholder_id_emits_saved_lookup_comment(app):
 
     assert re.search(r"placeholder_imdb_id: tt0108052\s+# Schindler's List", yaml_content)
     assert "__template_variable_comments" not in yaml_content
+
+
+def test_trakt_token_only_residue_is_not_emitted(app):
+    trakt = {
+        "trakt": {
+            "authorization": {
+                "access_token": "stale-access-token",
+                "refresh_token": "stale-refresh-token",
+            },
+            "client_id": None,
+            "client_secret": None,
+            "pin": None,
+            "force_refresh": False,
+        }
+    }
+
+    with app.app_context():
+        yaml_content = dump_section("", "trakt", trakt, "none", None)
+
+    assert yaml_content == ""
+    assert "trakt:" not in yaml_content
+    assert "authorization:" not in yaml_content
+    assert "stale-access-token" not in yaml_content

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -883,6 +883,32 @@ def test_workspace_context_keeps_trakt_optional_without_dependency(monkeypatch, 
     assert ctx["trakt_requirement_reasons"] == []
 
 
+def test_trakt_optional_token_only_residue_stays_unknown(qs_module):
+    section_rows = {
+        "trakt": {
+            "validated": False,
+            "user_entered": True,
+            "data": {
+                "validation_status": "",
+                "validation_reason": "",
+                "trakt": {
+                    "authorization": {
+                        "access_token": "stale-access-token",
+                        "refresh_token": "stale-refresh-token",
+                    },
+                    "client_id": None,
+                    "client_secret": None,
+                    "pin": None,
+                    "force_refresh": False,
+                },
+            },
+        }
+    }
+
+    state = qs_module._derive_step_status("130-trakt", "optional", section_rows, config_exists=True)
+    assert state == "unknown"
+
+
 def test_optional_skipped_without_changes_stays_unknown(qs_module):
     section_rows = {
         "tautulli": {
@@ -990,6 +1016,31 @@ def test_mal_optional_without_credentials_ignores_stale_failed_marker(qs_module)
                 "mal": {
                     "cache_expiration": "60",
                     "authorization": {"access_token": ""},
+                },
+            },
+        }
+    }
+
+    state = qs_module._derive_step_status("140-mal", "optional", section_rows, config_exists=True)
+    assert state == "unknown"
+
+
+def test_mal_optional_token_only_residue_stays_unknown(qs_module):
+    section_rows = {
+        "mal": {
+            "validated": False,
+            "user_entered": True,
+            "data": {
+                "validation_status": "",
+                "validation_reason": "",
+                "mal": {
+                    "authorization": {
+                        "access_token": "stale-access-token",
+                        "refresh_token": "stale-refresh-token",
+                    },
+                    "client_id": None,
+                    "client_secret": None,
+                    "localhost_url": None,
                 },
             },
         }


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This branch fixes several final-config and import/export stability issues found while testing imported bundles through the Libraries page.

### Final config / Libraries preservation

- Fixed lazy Libraries autosave so switching between libraries no longer drops unrelated library selections or their persisted collections, overlays, playlists, metadata files, or custom file entries.
- Updated regular Libraries step saves to merge partial active-card payloads with the full persisted library map before validation/output.
- Prevented hidden false-only `*-library` / `*-playlist` toggle values from being treated as intentional deselection for unloaded libraries.
- Preserved unloaded partial fields like `collection_files`, `metadata_files`, `overlay_files`, and playlist toggles during lazy saves.

### Import bundle handling

- Fixed import preview for Windows Explorer re-zipped bundles that add a single top-level wrapper folder.
- Import now normalizes wrapped bundle members so exported bundles can be edited/re-zipped on Windows and imported again without unsupported-entry failures.

### Output cleanup / deterministic YAML

- Made generated `collection_files` output deterministic by sorting defaults from `static/json/quickstart_collections.json`, with `collectionless` forced to the end and raw/custom file entries appended afterward.
- Dropped unusable Trakt token-only residue from emitted YAML when visible client identity fields have been cleared.
- Kept Trakt/MAL optional page status as unknown when only stale authorization tokens remain, instead of blocking Kometa setup.

### Frontend validation

- Fixed optional rating inputs so blank optional rating fields are valid; non-blank values are still validated against the configured min/max range.

## Testing

- Added regression coverage for lazy library switching preserving final emitted config.
- Added autosave coverage for switching across multiple libraries without dropping selections.
- Added regular Libraries save coverage for ignoring false-only hidden toggles from unmounted libraries.
- Added wrapped Windows zip import coverage.
- Added deterministic collection output order coverage.
- Added Trakt/MAL token-only residue status/output coverage.

Validated with targeted tests:
- `venv\Scripts\python.exe -m pytest tests/test_output_collection_order.py`
- `venv\Scripts\python.exe -m pytest tests/test_video_format_yaml_contract.py tests/test_output_id_list_annotations.py`
- `venv\Scripts\python.exe -m pytest tests/test_config_and_library_routes.py`
- `venv\Scripts\python.exe -m pytest tests/test_core_backend.py`
- `venv\Scripts\python.exe -m pytest tests/test_workspace_dependency_logic.py`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
