### PR TITLE
fix for selarators with dropdowns

### DIFF
--- a/modules/helpers/_plex.py
+++ b/modules/helpers/_plex.py
@@ -36,22 +36,46 @@ def get_top_imdb_items(library_id, media_type, placeholder_id=None):
         raise ValueError(f"Library ID {library_id} not found.")
 
     ts_log(f"Fetching items from '{section.title}' sorted by audienceRating", level="DEBUG")
-    items = section.search(sort="audienceRating:desc", maxresults=25)
+    items = section.search(sort="audienceRating:desc", maxresults=50)
 
+    source_counts = {"imdb_id": 0}
+    source_counts["tvdb_show" if str(media_type).lower() == "show" else "tmdb_movie"] = 0
     imdb_items = []
     for item in items:
         imdb_id = None
-        for guid in item.guids:
-            if guid.id.startswith("imdb://"):
-                imdb_id = guid.id.replace("imdb://", "")
-                break
-        if imdb_id:
-            imdb_items.append({"id": imdb_id, "title": item.title})
+        tmdb_id = None
+        tvdb_id = None
+        for guid in getattr(item, "guids", []) or []:
+            guid_id = str(getattr(guid, "id", "") or "").strip()
+            if guid_id.startswith("imdb://"):
+                imdb_id = guid_id.replace("imdb://", "", 1)
+            elif guid_id.startswith("tmdb://"):
+                tmdb_id = guid_id.replace("tmdb://", "", 1)
+            elif guid_id.startswith("tvdb://"):
+                tvdb_id = guid_id.replace("tvdb://", "", 1)
+        if imdb_id or tmdb_id or tvdb_id:
+            imdb_items.append(
+                {
+                    "id": imdb_id or tmdb_id or tvdb_id,
+                    "imdb_id": imdb_id or "",
+                    "tmdb_movie": tmdb_id or "",
+                    "tvdb_show": tvdb_id or "",
+                    "title": item.title,
+                }
+            )
+            if imdb_id:
+                source_counts["imdb_id"] += 1
+            if "tmdb_movie" in source_counts and tmdb_id:
+                source_counts["tmdb_movie"] += 1
+            if "tvdb_show" in source_counts and tvdb_id:
+                source_counts["tvdb_show"] += 1
+        if all(count >= 10 for count in source_counts.values()):
+            break
 
     # Best-effort placeholder recovery; disabled fallback to avoid missing module issues
     saved_item = None
 
-    ts_log(f"Returning {len(imdb_items)} IMDb items", level="DEBUG")
+    ts_log(f"Returning {len(imdb_items)} Plex top items", level="DEBUG")
     return imdb_items, saved_item
 
 

--- a/static/local-js/modules/separatorPreview.js
+++ b/static/local-js/modules/separatorPreview.js
@@ -103,6 +103,139 @@ function getSeparatorPlaceholderWrapper (libraryId) {
   return document.querySelector(`[data-separator-placeholder-wrapper="true"][data-library-prefix="${libraryId}"]`)
 }
 
+const separatorPlaceholderPicklistCache = new Map()
+
+function placeholderValueKey (source) {
+  if (source === 'tmdb_movie') return 'tmdb_movie'
+  if (source === 'tvdb_show') return 'tvdb_show'
+  return 'imdb_id'
+}
+
+function placeholderValueLabel (source) {
+  if (source === 'tmdb_movie') return 'TMDb'
+  if (source === 'tvdb_show') return 'TVDb'
+  return 'IMDb'
+}
+
+function itemValueForSource (item, source) {
+  const value = item?.[placeholderValueKey(source)]
+  if (value) return String(value).trim()
+  if (source === 'imdb' && String(item?.id || '').trim().startsWith('tt')) {
+    return String(item.id).trim()
+  }
+  return ''
+}
+
+function optionTextForItem (item, source, value) {
+  const title = String(item?.title || 'Untitled').trim()
+  const label = placeholderValueLabel(source)
+  return `${title} — ${label} ${value}`
+}
+
+function writeSeparatorLookupLabel (select) {
+  if (!select?.id) return
+  const hidden = document.getElementById(`${select.id}__lookup_labels`)
+  if (!hidden) return
+  const value = String(select.value || '').trim()
+  const selectedOption = select.selectedOptions?.[0]
+  const label = String(selectedOption?.dataset?.lookupLabel || '').trim()
+  hidden.value = value && label ? JSON.stringify({ [value]: label }) : '{}'
+  hidden.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+function setPlaceholderPicklistOptions (select, items) {
+  if (!select) return
+  const source = String(select.dataset.separatorPlaceholderInput || '').trim()
+  const savedValue = String(select.dataset.separatorPlaceholderValue || select.value || '').trim()
+  const options = []
+  const seen = new Set()
+
+  items.forEach(item => {
+    const value = itemValueForSource(item, source)
+    if (!value || seen.has(value)) return
+    seen.add(value)
+    options.push({
+      value,
+      text: optionTextForItem(item, source, value),
+      label: String(item?.title || '').trim()
+    })
+  })
+
+  select.replaceChildren()
+  const blank = document.createElement('option')
+  blank.value = ''
+  blank.textContent = options.length ? '-- Choose a top audience-rated item --' : `No top items with ${placeholderValueLabel(source)} IDs found`
+  select.appendChild(blank)
+
+  if (savedValue && !seen.has(savedValue)) {
+    const saved = document.createElement('option')
+    saved.value = savedValue
+    saved.textContent = `Saved ${placeholderValueLabel(source)} ID: ${savedValue}`
+    saved.dataset.lookupLabel = ''
+    select.appendChild(saved)
+  }
+
+  options.slice(0, 10).forEach(item => {
+    const option = document.createElement('option')
+    option.value = item.value
+    option.textContent = item.text
+    option.dataset.lookupLabel = item.label
+    select.appendChild(option)
+  })
+
+  select.value = savedValue || ''
+  if (select.value !== savedValue) {
+    select.value = ''
+  }
+  writeSeparatorLookupLabel(select)
+}
+
+function setPlaceholderPicklistLoading (wrapper, loading) {
+  wrapper.querySelectorAll('.separator-placeholder-picklist').forEach(select => {
+    if (loading) {
+      const currentValue = String(select.value || select.dataset.separatorPlaceholderValue || '').trim()
+      select.replaceChildren()
+      const option = document.createElement('option')
+      option.value = currentValue
+      option.textContent = 'Loading top audience-rated items...'
+      select.appendChild(option)
+      select.value = currentValue
+    }
+  })
+}
+
+function loadSeparatorPlaceholderPicklists (wrapper) {
+  if (!wrapper || wrapper.classList.contains('visually-hidden')) return
+  const libraryName = String(wrapper.dataset.libraryId || '').trim()
+  const libraryType = String(wrapper.dataset.libraryType || 'movie').trim().toLowerCase()
+  if (!libraryName) return
+
+  const cacheKey = `${libraryType}:${libraryName}`
+  let request = separatorPlaceholderPicklistCache.get(cacheKey)
+  if (!request) {
+    setPlaceholderPicklistLoading(wrapper, true)
+    request = fetch(`/get_top_imdb_items/${encodeURIComponent(libraryName)}?type=${encodeURIComponent(libraryType)}`, {
+      credentials: 'same-origin'
+    })
+      .then(response => {
+        if (!response.ok) throw new Error(`Top item lookup failed (${response.status})`)
+        return response.json()
+      })
+      .then(data => Array.isArray(data?.items) ? data.items : [])
+      .catch(error => {
+        console.error('[Separator Placeholder] Failed to load top items:', error)
+        return []
+      })
+    separatorPlaceholderPicklistCache.set(cacheKey, request)
+  }
+
+  request.then(items => {
+    wrapper.querySelectorAll('.separator-placeholder-picklist').forEach(select => {
+      setPlaceholderPicklistOptions(select, items)
+    })
+  })
+}
+
 /**
  * Reconcile a placeholder wrapper's visible fields against the
  * selected source. Which sources are allowed depends on library type
@@ -143,8 +276,11 @@ export function syncSeparatorPlaceholderFields (wrapper, options = {}) {
     if (fieldGroup) fieldGroup.classList.toggle('d-none', !isActive)
     if (!isActive) {
       input.value = ''
+      input.dataset.separatorPlaceholderValue = ''
+      writeSeparatorLookupLabel(input)
     }
   })
+  if (show) loadSeparatorPlaceholderPicklists(wrapper)
 }
 
 /**
@@ -288,4 +424,14 @@ export function initializeOverlays (libraryId, isMovie) {
     })
     sourceSelect.dataset.listenerAdded = 'true'
   }
+
+  placeholderWrapper?.querySelectorAll('.separator-placeholder-picklist').forEach(select => {
+    if (select.dataset.listenerAdded === 'true') return
+    select.addEventListener('change', () => {
+      select.dataset.separatorPlaceholderValue = String(select.value || '').trim()
+      writeSeparatorLookupLabel(select)
+      updateAccordionHighlights()
+    })
+    select.dataset.listenerAdded = 'true'
+  })
 }

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -64,7 +64,7 @@ export const ValidationHandler = {
     } else {
       console.log('[DEBUG] Validation Failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
-        'Please review your selections: ensure you have picked at least one library, selected an item inside each chosen library, and if using Separators, selected a valid <strong>Placeholder IMDb ID</strong>. Items needing attention are highlighted in red below.',
+        'Please review your selections: ensure you have picked at least one library, selected an item inside each chosen library, and if using Separators, selected a valid <strong>Placeholder ID</strong>. Items needing attention are highlighted in red below.',
         'danger',
         { html: true }
       )

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -313,6 +313,28 @@ prefix if yml_location == "top_level" else
 {% set has_plex_pass = true %}
 {% endif %}
 {% set disable_for_plex_pass = requires_plex_pass and not has_plex_pass %}
+{% if prefix == "use_separator" %}
+{% set library_media_type = 'movie' if library.id.startswith('mov-') else 'show' %}
+{% set source_select_id = library.id ~ "-attribute_template_variables_placeholder_source" %}
+{% set imdb_name = library.id ~ "-attribute_template_variables[placeholder_imdb_id]" %}
+{% set imdb_id = imdb_name.replace("[", "_").replace("]", "") %}
+{% set imdb_data = data.libraries.get(imdb_name, "") %}
+{% set tmdb_name = library.id ~ "-attribute_template_variables[placeholder_tmdb_movie]" %}
+{% set tmdb_id = tmdb_name.replace("[", "_").replace("]", "") %}
+{% set tmdb_data = data.libraries.get(tmdb_name, "") %}
+{% set tvdb_name = library.id ~ "-attribute_template_variables[placeholder_tvdb_show]" %}
+{% set tvdb_id = tvdb_name.replace("[", "_").replace("]", "") %}
+{% set tvdb_data = data.libraries.get(tvdb_name, "") %}
+{% if library_media_type == 'movie' and tmdb_data %}
+{% set active_source = 'tmdb_movie' %}
+{% elif library_media_type == 'show' and tvdb_data %}
+{% set active_source = 'tvdb_show' %}
+{% elif imdb_data %}
+{% set active_source = 'imdb' %}
+{% else %}
+{% set active_source = 'imdb' %}
+{% endif %}
+{% endif %}
 <div class="{{ container_class }}">
     <div class="row">
         <div class="col-md-6 mb-2">
@@ -337,9 +359,114 @@ prefix if yml_location == "top_level" else
             <input type="hidden" name="{{ field_name }}" value="{{ selected }}">
             <div class="form-text text-warning">Requires Plex Pass. Validate Plex first if this should be available.</div>
             {% endif %}
+            {% if prefix == "use_separator" %}
+            <div class="separator-placeholder-wrapper visually-hidden mt-2"
+                data-separator-placeholder-wrapper="true"
+                data-library-id="{{ library.name }}"
+                data-library-prefix="{{ library.id }}"
+                data-library-type="{{ library_media_type }}">
+                <div class="input-group mb-2">
+                    <span class="input-group-text" id="{{ source_select_id }}_text">
+                        <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                            rel="noopener noreferrer">Placeholder Source</a>
+                        <span class="text-{{ tooltip_variant }} ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                            title="Choose exactly one placeholder source for separators in this library.">
+                            <i
+                                class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
+                        </span>
+                    </span>
+                    <select class="form-select separator-placeholder-source" id="{{ source_select_id }}"
+                        aria-describedby="{{ source_select_id }}_text"
+                        data-default="imdb"
+                        data-library-type="{{ library_media_type }}"
+                        data-active-source="{{ active_source }}">
+                        <option value="imdb" {% if active_source == 'imdb' %}selected{% endif %}>IMDb ID</option>
+                        {% if library_media_type == 'movie' %}
+                        <option value="tmdb_movie" {% if active_source == 'tmdb_movie' %}selected{% endif %}>TMDb Movie ID</option>
+                        {% else %}
+                        <option value="tvdb_show" {% if active_source == 'tvdb_show' %}selected{% endif %}>TVDb Show ID</option>
+                        {% endif %}
+                    </select>
+                </div>
+                <div class="input-group mb-2 separator-placeholder-field" data-placeholder-source="imdb">
+                    <span class="input-group-text" id="{{ imdb_id }}_text">
+                        <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                            rel="noopener noreferrer">Placeholder IMDb ID</a>
+                    </span>
+                    <select class="form-select separator-placeholder-picklist" id="{{ imdb_id }}" name="{{ imdb_name }}"
+                        data-default=""
+                        data-separator-placeholder-input="imdb"
+                        data-separator-placeholder-value="{{ imdb_data | default('', true) }}"
+                        data-template-scalar-lookup="true"
+                        data-validation-preset="imdb_id_tmdb"
+                        data-library-name="{{ library.name }}"
+                        data-media-type="{{ library_media_type }}"
+                        aria-describedby="{{ imdb_id }}_text"
+                        title="Choose one of the top audience-rated Plex items with an IMDb ID.">
+                        <option value="">Loading top audience-rated items...</option>
+                        {% if imdb_data %}
+                        <option value="{{ imdb_data }}" selected>Saved IMDb ID: {{ imdb_data }}</option>
+                        {% endif %}
+                    </select>
+                </div>
+                <input type="hidden" id="{{ imdb_id }}__lookup_labels" name="{{ imdb_name }}__lookup_labels"
+                    value="{{ data['libraries'].get(imdb_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
+                    data-template-metadata="lookup-labels" data-skip-override-count="true">
+                {% if library_media_type == 'movie' %}
+                <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tmdb_movie">
+                    <span class="input-group-text" id="{{ tmdb_id }}_text">
+                        <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                            rel="noopener noreferrer">Placeholder TMDb Movie ID</a>
+                    </span>
+                    <select class="form-select separator-placeholder-picklist" id="{{ tmdb_id }}" name="{{ tmdb_name }}"
+                        data-default=""
+                        data-separator-placeholder-input="tmdb_movie"
+                        data-separator-placeholder-value="{{ tmdb_data | default('', true) }}"
+                        data-template-scalar-lookup="true"
+                        data-validation-preset="numeric_id"
+                        data-library-name="{{ library.name }}"
+                        data-media-type="{{ library_media_type }}"
+                        aria-describedby="{{ tmdb_id }}_text"
+                        title="Choose one of the top audience-rated Plex movies with a TMDb ID.">
+                        <option value="">Loading top audience-rated items...</option>
+                        {% if tmdb_data %}
+                        <option value="{{ tmdb_data }}" selected>Saved TMDb Movie ID: {{ tmdb_data }}</option>
+                        {% endif %}
+                    </select>
+                </div>
+                <input type="hidden" id="{{ tmdb_id }}__lookup_labels" name="{{ tmdb_name }}__lookup_labels"
+                    value="{{ data['libraries'].get(tmdb_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
+                    data-template-metadata="lookup-labels" data-skip-override-count="true">
+                {% else %}
+                <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tvdb_show">
+                    <span class="input-group-text" id="{{ tvdb_id }}_text">
+                        <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                            rel="noopener noreferrer">Placeholder TVDb Show ID</a>
+                    </span>
+                    <select class="form-select separator-placeholder-picklist" id="{{ tvdb_id }}" name="{{ tvdb_name }}"
+                        data-default=""
+                        data-separator-placeholder-input="tvdb_show"
+                        data-separator-placeholder-value="{{ tvdb_data | default('', true) }}"
+                        aria-describedby="{{ tvdb_id }}_text"
+                        title="Choose one of the top audience-rated Plex shows with a TVDb ID.">
+                        <option value="">Loading top audience-rated items...</option>
+                        {% if tvdb_data %}
+                        <option value="{{ tvdb_data }}" selected>Saved TVDb Show ID: {{ tvdb_data }}</option>
+                        {% endif %}
+                    </select>
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+            {% if preview_image and prefix == "use_separator" %}
+            <div id="{{ field_id }}-separatorPreviewContainer" class="mt-3 d-flex justify-content-start">
+                <img id="{{ field_id }}-separatorPreviewImage" src="" alt="{{ field_id }} Separator Preview"
+                    class="img-fluid" style="max-width: 320px; width: 100%; height: auto; border: 1px solid #ccc;">
+            </div>
+            {% endif %}
         </div>
 
-        {% if preview_image and prefix != "placeholder_imdb_id" %}
+        {% if preview_image and prefix not in ["placeholder_imdb_id", "use_separator"] %}
         <div class="col-md-6 d-flex align-items-center justify-content-center">
             <div id="{{ field_id }}-separatorPreviewContainer">
                 <img id="{{ field_id }}-separatorPreviewImage" src="" alt="{{ field_id }} Separator Preview"
@@ -349,128 +476,6 @@ prefix if yml_location == "top_level" else
         {% endif %}
     </div>
 </div>
-
-{# Separator placeholder controls (conditionally shown with JS) #}
-{% if prefix == "use_separator" %}
-{% set library_media_type = 'movie' if library.id.startswith('mov-') else 'show' %}
-{% set source_select_id = library.id ~ "-attribute_template_variables_placeholder_source" %}
-{% set imdb_name = library.id ~ "-attribute_template_variables[placeholder_imdb_id]" %}
-{% set imdb_id = imdb_name.replace("[", "_").replace("]", "") %}
-{% set imdb_data = data.libraries.get(imdb_name, "") %}
-{% set tmdb_name = library.id ~ "-attribute_template_variables[placeholder_tmdb_movie]" %}
-{% set tmdb_id = tmdb_name.replace("[", "_").replace("]", "") %}
-{% set tmdb_data = data.libraries.get(tmdb_name, "") %}
-{% set tvdb_name = library.id ~ "-attribute_template_variables[placeholder_tvdb_show]" %}
-{% set tvdb_id = tvdb_name.replace("[", "_").replace("]", "") %}
-{% set tvdb_data = data.libraries.get(tvdb_name, "") %}
-{% if library_media_type == 'movie' and tmdb_data %}
-{% set active_source = 'tmdb_movie' %}
-{% elif library_media_type == 'show' and tvdb_data %}
-{% set active_source = 'tvdb_show' %}
-{% elif imdb_data %}
-{% set active_source = 'imdb' %}
-{% else %}
-{% set active_source = 'imdb' %}
-{% endif %}
-<div class="row mt-2 separator-placeholder-wrapper visually-hidden"
-    data-separator-placeholder-wrapper="true"
-    data-library-id="{{ library.name }}"
-    data-library-prefix="{{ library.id }}"
-    data-library-type="{{ library_media_type }}">
-    <div class="col-12 col-xl-5">
-        <div class="input-group mb-2">
-            <span class="input-group-text" id="{{ source_select_id }}_text">
-                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
-                    rel="noopener noreferrer">Placeholder Source</a>
-                <span class="text-{{ tooltip_variant }} ms-3" data-bs-toggle="tooltip" data-bs-html="true"
-                    title="Choose exactly one placeholder source for separators in this library.">
-                    <i
-                        class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
-                </span>
-            </span>
-            <select class="form-select separator-placeholder-source" id="{{ source_select_id }}"
-                aria-describedby="{{ source_select_id }}_text"
-                data-default="imdb"
-                data-library-type="{{ library_media_type }}"
-                data-active-source="{{ active_source }}">
-                <option value="imdb" {% if active_source == 'imdb' %}selected{% endif %}>IMDb ID</option>
-                {% if library_media_type == 'movie' %}
-                <option value="tmdb_movie" {% if active_source == 'tmdb_movie' %}selected{% endif %}>TMDb Movie ID</option>
-                {% else %}
-                <option value="tvdb_show" {% if active_source == 'tvdb_show' %}selected{% endif %}>TVDb Show ID</option>
-                {% endif %}
-            </select>
-        </div>
-    </div>
-    <div class="col-12 col-xl-7">
-        <div class="input-group mb-2 separator-placeholder-field" data-placeholder-source="imdb">
-            <span class="input-group-text" id="{{ imdb_id }}_text">
-                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
-                    rel="noopener noreferrer">Placeholder IMDb ID</a>
-            </span>
-            <input type="text" class="form-control" id="{{ imdb_id }}" name="{{ imdb_name }}"
-                value="{{ imdb_data | default('', true) }}"
-                data-default=""
-                data-separator-placeholder-input="imdb"
-                data-template-scalar-lookup="true"
-                data-validation-preset="imdb_id_tmdb"
-                data-library-name="{{ library.name }}"
-                data-media-type="{{ library_media_type }}"
-                aria-describedby="{{ imdb_id }}_text"
-                placeholder="tt1234567"
-                pattern="tt\d{7,8}"
-                title="IMDb IDs must look like tt1234567"
-                inputmode="text"
-                autocapitalize="off">
-        </div>
-        <input type="hidden" id="{{ imdb_id }}__lookup_labels" name="{{ imdb_name }}__lookup_labels"
-            value="{{ data['libraries'].get(imdb_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
-            data-template-metadata="lookup-labels" data-skip-override-count="true">
-        {% if library_media_type == 'movie' %}
-        <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tmdb_movie">
-            <span class="input-group-text" id="{{ tmdb_id }}_text">
-                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
-                    rel="noopener noreferrer">Placeholder TMDb Movie ID</a>
-            </span>
-            <input type="text" class="form-control" id="{{ tmdb_id }}" name="{{ tmdb_name }}"
-                value="{{ tmdb_data | default('', true) }}"
-                data-default=""
-                data-separator-placeholder-input="tmdb_movie"
-                data-template-scalar-lookup="true"
-                data-validation-preset="numeric_id"
-                data-library-name="{{ library.name }}"
-                data-media-type="{{ library_media_type }}"
-                aria-describedby="{{ tmdb_id }}_text"
-                placeholder="603"
-                pattern="\d+"
-                title="TMDb movie IDs must be numeric"
-                inputmode="numeric"
-                data-numeric-only="true">
-        </div>
-        <input type="hidden" id="{{ tmdb_id }}__lookup_labels" name="{{ tmdb_name }}__lookup_labels"
-            value="{{ data['libraries'].get(tmdb_name ~ '__lookup_labels', '{}') | default('{}', true) }}"
-            data-template-metadata="lookup-labels" data-skip-override-count="true">
-        {% else %}
-        <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tvdb_show">
-            <span class="input-group-text" id="{{ tvdb_id }}_text">
-                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
-                    rel="noopener noreferrer">Placeholder TVDb Show ID</a>
-            </span>
-            <input type="text" class="form-control" id="{{ tvdb_id }}" name="{{ tvdb_name }}"
-                value="{{ tvdb_data | default('', true) }}"
-                data-default=""
-                data-separator-placeholder-input="tvdb_show"
-                aria-describedby="{{ tvdb_id }}_text"
-                placeholder="121361"
-                pattern="\d+"
-                title="TVDb show IDs must be numeric"
-                inputmode="numeric"
-                data-numeric-only="true">
-        </div>
-        {% endif %}
-    </div>
-</div>
-{% endif %}
 {% endmacro %}
 
 

--- a/tests/js/modules/separatorPreview.test.js
+++ b/tests/js/modules/separatorPreview.test.js
@@ -20,7 +20,16 @@ vi.spyOn(console, 'error').mockImplementation(() => {})
 
 afterEach(() => {
   document.body.innerHTML = ''
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
 })
+
+async function flushAsyncWork () {
+  for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve()
+  }
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
 
 describe('separatorPreview module surface', () => {
   it('exports initializeOverlays as a function', () => {
@@ -143,5 +152,93 @@ describe('separatorPreview: smoke tests', () => {
     select.value = 'tvdb_show' // not allowed for movie library
     separatorPreview.syncSeparatorPlaceholderFields(wrapper, { show: true })
     expect(select.value).toBe('imdb')
+  })
+
+  it('initializeOverlays: populates separator placeholder picklists from Plex top audience-rated items', async () => {
+    const items = Array.from({ length: 12 }, (_, index) => ({
+      title: `Movie ${index + 1}`,
+      imdb_id: `tt123456${index}`,
+      tmdb_movie: `${600 + index}`
+    }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'success', items })
+    }))
+    document.body.innerHTML = `
+      <form id="configForm">
+        <select name="mov-library_1-template_variables[use_separator]">
+          <option value="gold" selected>gold</option>
+        </select>
+        <div data-separator-placeholder-wrapper="true" data-library-id="Movies" data-library-prefix="mov-library_1" data-library-type="movie">
+          <select class="separator-placeholder-source">
+            <option value="imdb" selected>IMDb ID</option>
+            <option value="tmdb_movie">TMDb Movie ID</option>
+          </select>
+          <div class="separator-placeholder-field" data-placeholder-source="imdb">
+            <select id="imdb_picklist" class="separator-placeholder-picklist" data-separator-placeholder-input="imdb" data-separator-placeholder-value=""></select>
+            <input type="hidden" id="imdb_picklist__lookup_labels">
+          </div>
+          <div class="separator-placeholder-field d-none" data-placeholder-source="tmdb_movie">
+            <select id="tmdb_picklist" class="separator-placeholder-picklist" data-separator-placeholder-input="tmdb_movie" data-separator-placeholder-value=""></select>
+            <input type="hidden" id="tmdb_picklist__lookup_labels">
+          </div>
+        </div>
+      </form>
+    `
+
+    separatorPreview.initializeOverlays('mov-library_1', true)
+    await flushAsyncWork()
+
+    expect(fetch).toHaveBeenCalledWith('/get_top_imdb_items/Movies?type=movie', { credentials: 'same-origin' })
+    const imdbOptions = Array.from(document.getElementById('imdb_picklist').querySelectorAll('option')).map(option => option.value).filter(Boolean)
+    expect(imdbOptions).toHaveLength(10)
+    expect(imdbOptions[0]).toBe('tt1234560')
+    expect(imdbOptions[9]).toBe('tt1234569')
+  })
+
+  it('initializeOverlays: rebuilds the active picklist for the selected placeholder source', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        status: 'success',
+        items: [{ title: 'The Matrix', imdb_id: 'tt0133093', tmdb_movie: '603' }]
+      })
+    }))
+    document.body.innerHTML = `
+      <form id="configForm">
+        <select name="mov-library_1-template_variables[use_separator]">
+          <option value="gold" selected>gold</option>
+        </select>
+        <div data-separator-placeholder-wrapper="true" data-library-id="Movies" data-library-prefix="mov-library_1" data-library-type="movie">
+          <select class="separator-placeholder-source">
+            <option value="imdb" selected>IMDb ID</option>
+            <option value="tmdb_movie">TMDb Movie ID</option>
+          </select>
+          <div class="separator-placeholder-field" data-placeholder-source="imdb">
+            <select id="imdb_picklist" class="separator-placeholder-picklist" data-separator-placeholder-input="imdb" data-separator-placeholder-value=""></select>
+            <input type="hidden" id="imdb_picklist__lookup_labels">
+          </div>
+          <div class="separator-placeholder-field d-none" data-placeholder-source="tmdb_movie">
+            <select id="tmdb_picklist" class="separator-placeholder-picklist" data-separator-placeholder-input="tmdb_movie" data-separator-placeholder-value=""></select>
+            <input type="hidden" id="tmdb_picklist__lookup_labels">
+          </div>
+        </div>
+      </form>
+    `
+
+    separatorPreview.initializeOverlays('mov-library_1', true)
+    await flushAsyncWork()
+
+    const source = document.querySelector('.separator-placeholder-source')
+    source.value = 'tmdb_movie'
+    source.dispatchEvent(new Event('change'))
+    await flushAsyncWork()
+
+    const imdbField = document.querySelector('[data-placeholder-source="imdb"]')
+    const tmdbField = document.querySelector('[data-placeholder-source="tmdb_movie"]')
+    expect(imdbField.classList.contains('d-none')).toBe(true)
+    expect(tmdbField.classList.contains('d-none')).toBe(false)
+    const tmdbOptions = Array.from(document.getElementById('tmdb_picklist').querySelectorAll('option')).map(option => option.value)
+    expect(tmdbOptions).toContain('603')
   })
 })

--- a/tests/test_plex_helpers.py
+++ b/tests/test_plex_helpers.py
@@ -1,0 +1,72 @@
+from modules.helpers import _plex
+
+
+class _Guid:
+    def __init__(self, guid_id):
+        self.id = guid_id
+
+
+class _Item:
+    def __init__(self, title, guids):
+        self.title = title
+        self.guids = [_Guid(guid) for guid in guids]
+
+
+class _Section:
+    key = "1"
+    title = "Movies"
+
+    def __init__(self, items):
+        self._items = items
+
+    def search(self, sort=None, maxresults=None):
+        assert sort == "audienceRating:desc"
+        assert maxresults == 50
+        return self._items
+
+
+class _Library:
+    def __init__(self, section):
+        self._section = section
+
+    def sections(self):
+        return [self._section]
+
+
+class _Plex:
+    def __init__(self, section):
+        self.library = _Library(section)
+
+
+def test_get_top_imdb_items_returns_top_ten_with_source_ids(monkeypatch):
+    items = [_Item(f"Movie {index}", [f"imdb://tt12345{index:02d}", f"tmdb://{600 + index}"]) for index in range(12)]
+    section = _Section(items)
+
+    monkeypatch.setattr(_plex.persistence, "get_stored_plex_credentials", lambda page: ("http://plex", "token"))
+    monkeypatch.setattr(_plex, "PlexServer", lambda url, token: _Plex(section))
+
+    result, saved_item = _plex.get_top_imdb_items("Movies", "movie")
+
+    assert saved_item is None
+    assert len(result) == 10
+    assert result[0] == {
+        "id": "tt1234500",
+        "imdb_id": "tt1234500",
+        "tmdb_movie": "600",
+        "tvdb_show": "",
+        "title": "Movie 0",
+    }
+    assert result[-1]["imdb_id"] == "tt1234509"
+
+
+def test_get_top_imdb_items_continues_until_each_relevant_source_has_top_ten(monkeypatch):
+    items = [_Item(f"IMDb Only {index}", [f"imdb://tt20000{index:02d}"]) for index in range(10)] + [_Item(f"TMDb Only {index}", [f"tmdb://{900 + index}"]) for index in range(10)]
+    section = _Section(items)
+
+    monkeypatch.setattr(_plex.persistence, "get_stored_plex_credentials", lambda page: ("http://plex", "token"))
+    monkeypatch.setattr(_plex, "PlexServer", lambda url, token: _Plex(section))
+
+    result, _saved_item = _plex.get_top_imdb_items("Movies", "movie")
+
+    assert len(result) == 20
+    assert [item["tmdb_movie"] for item in result if item["tmdb_movie"]] == [str(900 + index) for index in range(10)]


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Fixes the separator placeholder UX on the Libraries page by replacing free-text placeholder ID entry with source-aware picklists populated from Plex top audience-rated items.

## Changes

- Adds separator placeholder picklists for IMDb, TMDb movie, and TVDb show IDs.
- Uses the selected Plex library/media type to expose the correct placeholder source options.
- Updates Plex top-item lookup to return source-specific IDs and scan enough items to populate each relevant picklist.
- Keeps separator export behavior intact for `placeholder_imdb_id`, `placeholder_tmdb_movie`, and `placeholder_tvdb_show`.
- Reworks the separator layout so fields are grouped together and the preview image sits underneath them instead of floating awkwardly to the right.
- Updates validation copy from IMDb-specific wording to generic `Placeholder ID`.

## Tests

- `venv\Scripts\python.exe -m pytest tests\test_plex_helpers.py tests\test_core_backend.py::test_build_libraries_section_includes_separator_placeholder_imdb_id tests\test_core_backend.py::test_build_libraries_section_includes_separator_placeholder_tmdb_movie tests\test_core_backend.py::test_build_libraries_section_includes_separator_placeholder_tvdb_show`
- `npx vitest run tests\js\modules\separatorPreview.test.js`
- `npx eslint static\local-js\modules\separatorPreview.js static\local-js\validationHandler.js tests\js\modules\separatorPreview.test.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1653 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
