### PR TITLE
bars fixed

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -180,8 +180,10 @@ def _library_fragment_context(library_id, *, include_attributes=True, include_co
         return None
 
     attribute_config = helpers.load_quickstart_config("quickstart_attributes.json") if include_attributes else {}
-    collection_config = helpers.load_quickstart_config("quickstart_collections.json") if include_collections else []
-    overlay_config = helpers.load_quickstart_overlay_config() if include_overlays else []
+    lazy_collection_config = helpers.load_quickstart_config("quickstart_collections.json")
+    lazy_overlay_config = helpers.load_quickstart_overlay_config()
+    collection_config = lazy_collection_config if include_collections else []
+    overlay_config = lazy_overlay_config if include_overlays else []
 
     legacy_playlist_libraries = _migrate_legacy_playlist_libraries_to_library_toggles(movie_libraries, show_libraries)
     data = persistence.retrieve_settings("025-libraries")
@@ -203,13 +205,34 @@ def _library_fragment_context(library_id, *, include_attributes=True, include_co
         "movie_images": image_data.get("movie", []),
         "configured_ids": configured_ids,
         "legacy_playlist_libraries": legacy_playlist_libraries,
-        "lazy_section_override_counts": _lazy_section_override_counts(library, data.get("libraries", {}), telemetry_data),
+        "lazy_section_override_counts": _lazy_section_override_counts(
+            library,
+            data.get("libraries", {}),
+            telemetry_data,
+            collection_config=lazy_collection_config,
+            overlay_config=lazy_overlay_config,
+        ),
+        "lazy_section_active_states": _lazy_section_active_states(
+            library,
+            data.get("libraries", {}),
+            collection_config=lazy_collection_config,
+            overlay_config=lazy_overlay_config,
+        ),
         "collection_group_override_counts": (
             _collection_group_override_counts_for_library(
                 library,
                 data.get("libraries", {}),
                 collection_config,
                 telemetry_data,
+            )
+            if include_collections
+            else {}
+        ),
+        "collection_group_active_states": (
+            _collection_group_active_states_for_library(
+                library,
+                data.get("libraries", {}),
+                collection_config,
             )
             if include_collections
             else {}
@@ -376,6 +399,35 @@ def _collection_group_override_counts_for_library(library, libraries_data, colle
     telemetry_data = telemetry_data if isinstance(telemetry_data, dict) else {}
     library_with_plex["plex_pass"] = bool(telemetry_data.get("plex_pass"))
     return {index: _count_collection_group_overrides_for_library(library_with_plex, libraries_data, group) for index, group in enumerate(collection_config)}
+
+
+def _collection_group_has_active_selection_for_library(library, libraries_data, group):
+    if not isinstance(libraries_data, dict) or not isinstance(group, dict) or not isinstance(library, dict):
+        return False
+    library_id = library.get("id")
+    library_type = library.get("type")
+    if not library_id or not library_type:
+        return False
+    for collection in group.get("collections", []) or []:
+        media_types = collection.get("media_types") or []
+        if media_types and library_type not in media_types:
+            continue
+        collection_id = str(collection.get("id", "")).strip()
+        if not collection_id:
+            continue
+        if _coerce_bool(libraries_data.get(f"{library_id}-{collection_id}")):
+            return True
+    return False
+
+
+def _collection_group_active_states_for_library(library, libraries_data, collection_config):
+    if not isinstance(collection_config, list):
+        return {}
+    return {index: _collection_group_has_active_selection_for_library(library, libraries_data, group) for index, group in enumerate(collection_config)}
+
+
+def _has_active_collection_selection_for_library(library, libraries_data, collection_config):
+    return any(_collection_group_active_states_for_library(library, libraries_data, collection_config).values())
 
 
 def _iter_overlay_template_items(template_variables):
@@ -566,16 +618,42 @@ def _count_overlay_overrides_for_library(library, libraries_data, overlay_config
     return count
 
 
-def _lazy_section_override_counts(library, libraries_data, telemetry_data=None):
+def _has_active_overlay_selection_for_library(library, libraries_data, overlay_config):
+    if not isinstance(libraries_data, dict):
+        return False
+    library_id = library["id"]
+    library_type = library["type"]
+    render_types = ["movie"] if library_type == "movie" else ["show", "season", "episode"]
+    for group in overlay_config or []:
+        for overlay in group.get("overlays", []):
+            for render_type in render_types:
+                media_types = overlay.get("media_types") or []
+                if media_types and render_type not in media_types:
+                    continue
+                if _overlay_group_is_active(library_id, render_type, group, overlay, libraries_data):
+                    return True
+    return False
+
+
+def _lazy_section_override_counts(library, libraries_data, telemetry_data=None, collection_config=None, overlay_config=None):
     library_with_plex = dict(library)
     # Collection visibility for visible_* variables depends on Plex Pass.
     telemetry_data = telemetry_data if isinstance(telemetry_data, dict) else {}
     library_with_plex["plex_pass"] = bool(telemetry_data.get("plex_pass"))
-    collection_config = helpers.load_quickstart_config("quickstart_collections.json")
-    overlay_config = helpers.load_quickstart_overlay_config()
+    collection_config = collection_config if isinstance(collection_config, list) else helpers.load_quickstart_config("quickstart_collections.json")
+    overlay_config = overlay_config if isinstance(overlay_config, list) else helpers.load_quickstart_overlay_config()
     return {
         "collections": _count_collection_overrides_for_library(library_with_plex, libraries_data, collection_config),
         "overlays": _count_overlay_overrides_for_library(library, libraries_data, overlay_config),
+    }
+
+
+def _lazy_section_active_states(library, libraries_data, collection_config=None, overlay_config=None):
+    collection_config = collection_config if isinstance(collection_config, list) else helpers.load_quickstart_config("quickstart_collections.json")
+    overlay_config = overlay_config if isinstance(overlay_config, list) else helpers.load_quickstart_overlay_config()
+    return {
+        "collections": _has_active_collection_selection_for_library(library, libraries_data, collection_config),
+        "overlays": _has_active_overlay_selection_for_library(library, libraries_data, overlay_config),
     }
 
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -8139,6 +8139,25 @@ function formatTemplateOverrideCount (count) {
   return count === 1 ? '1 override' : `${count} overrides`
 }
 
+function isTrueDatasetValue (value) {
+  return String(value || '').trim().toLowerCase() === 'true'
+}
+
+function isTemplateGroupActiveForSignal (group) {
+  if (!group) return false
+  const toggle = group.querySelector('input[type="checkbox"][data-template-group], input[type="radio"][data-template-group], .overlay-toggle')
+  if (!toggle) return false
+  return toggle.checked
+}
+
+function getLazyElementSignalCount (element) {
+  return Number(element?.dataset?.lazyOverrideCount || '0') || 0
+}
+
+function getLazyElementHasSignal (element) {
+  return getLazyElementSignalCount(element) > 0 || isTrueDatasetValue(element?.dataset?.lazyActive)
+}
+
 function setOverrideSummaryBadge (badge, count) {
   if (!badge) return
   badge.textContent = count > 0 ? formatTemplateOverrideCount(count) : ''
@@ -8233,9 +8252,10 @@ function updateAncestorOverrideSummaries (element) {
     const accordionItem = collapse.closest('.accordion-item')
     const header = accordionItem?.querySelector('.accordion-header')
     const count = getAccordionCollapseOverrideCount(collapse)
+    const hasSignal = getAccordionCollapseHasActiveSignal(collapse)
 
-    accordionItem?.classList.toggle('template-variable-section-has-overrides', count > 0)
-    header?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    accordionItem?.classList.toggle('template-variable-section-has-overrides', hasSignal)
+    header?.classList.toggle('template-variable-section-has-overrides', hasSignal)
     setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
 
     collapse = accordionItem?.parentElement?.closest('.accordion-collapse')
@@ -8246,22 +8266,24 @@ function updateAncestorOverrideSummaries (element) {
 function updateLazySectionOverrideSummaries (scope) {
   const root = scope || document
   root.querySelectorAll?.('[data-library-lazy-section][data-lazy-override-count]').forEach(placeholder => {
-    const count = Number(placeholder.dataset.lazyOverrideCount || '0') || 0
+    const count = getLazyElementSignalCount(placeholder)
+    const hasSignal = getLazyElementHasSignal(placeholder)
     const collapse = placeholder.closest('.accordion-collapse')
     const item = collapse?.closest('.accordion-item')
     const header = item?.querySelector(':scope > .accordion-header') || item?.querySelector('.accordion-header')
 
-    item?.classList.toggle('template-variable-section-has-overrides', count > 0)
-    header?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    item?.classList.toggle('template-variable-section-has-overrides', hasSignal)
+    header?.classList.toggle('template-variable-section-has-overrides', hasSignal)
     setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
   })
   root.querySelectorAll?.('[data-collection-group-lazy-collapse][data-lazy-override-count]').forEach(collapse => {
-    const count = Number(collapse.dataset.lazyOverrideCount || '0') || 0
+    const count = getLazyElementSignalCount(collapse)
+    const hasSignal = getLazyElementHasSignal(collapse)
     const item = collapse.closest('.accordion-item')
     const header = item?.querySelector(':scope > .accordion-header') || item?.querySelector('.accordion-header')
 
-    item?.classList.toggle('template-variable-section-has-overrides', count > 0)
-    header?.classList.toggle('template-variable-section-has-overrides', count > 0)
+    item?.classList.toggle('template-variable-section-has-overrides', hasSignal)
+    header?.classList.toggle('template-variable-section-has-overrides', hasSignal)
     setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
   })
 }
@@ -8270,6 +8292,7 @@ function clearLazyCollectionShellOverrideSummaries (scope) {
   const root = scope || document
   root.querySelectorAll?.('[data-collection-group-lazy-collapse][data-lazy-override-count]').forEach(collapse => {
     collapse.dataset.lazyOverrideCount = '0'
+    collapse.dataset.lazyActive = 'false'
     const item = collapse.closest('.accordion-item')
     const header = item?.querySelector(':scope > .accordion-header') || item?.querySelector('.accordion-header')
 
@@ -8307,6 +8330,17 @@ function getAccordionCollapseOverrideCount (collapse) {
     if (!isOverlayTemplateGroupActiveForCounts(group)) return total
     return total + (Number(group.dataset.overrideCount || '0') || 0)
   }, 0)
+}
+
+function getAccordionCollapseHasActiveSignal (collapse) {
+  if (!collapse) return false
+  if (getAccordionCollapseOverrideCount(collapse) > 0) return true
+  const lazyPlaceholder = collapse.querySelector?.('[data-library-lazy-section][data-lazy-active="true"]')
+  if (lazyPlaceholder) return true
+  if (collapse.dataset?.collectionGroupLazyCollapse === 'true' && isTrueDatasetValue(collapse.dataset.lazyActive)) return true
+  return Array.from(collapse.querySelectorAll?.('.template-toggle-group') || []).some(group => {
+    return isOverlayTemplateGroupActiveForCounts(group) && isTemplateGroupActiveForSignal(group)
+  })
 }
 
 function getAccordionItemOverrideCount (item) {
@@ -8347,7 +8381,7 @@ function updateTemplateGroupOverrideSummary (section) {
     : 0
 
   group.dataset.overrideCount = String(count)
-  group.classList.toggle('template-variable-section-has-overrides', count > 0)
+  group.classList.toggle('template-variable-section-has-overrides', count > 0 || isTemplateGroupActiveForSignal(group))
   setOverrideSummaryBadge(getOrCreateTemplateOverrideBadge(group), count)
   updateAncestorOverrideSummaries(group)
 }

--- a/templates/partials/_movie_collections.html
+++ b/templates/partials/_movie_collections.html
@@ -17,10 +17,12 @@
 {% for group in collection_config %}
 {% set accordion_safe = group.accordion | replace(' ', '') %}
 {% set group_count = collection_group_override_counts.get(loop.index0, 0) if collection_group_override_counts is defined else 0 %}
+{% set group_active = collection_group_active_states.get(loop.index0, false) if collection_group_active_states is defined else false %}
+{% set group_signal = group_count > 0 or group_active %}
 <div class="accordion mt-3" id="{{ library.id }}-{{ accordion_safe }}Accordion"
   data-collection-group-shell="true" data-library-id="{{ library.id }}" data-collection-group-index="{{ loop.index0 }}">
-  <div class="accordion-item{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
-    <h2 class="accordion-header overlay-accordion-header d-flex align-items-center{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
+  <div class="accordion-item{% if group_signal %} template-variable-section-has-overrides{% endif %}">
+    <h2 class="accordion-header overlay-accordion-header d-flex align-items-center{% if group_signal %} template-variable-section-has-overrides{% endif %}">
       <button class="accordion-button collapsed flex-grow-1" type="button" data-bs-toggle="collapse"
         data-bs-target="#{{ library.id }}-{{ accordion_safe }}" aria-expanded="false"
         aria-controls="{{ library.id }}-{{ accordion_safe }}">
@@ -36,7 +38,8 @@
       data-collection-group-lazy-collapse="true"
       data-library-id="{{ library.id }}"
       data-collection-group-index="{{ loop.index0 }}"
-      data-lazy-override-count="{{ group_count }}">
+      data-lazy-override-count="{{ group_count }}"
+      data-lazy-active="{{ 'true' if group_active else 'false' }}">
       <div class="accordion-body">
         <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
           data-collection-group-lazy-placeholder="true">

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -5,11 +5,18 @@
         {% include "partials/_library_core_separator.html" %}
 
         <!-- Movie Collections -->
-        <div class="accordion-item">
-            <h2 class="accordion-header">
+        {% set collections_lazy_count = lazy_section_override_counts.get('collections', 0) if lazy_section_override_counts is defined else 0 %}
+        {% set collections_lazy_active = lazy_section_active_states.get('collections', false) if lazy_section_active_states is defined else false %}
+        {% set collections_lazy_signal = collections_lazy_count > 0 or collections_lazy_active %}
+        <div class="accordion-item{% if collections_lazy_signal %} template-variable-section-has-overrides{% endif %}">
+            <h2 class="accordion-header{% if collections_lazy_signal %} template-variable-section-has-overrides{% endif %}">
                 <button class="accordion-button" type="button" data-bs-toggle="collapse"
                     data-bs-target="#{{ library.id }}-collections">
                     Collections
+                    <span class="small accordion-override-summary ms-3{% if collections_lazy_count <= 0 %} d-none{% endif %}"
+                        data-accordion-override-summary>
+                        {{ collections_lazy_count }} {{ 'override' if collections_lazy_count == 1 else 'overrides' }}
+                    </span>
                 </button>
             </h2>
             <div id="{{ library.id }}-collections" class="accordion-collapse collapse">
@@ -17,7 +24,8 @@
                     {% if defer_heavy_sections %}
                     <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
                         data-library-lazy-section="collections" data-library-id="{{ library.id }}"
-                        data-lazy-override-count="{{ lazy_section_override_counts.collections | default(0) }}">
+                        data-lazy-override-count="{{ collections_lazy_count }}"
+                        data-lazy-active="{{ 'true' if collections_lazy_active else 'false' }}">
                         <div class="spinner-border spinner-border-sm text-info d-none" role="status"
                             aria-hidden="true"></div>
                         <span>Open this section to load collection settings.</span>
@@ -30,11 +38,18 @@
         </div>
 
         <!-- Movie Overlays -->
-        <div class="accordion-item">
-            <h2 class="accordion-header">
+        {% set overlays_lazy_count = lazy_section_override_counts.get('overlays', 0) if lazy_section_override_counts is defined else 0 %}
+        {% set overlays_lazy_active = lazy_section_active_states.get('overlays', false) if lazy_section_active_states is defined else false %}
+        {% set overlays_lazy_signal = overlays_lazy_count > 0 or overlays_lazy_active %}
+        <div class="accordion-item{% if overlays_lazy_signal %} template-variable-section-has-overrides{% endif %}">
+            <h2 class="accordion-header{% if overlays_lazy_signal %} template-variable-section-has-overrides{% endif %}">
                 <button class="accordion-button" type="button" data-bs-toggle="collapse"
                     data-bs-target="#{{ library.id }}-overlays">
                     Overlays
+                    <span class="small accordion-override-summary ms-3{% if overlays_lazy_count <= 0 %} d-none{% endif %}"
+                        data-accordion-override-summary>
+                        {{ overlays_lazy_count }} {{ 'override' if overlays_lazy_count == 1 else 'overrides' }}
+                    </span>
                 </button>
             </h2>
             <div id="{{ library.id }}-overlays" class="accordion-collapse collapse">
@@ -42,7 +57,8 @@
                     {% if defer_heavy_sections %}
                     <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
                         data-library-lazy-section="overlays" data-library-id="{{ library.id }}"
-                        data-lazy-override-count="{{ lazy_section_override_counts.overlays | default(0) }}">
+                        data-lazy-override-count="{{ overlays_lazy_count }}"
+                        data-lazy-active="{{ 'true' if overlays_lazy_active else 'false' }}">
                         <div class="spinner-border spinner-border-sm text-info d-none" role="status"
                             aria-hidden="true"></div>
                         <span>Open this section to load overlay settings.</span>

--- a/templates/partials/_show_collections.html
+++ b/templates/partials/_show_collections.html
@@ -17,10 +17,12 @@
 {% for group in collection_config %}
 {% set accordion_safe = group.accordion | replace(' ', '') %}
 {% set group_count = collection_group_override_counts.get(loop.index0, 0) if collection_group_override_counts is defined else 0 %}
+{% set group_active = collection_group_active_states.get(loop.index0, false) if collection_group_active_states is defined else false %}
+{% set group_signal = group_count > 0 or group_active %}
 <div class="accordion mt-3" id="{{ library.id }}-{{ accordion_safe }}Accordion"
   data-collection-group-shell="true" data-library-id="{{ library.id }}" data-collection-group-index="{{ loop.index0 }}">
-  <div class="accordion-item{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
-    <h2 class="accordion-header overlay-accordion-header d-flex align-items-center{% if group_count > 0 %} template-variable-section-has-overrides{% endif %}">
+  <div class="accordion-item{% if group_signal %} template-variable-section-has-overrides{% endif %}">
+    <h2 class="accordion-header overlay-accordion-header d-flex align-items-center{% if group_signal %} template-variable-section-has-overrides{% endif %}">
       <button class="accordion-button collapsed flex-grow-1" type="button" data-bs-toggle="collapse"
         data-bs-target="#{{ library.id }}-{{ accordion_safe }}" aria-expanded="false"
         aria-controls="{{ library.id }}-{{ accordion_safe }}">
@@ -36,7 +38,8 @@
       data-collection-group-lazy-collapse="true"
       data-library-id="{{ library.id }}"
       data-collection-group-index="{{ loop.index0 }}"
-      data-lazy-override-count="{{ group_count }}">
+      data-lazy-override-count="{{ group_count }}"
+      data-lazy-active="{{ 'true' if group_active else 'false' }}">
       <div class="accordion-body">
         <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
           data-collection-group-lazy-placeholder="true">

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -5,11 +5,18 @@
         {% include "partials/_library_core_separator.html" %}
 
         <!-- Show Collections -->
-        <div class="accordion-item">
-            <h2 class="accordion-header">
+        {% set collections_lazy_count = lazy_section_override_counts.get('collections', 0) if lazy_section_override_counts is defined else 0 %}
+        {% set collections_lazy_active = lazy_section_active_states.get('collections', false) if lazy_section_active_states is defined else false %}
+        {% set collections_lazy_signal = collections_lazy_count > 0 or collections_lazy_active %}
+        <div class="accordion-item{% if collections_lazy_signal %} template-variable-section-has-overrides{% endif %}">
+            <h2 class="accordion-header{% if collections_lazy_signal %} template-variable-section-has-overrides{% endif %}">
                 <button class="accordion-button" type="button" data-bs-toggle="collapse"
                     data-bs-target="#{{ library.id }}-collections">
                     Collections
+                    <span class="small accordion-override-summary ms-3{% if collections_lazy_count <= 0 %} d-none{% endif %}"
+                        data-accordion-override-summary>
+                        {{ collections_lazy_count }} {{ 'override' if collections_lazy_count == 1 else 'overrides' }}
+                    </span>
                 </button>
             </h2>
             <div id="{{ library.id }}-collections" class="accordion-collapse collapse">
@@ -17,7 +24,8 @@
                     {% if defer_heavy_sections %}
                     <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
                         data-library-lazy-section="collections" data-library-id="{{ library.id }}"
-                        data-lazy-override-count="{{ lazy_section_override_counts.collections | default(0) }}">
+                        data-lazy-override-count="{{ collections_lazy_count }}"
+                        data-lazy-active="{{ 'true' if collections_lazy_active else 'false' }}">
                         <div class="spinner-border spinner-border-sm text-info d-none" role="status"
                             aria-hidden="true"></div>
                         <span>Open this section to load collection settings.</span>
@@ -30,11 +38,18 @@
         </div>
 
         <!-- Show Overlays -->
-        <div class="accordion-item">
-            <h2 class="accordion-header">
+        {% set overlays_lazy_count = lazy_section_override_counts.get('overlays', 0) if lazy_section_override_counts is defined else 0 %}
+        {% set overlays_lazy_active = lazy_section_active_states.get('overlays', false) if lazy_section_active_states is defined else false %}
+        {% set overlays_lazy_signal = overlays_lazy_count > 0 or overlays_lazy_active %}
+        <div class="accordion-item{% if overlays_lazy_signal %} template-variable-section-has-overrides{% endif %}">
+            <h2 class="accordion-header{% if overlays_lazy_signal %} template-variable-section-has-overrides{% endif %}">
                 <button class="accordion-button" type="button" data-bs-toggle="collapse"
                     data-bs-target="#{{ library.id }}-overlays">
                     Overlays
+                    <span class="small accordion-override-summary ms-3{% if overlays_lazy_count <= 0 %} d-none{% endif %}"
+                        data-accordion-override-summary>
+                        {{ overlays_lazy_count }} {{ 'override' if overlays_lazy_count == 1 else 'overrides' }}
+                    </span>
                 </button>
             </h2>
             <div id="{{ library.id }}-overlays" class="accordion-collapse collapse">
@@ -42,7 +57,8 @@
                     {% if defer_heavy_sections %}
                     <div class="library-section-lazy-placeholder text-muted d-flex align-items-center gap-2"
                         data-library-lazy-section="overlays" data-library-id="{{ library.id }}"
-                        data-lazy-override-count="{{ lazy_section_override_counts.overlays | default(0) }}">
+                        data-lazy-override-count="{{ overlays_lazy_count }}"
+                        data-lazy-active="{{ 'true' if overlays_lazy_active else 'false' }}">
                         <div class="spinner-border spinner-border-sm text-info d-none" role="status"
                             aria-hidden="true"></div>
                         <span>Open this section to load overlay settings.</span>


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Fixes Libraries page green-bar consistency for lazy-loaded accordions.

Green bars now indicate that a collapsed section has active YAML-affecting selections or real overrides, while numeric badges remain strictly override counts. This prevents selected collection/overlay defaults with no template-variable changes from looking inactive before the section is expanded.

## Changes

- Added backend active-state metadata for lazy `Collections` and `Overlays` sections.
- Added active-state metadata for lazy collection group shells.
- Updated movie/show Libraries templates to render green bars before lazy content loads.
- Updated Libraries JS so refresh/reset logic keeps green bars based on active selections without inflating override counts.

## Testing

- `npx eslint static\local-js\025-libraries.js`
- `venv\Scripts\python.exe -m pytest tests\test_config_and_library_routes.py`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
