### PR TITLE
added new grouping for mass_*_updates

### DIFF
--- a/modules/dependency_reasons.py
+++ b/modules/dependency_reasons.py
@@ -84,6 +84,7 @@ QS_MAL_DEP_COLLECTION_IDS = {"collection_myanimelist"}
 QS_OMDB_DEP_SOURCE_PREFIXES = ("omdb",)
 QS_MDBLIST_DEP_SOURCE_PREFIXES = ("mdb",)
 QS_ANIDB_DEP_SOURCE_PREFIXES = ("anidb",)
+QS_TRAKT_DEP_SOURCE_PREFIXES = ("trakt",)
 QS_MDBLIST_OVERLAY_IMAGE_VALUES = {"letterboxd", "metacritic", "rt_tomato", "rt_popcorn", "mdb"}
 QS_ANIDB_OVERLAY_IMAGE_VALUES = {"anidb"}
 QS_TRAKT_OVERLAY_IMAGE_VALUES = {"trakt"}
@@ -376,6 +377,15 @@ def _attribute_dependency_source_reasons(libraries_data, source_prefixes):
         if prefix and prefix not in active_prefixes:
             continue
 
+        attr_body = key.split("-attribute_", 1)[1]
+        if attr_body.endswith("_source"):
+            operation = attr_body[: -len("_source")]
+            source_value = str(raw_value or "").strip().lower()
+            if operation.startswith("mass_") and matches_source(source_value):
+                detail = f"{operation} uses {source_value}"
+                _append_dependency_reason(reasons, seen, libraries_data, prefix or "library", detail)
+                continue
+
         operation, source_value = extract_operation_and_source(key)
         if operation and source_value and _is_truthy_setting_value(raw_value):
             detail = f"{operation} uses {source_value}"
@@ -417,11 +427,19 @@ def _libraries_data_trakt_dependency_reasons(libraries_data):
         QS_TRAKT_DEP_COLLECTION_IDS,
         "Trakt Charts collection enabled",
     )
+    attribute_reasons = _attribute_dependency_source_reasons(
+        libraries_data,
+        QS_TRAKT_DEP_SOURCE_PREFIXES,
+    )
     overlay_reasons = _libraries_data_overlay_rating_dependency_reasons(
         libraries_data,
         QS_TRAKT_OVERLAY_IMAGE_VALUES,
     )
-    return collection_reasons + [reason for reason in overlay_reasons if reason not in collection_reasons]
+    reasons = collection_reasons[:]
+    for reason in attribute_reasons + overlay_reasons:
+        if reason not in reasons:
+            reasons.append(reason)
+    return reasons
 
 
 def _libraries_data_omdb_dependency_reasons(libraries_data):

--- a/modules/importer_operations.py
+++ b/modules/importer_operations.py
@@ -70,6 +70,15 @@ def _normalize_op_items(value: Any) -> list:
     return [value]
 
 
+def _first_valid_option(raw_value: Any, valid_options: set[str]) -> str | None:
+    """Return the first valid option from a scalar or list-like value."""
+    for item in _normalize_op_items(raw_value):
+        candidate = str(item).strip()
+        if candidate in valid_options:
+            return candidate
+    return None
+
+
 def handle_mass_update_operation(
     lib_id: str,
     lib_name: str,
@@ -176,10 +185,13 @@ def handle_toggle_select_operation(
     select_options = set(definition.get("select_options") or [])
     toggle_keys = set(definition.get("toggle_keys") or [])
     toggle_aliases = {}
+    stripped_prefix = op_key.replace("_update", "_", 1)
     for key in toggle_keys:
         toggle_aliases[key] = key
         if key.startswith(f"{op_key}_"):
             toggle_aliases[key.replace(f"{op_key}_", "", 1)] = key
+        if key.startswith(stripped_prefix):
+            toggle_aliases[key.replace(stripped_prefix, "", 1)] = key
 
     def resolve_toggle_key(raw_key: str) -> str | None:
         return toggle_aliases.get(raw_key)
@@ -191,8 +203,8 @@ def handle_toggle_select_operation(
         for raw_key, raw_value in op_value.items():
             key = str(raw_key)
             if key == "source":
-                candidate = str(raw_value).strip()
-                if candidate in select_options:
+                candidate = _first_valid_option(raw_value, select_options)
+                if candidate:
                     source = candidate
                     report.add("imported", f"libraries.{lib_name}.operations.{op_key}.source")
                     imported_any = True
@@ -333,6 +345,294 @@ def handle_delete_collections_operation(
     return True, imported_any
 
 
+def handle_metadata_backup_operation(
+    lib_id: str,
+    lib_name: str,
+    op_key: str,
+    op_value: Any,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> tuple[bool, bool]:
+    """Dispatch the ``metadata_backup`` operation into flat fields."""
+    if op_key != "metadata_backup":
+        return False, False
+    if not isinstance(op_value, dict):
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported metadata_backup format.")
+        return True, False
+
+    imported_any = False
+    field_map = {
+        "path": "metadata_backup_path",
+        "exclude": "metadata_backup_exclude",
+        "sync_tags": "sync_tags",
+        "add_blank_entries": "add_blank_entries",
+    }
+    for raw_key, raw_value in op_value.items():
+        key = str(raw_key)
+        target = field_map.get(key)
+        if not target:
+            report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{key}")
+            continue
+        if key == "exclude":
+            values = raw_value if isinstance(raw_value, list) else _normalize_op_items(raw_value)
+            cleaned = [str(item).strip() for item in values if str(item).strip()]
+            if cleaned:
+                libraries_data[f"{lib_id}-attribute_{target}"] = _encode_json(cleaned)
+                imported_any = True
+        else:
+            libraries_data[f"{lib_id}-attribute_{target}"] = raw_value
+            imported_any = True
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
+
+    if imported_any:
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+    else:
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
+    return True, imported_any
+
+
+_MASS_METADATA_DIRECT_ALIASES = {
+    "original_title": "mass_original_title_update",
+    "studio": "mass_studio_update",
+    "originally_available": "mass_originally_available_update",
+    "added_at": "mass_added_at_update",
+}
+
+_MASS_METADATA_RATING_ALIASES = {
+    "audience": "mass_audience_rating_update",
+    "critic": "mass_critic_rating_update",
+    "user": "mass_user_rating_update",
+    "episode_audience": "mass_episode_audience_rating_update",
+    "episode_critic": "mass_episode_critic_rating_update",
+    "episode_user": "mass_episode_user_rating_update",
+}
+
+_MASS_METADATA_IMAGE_ALIASES = {
+    "poster": "mass_poster_update",
+    "background": "mass_background_update",
+    "logo": "mass_logo_update",
+    "square_art": "mass_square_art_update",
+    "squart_art": "mass_square_art_update",
+}
+
+
+def _mass_metadata_source(value: Any) -> Any:
+    if isinstance(value, dict) and "source" in value:
+        return value.get("source")
+    return value
+
+
+def _mass_metadata_dict_keys_as_sources(value: dict, ignored_keys: set[str]) -> list[str]:
+    return [str(key) for key in value if str(key) not in ignored_keys]
+
+
+def handle_mass_image_update_operation(
+    lib_id: str,
+    lib_name: str,
+    op_key: str,
+    op_value: Any,
+    *,
+    toggle_select_defs: dict,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> tuple[bool, bool]:
+    """Dispatch Kometa's grouped ``mass_image_update`` compatibility op."""
+    if op_key != "mass_image_update":
+        return False, False
+    if not isinstance(op_value, dict):
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported mass_image_update format.")
+        return True, False
+
+    imported_any = False
+    for image_key, image_value in op_value.items():
+        old_key = _MASS_METADATA_IMAGE_ALIASES.get(str(image_key))
+        if not old_key:
+            report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{image_key}")
+            continue
+        _handled, imported = handle_toggle_select_operation(
+            lib_id,
+            lib_name,
+            old_key,
+            image_value,
+            toggle_select_defs=toggle_select_defs,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        imported_any = imported_any or imported
+
+    if imported_any:
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+    else:
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
+    return True, imported_any
+
+
+def handle_mass_metadata_update_operation(
+    lib_id: str,
+    lib_name: str,
+    op_key: str,
+    op_value: Any,
+    *,
+    mass_update_defs: dict,
+    toggle_select_defs: dict,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> tuple[bool, bool]:
+    """Dispatch grouped ``mass_metadata_update`` into legacy flat UI keys."""
+    if op_key != "mass_metadata_update":
+        return False, False
+    if not isinstance(op_value, dict):
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported mass_metadata_update format.")
+        return True, False
+
+    imported_any = False
+
+    for new_key, old_key in _MASS_METADATA_DIRECT_ALIASES.items():
+        if new_key not in op_value:
+            continue
+        _handled, imported = handle_mass_update_operation(
+            lib_id,
+            lib_name,
+            old_key,
+            _mass_metadata_source(op_value[new_key]),
+            mass_update_defs=mass_update_defs,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        imported_any = imported_any or imported
+        if imported:
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{new_key}")
+
+    if "genre" in op_value:
+        genre_value = op_value["genre"]
+        if isinstance(genre_value, dict):
+            if isinstance(genre_value.get("mappings"), dict) and genre_value["mappings"]:
+                libraries_data[f"{lib_id}-attribute_genre_mapper"] = json.dumps(genre_value["mappings"], ensure_ascii=True)
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.genre.mappings")
+                imported_any = True
+            source_value = genre_value.get("source")
+            if source_value is None:
+                source_value = _mass_metadata_dict_keys_as_sources(genre_value, {"mappings", "schedule"})
+        else:
+            source_value = genre_value
+        if source_value:
+            _handled, imported = handle_mass_update_operation(
+                lib_id,
+                lib_name,
+                "mass_genre_update",
+                source_value,
+                mass_update_defs=mass_update_defs,
+                libraries_data=libraries_data,
+                report=report,
+            )
+            imported_any = imported_any or imported
+            if imported:
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.genre")
+
+    if "content_rating" in op_value:
+        rating_value = op_value["content_rating"]
+        if isinstance(rating_value, dict):
+            if isinstance(rating_value.get("mappings"), dict) and rating_value["mappings"]:
+                libraries_data[f"{lib_id}-attribute_content_rating_mapper"] = json.dumps(rating_value["mappings"], ensure_ascii=True)
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.content_rating.mappings")
+                imported_any = True
+            source_value = rating_value.get("source")
+            if source_value is None:
+                source_value = _mass_metadata_dict_keys_as_sources(rating_value, {"mappings", "schedule"})
+        else:
+            source_value = rating_value
+        if source_value:
+            _handled, imported = handle_mass_update_operation(
+                lib_id,
+                lib_name,
+                "mass_content_rating_update",
+                source_value,
+                mass_update_defs=mass_update_defs,
+                libraries_data=libraries_data,
+                report=report,
+            )
+            imported_any = imported_any or imported
+            if imported:
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.content_rating")
+
+    labels = op_value.get("labels")
+    if labels is not None:
+        label_value = labels.get("severity") if isinstance(labels, dict) else labels
+        if label_value not in (None, ""):
+            libraries_data[f"{lib_id}-attribute_mass_imdb_parental_labels"] = label_value
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}.labels")
+            imported_any = True
+
+    collections = op_value.get("collections")
+    if collections is not None:
+        collection_mode = collections.get("mode") if isinstance(collections, dict) else collections
+        if collection_mode not in (None, ""):
+            libraries_data[f"{lib_id}-attribute_mass_collection_mode"] = collection_mode
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}.collections")
+            imported_any = True
+
+    ratings = op_value.get("ratings")
+    if isinstance(ratings, dict):
+        for new_key, old_key in _MASS_METADATA_RATING_ALIASES.items():
+            if new_key not in ratings:
+                continue
+            _handled, imported = handle_mass_update_operation(
+                lib_id,
+                lib_name,
+                old_key,
+                _mass_metadata_source(ratings[new_key]),
+                mass_update_defs=mass_update_defs,
+                libraries_data=libraries_data,
+                report=report,
+            )
+            imported_any = imported_any or imported
+            if imported:
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.ratings.{new_key}")
+    elif ratings is not None:
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.ratings", "Unsupported ratings format.")
+
+    for new_key, old_key in _MASS_METADATA_IMAGE_ALIASES.items():
+        if new_key not in op_value:
+            continue
+        _handled, imported = handle_toggle_select_operation(
+            lib_id,
+            lib_name,
+            old_key,
+            op_value[new_key],
+            toggle_select_defs=toggle_select_defs,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        imported_any = imported_any or imported
+        if imported:
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{new_key}")
+
+    if "backup" in op_value:
+        _handled, imported = handle_metadata_backup_operation(
+            lib_id,
+            lib_name,
+            "metadata_backup",
+            op_value["backup"],
+            libraries_data=libraries_data,
+            report=report,
+        )
+        imported_any = imported_any or imported
+        if imported:
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}.backup")
+
+    known_keys = set(_MASS_METADATA_DIRECT_ALIASES) | {"genre", "content_rating", "labels", "collections", "ratings", "backup"} | set(_MASS_METADATA_IMAGE_ALIASES)
+    for key in op_value:
+        if str(key) not in known_keys and str(key) != "schedule":
+            report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{key}", "Unsupported mass_metadata_update field.")
+
+    if imported_any:
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+    else:
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
+    return True, imported_any
+
+
 def process_operations_block(
     lib_id: str,
     lib_name: str,
@@ -388,6 +688,45 @@ def process_operations_block(
             lib_name,
             key,
             value,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        if handled:
+            imported_ops = imported_ops or imported
+            continue
+
+        handled, imported = handle_mass_metadata_update_operation(
+            lib_id,
+            lib_name,
+            key,
+            value,
+            mass_update_defs=mass_update_defs,
+            toggle_select_defs=toggle_select_defs,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        if handled:
+            imported_ops = imported_ops or imported
+            continue
+
+        handled, imported = handle_metadata_backup_operation(
+            lib_id,
+            lib_name,
+            key,
+            value,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        if handled:
+            imported_ops = imported_ops or imported
+            continue
+
+        handled, imported = handle_mass_image_update_operation(
+            lib_id,
+            lib_name,
+            key,
+            value,
+            toggle_select_defs=toggle_select_defs,
             libraries_data=libraries_data,
             report=report,
         )

--- a/modules/output_libraries_section.py
+++ b/modules/output_libraries_section.py
@@ -38,10 +38,7 @@ from modules.output_library_ops import (
     build_grouped_mass_update_operations,
     build_library_operations,
     build_library_settings,
-    build_mapper_operations,
-    build_mass_background_update_operation,
-    build_mass_genre_update_operation,
-    build_mass_poster_update_operation,
+    build_mass_metadata_update_operation,
     build_metadata_backup_operation,
     build_service_overrides,
     build_template_variables,
@@ -145,10 +142,6 @@ def build_libraries_section(
         operations.update(build_library_operations(attr_group, library_type, lib_id))
         service_name, service_overrides = build_service_overrides(attr_group, library_type, lib_id)
 
-        mass_genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
-        if mass_genre_update:
-            operations["mass_genre_update"] = mass_genre_update
-
         delete_collections = build_delete_collections_operation(attr_group, library_type, lib_id)
         if delete_collections:
             operations["delete_collections"] = delete_collections
@@ -198,21 +191,18 @@ def build_libraries_section(
         if template_variable_comments:
             entry[_TEMPLATE_VARIABLE_COMMENTS_KEY] = template_variable_comments
 
-        # Grouped mass update operations (mass_genre_update handled above)
-        operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id))
-        operations.update(build_mapper_operations(attr_group, library_type, lib_id))
+        # Grouped mass metadata output.  Quickstart's DB/UI still stores
+        # these as flat operation fields, matching Kometa's parsed runtime
+        # fields, but final YAML should use the canonical grouped key.
+        mass_metadata = build_mass_metadata_update_operation(attr_group, library_type, lib_id)
+        if mass_metadata:
+            operations["mass_metadata_update"] = mass_metadata
+
+        operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id, include_mass_metadata_legacy=False))
 
         backup = build_metadata_backup_operation(attr_group, library_type, lib_id)
-        if backup:
+        if backup and not mass_metadata:
             operations["metadata_backup"] = backup
-
-        poster = build_mass_poster_update_operation(attr_group, library_type, lib_id)
-        if poster:
-            operations["mass_poster_update"] = poster
-
-        background = build_mass_background_update_operation(attr_group, library_type, lib_id)
-        if background:
-            operations["mass_background_update"] = background
 
         # Top-level fields (Remove/Reset Overlays, etc.)
         top_group = top_level.get(lib_id, {})

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -156,11 +156,13 @@ def build_mass_genre_update_operation(attr_group, library_type, lib_id):
     return result
 
 
-# Keys read from attr_group for each 'mass_<media>_update' operation.
-# Poster has one extra key (ignore_overlays) that background lacks;
-# otherwise the shape is identical, which is why they share a helper.
+# Keys read from attr_group for each mass image operation.  Poster has
+# show-level toggles and ignore_overlays, background has show-level
+# toggles, logo/square_art are item-level only in Kometa.
 _MASS_POSTER_UPDATE_KEYS = ("seasons", "episodes", "ignore_locked", "ignore_overlays", "source")
 _MASS_BACKGROUND_UPDATE_KEYS = ("seasons", "episodes", "ignore_locked", "source")
+_MASS_LOGO_UPDATE_KEYS = ("ignore_locked", "ignore_overlays", "source")
+_MASS_SQUARE_ART_UPDATE_KEYS = ("ignore_locked", "ignore_overlays", "source")
 
 # Values that the mass_poster/background 'empty' check considers
 # 'user hasn't set this field' -- distinct from _EMPTY_OVERRIDE_VALUES
@@ -209,6 +211,16 @@ def build_mass_background_update_operation(attr_group, library_type, lib_id):
     ``mass_background_source``.
     """
     return _build_mass_media_update_operation(attr_group, library_type, lib_id, "background", _MASS_BACKGROUND_UPDATE_KEYS)
+
+
+def build_mass_logo_update_operation(attr_group, library_type, lib_id):
+    """Return the ``mass_logo_update`` operations dict, or empty."""
+    return _build_mass_media_update_operation(attr_group, library_type, lib_id, "logo", _MASS_LOGO_UPDATE_KEYS)
+
+
+def build_mass_square_art_update_operation(attr_group, library_type, lib_id):
+    """Return the ``mass_square_art_update`` operations dict, or empty."""
+    return _build_mass_media_update_operation(attr_group, library_type, lib_id, "square_art", _MASS_SQUARE_ART_UPDATE_KEYS)
 
 
 def build_mapper_operations(attr_group, library_type, lib_id):
@@ -452,6 +464,24 @@ _GROUPED_OPERATIONS = (
     "sonarr_remove_by_tag",
 )
 
+_MASS_METADATA_GROUPED_OPERATIONS = frozenset(
+    {
+        "mass_content_rating_update",
+        "mass_original_title_update",
+        "mass_studio_update",
+        "mass_originally_available_update",
+        "mass_added_at_update",
+        "mass_audience_rating_update",
+        "mass_critic_rating_update",
+        "mass_user_rating_update",
+        "mass_episode_audience_rating_update",
+        "mass_episode_critic_rating_update",
+        "mass_episode_user_rating_update",
+        "mass_background_update",
+        "mass_poster_update",
+    }
+)
+
 # Rating operations whose ``custom_string`` fallback must be coerced
 # to float instead of string.  Frozen so callers can't mutate it.
 _RATING_OPERATIONS_FLOAT_COERCE = frozenset(
@@ -521,7 +551,7 @@ def _format_grouped_op_sequence(values):
     return seq
 
 
-def build_grouped_mass_update_operations(attr_group, library_type, lib_id):
+def build_grouped_mass_update_operations(attr_group, library_type, lib_id, *, include_mass_metadata_legacy=True):
     """Return a dict of the 17 grouped mass_update operations.
 
     For each operation name in ``_GROUPED_OPERATIONS``, reads three
@@ -543,6 +573,8 @@ def build_grouped_mass_update_operations(attr_group, library_type, lib_id):
     """
     result = {}
     for op in _GROUPED_OPERATIONS:
+        if not include_mass_metadata_legacy and op in _MASS_METADATA_GROUPED_OPERATIONS:
+            continue
         values = []
 
         # 1. Ordered source list (sortable)
@@ -568,6 +600,104 @@ def build_grouped_mass_update_operations(attr_group, library_type, lib_id):
 
         if values:
             result[op] = _format_grouped_op_sequence(values)
+
+    return result
+
+
+def _single_or_sequence(value):
+    """Use scalar YAML for one source and block sequence for multiple."""
+    if isinstance(value, CommentedSeq):
+        items = list(value)
+    elif isinstance(value, list):
+        items = value
+    else:
+        return value
+    if len(items) == 1:
+        return items[0]
+    seq = CommentedSeq(items)
+    seq.fa.set_block_style()
+    return seq
+
+
+_MASS_METADATA_DIRECT_ALIASES = (
+    ("mass_original_title_update", "original_title"),
+    ("mass_studio_update", "studio"),
+    ("mass_originally_available_update", "originally_available"),
+    ("mass_added_at_update", "added_at"),
+)
+
+_MASS_METADATA_RATING_ALIASES = (
+    ("mass_audience_rating_update", "audience"),
+    ("mass_critic_rating_update", "critic"),
+    ("mass_user_rating_update", "user"),
+    ("mass_episode_audience_rating_update", "episode_audience"),
+    ("mass_episode_critic_rating_update", "episode_critic"),
+    ("mass_episode_user_rating_update", "episode_user"),
+)
+
+
+def build_mass_metadata_update_operation(attr_group, library_type, lib_id):
+    """Return Kometa's grouped ``mass_metadata_update`` operation.
+
+    Quickstart stores/edit these controls as flat legacy operation
+    fields.  Kometa does the same internally after parsing the grouped
+    key, so this builder only canonicalizes final YAML output.
+    """
+    result = {}
+    grouped_ops = build_grouped_mass_update_operations(attr_group, library_type, lib_id)
+
+    genre = {}
+    genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
+    if genre_update:
+        genre["source"] = _single_or_sequence(genre_update)
+    mappers = build_mapper_operations(attr_group, library_type, lib_id)
+    if mappers.get("genre_mapper"):
+        genre["mappings"] = mappers["genre_mapper"]
+    if genre:
+        result["genre"] = genre
+
+    content_rating = {}
+    if grouped_ops.get("mass_content_rating_update"):
+        content_rating["source"] = _single_or_sequence(grouped_ops["mass_content_rating_update"])
+    if mappers.get("content_rating_mapper"):
+        content_rating["mappings"] = mappers["content_rating_mapper"]
+    if content_rating:
+        result["content_rating"] = content_rating
+
+    for old_key, new_key in _MASS_METADATA_DIRECT_ALIASES:
+        value = grouped_ops.get(old_key)
+        if value:
+            result[new_key] = _single_or_sequence(value)
+
+    labels = attr_group.get(_attr_key(library_type, lib_id, "mass_imdb_parental_labels"))
+    if labels not in _SETTINGS_EMPTY_VALUES:
+        result["labels"] = labels
+
+    collection_mode = attr_group.get(_attr_key(library_type, lib_id, "mass_collection_mode"))
+    if collection_mode not in _SETTINGS_EMPTY_VALUES:
+        result["collections"] = {"mode": collection_mode}
+
+    ratings = {}
+    for old_key, new_key in _MASS_METADATA_RATING_ALIASES:
+        value = grouped_ops.get(old_key)
+        if value:
+            ratings[new_key] = _single_or_sequence(value)
+    if ratings:
+        result["ratings"] = ratings
+
+    images = (
+        ("poster", build_mass_poster_update_operation(attr_group, library_type, lib_id)),
+        ("background", build_mass_background_update_operation(attr_group, library_type, lib_id)),
+        ("logo", build_mass_logo_update_operation(attr_group, library_type, lib_id)),
+        ("square_art", build_mass_square_art_update_operation(attr_group, library_type, lib_id)),
+    )
+    for image_key, image_value in images:
+        if image_value:
+            result[image_key] = image_value
+
+    backup = build_metadata_backup_operation(attr_group, library_type, lib_id)
+    if backup:
+        result["backup"] = backup
 
     return result
 
@@ -623,8 +753,6 @@ _SETTINGS_EMPTY_VALUES = frozenset({None, "", False})
 _LIBRARY_OPERATIONS_FIELDS = (
     "assets_for_all",
     "assets_for_all_collections",
-    "mass_imdb_parental_labels",
-    "mass_collection_mode",
     "update_blank_track_titles",
     "remove_title_parentheses",
     "split_duplicates",

--- a/modules/output_reorder.py
+++ b/modules/output_reorder.py
@@ -47,6 +47,7 @@ _OPERATIONS_ORDER = (
     "assets_for_all",
     "assets_for_all_collections",
     "delete_collections",
+    "mass_metadata_update",
     "mass_genre_update",
     "mass_content_rating_update",
     "mass_original_title_update",

--- a/static/json/quickstart_attributes.json
+++ b/static/json/quickstart_attributes.json
@@ -1630,6 +1630,14 @@
             "TMDb"
           ],
           [
+            "trakt",
+            "Trakt"
+          ],
+          [
+            "tvdb",
+            "TVDb"
+          ],
+          [
             "plex",
             "Plex"
           ],
@@ -1693,6 +1701,14 @@
             "TMDb"
           ],
           [
+            "trakt",
+            "Trakt"
+          ],
+          [
+            "tvdb",
+            "TVDb"
+          ],
+          [
             "plex",
             "Plex"
           ],
@@ -1739,6 +1755,14 @@
           [
             "tmdb",
             "TMDb"
+          ],
+          [
+            "trakt",
+            "Trakt"
+          ],
+          [
+            "tvdb",
+            "TVDb"
           ],
           [
             "plex",
@@ -1799,6 +1823,14 @@
             "TMDb"
           ],
           [
+            "trakt",
+            "Trakt"
+          ],
+          [
+            "tvdb",
+            "TVDb"
+          ],
+          [
             "plex",
             "Plex"
           ],
@@ -1809,6 +1841,126 @@
           [
             "unlock",
             "Unlock Background Field"
+          ]
+        ]
+      },
+      "yml_location": "attribute"
+    },
+    {
+      "prefix": "mass_logo_update",
+      "type": "toggle_with_select",
+      "accordion": "library",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Mass Logo Update",
+      "wiki": "https://kometa.wiki/en/nightly/config/operations/#mass-metadata-update",
+      "description": "Updates the logo of each item in the library based on the selected source and optional toggles.",
+      "tooltip_variant": "info",
+      "container_class": "accordion",
+      "toggles": [
+        {
+          "key": "mass_logo_ignore_locked",
+          "label": "Ignore Locked Logos",
+          "tooltip": "Skip updating image if the logo field is locked."
+        },
+        {
+          "key": "mass_logo_ignore_overlays",
+          "label": "Ignore Overlaid Logos",
+          "tooltip": "Skip updating image if the current image has an Overlay."
+        }
+      ],
+      "select_input": {
+        "key": "mass_logo_source",
+        "label": "Logo Source",
+        "tooltip": "Choose the source to update the logo image from.",
+        "options": [
+          [
+            "",
+            "None"
+          ],
+          [
+            "tmdb",
+            "TMDb"
+          ],
+          [
+            "trakt",
+            "Trakt"
+          ],
+          [
+            "tvdb",
+            "TVDb"
+          ],
+          [
+            "plex",
+            "Plex"
+          ],
+          [
+            "lock",
+            "Lock Logo Field"
+          ],
+          [
+            "unlock",
+            "Unlock Logo Field"
+          ]
+        ]
+      },
+      "yml_location": "attribute"
+    },
+    {
+      "prefix": "mass_square_art_update",
+      "type": "toggle_with_select",
+      "accordion": "library",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Mass Square Art Update",
+      "wiki": "https://kometa.wiki/en/nightly/config/operations/#mass-metadata-update",
+      "description": "Updates square art for each item in the library based on the selected source and optional toggles.",
+      "tooltip_variant": "info",
+      "container_class": "accordion",
+      "toggles": [
+        {
+          "key": "mass_square_art_ignore_locked",
+          "label": "Ignore Locked Square Art",
+          "tooltip": "Skip updating image if the square art field is locked."
+        },
+        {
+          "key": "mass_square_art_ignore_overlays",
+          "label": "Ignore Overlaid Square Art",
+          "tooltip": "Skip updating image if the current image has an Overlay."
+        }
+      ],
+      "select_input": {
+        "key": "mass_square_art_source",
+        "label": "Square Art Source",
+        "tooltip": "Choose the source to update square art from.",
+        "options": [
+          [
+            "",
+            "None"
+          ],
+          [
+            "plex",
+            "Plex"
+          ],
+          [
+            "trakt",
+            "Trakt"
+          ],
+          [
+            "tvdb",
+            "TVDb"
+          ],
+          [
+            "lock",
+            "Lock Square Art Field"
+          ],
+          [
+            "unlock",
+            "Unlock Square Art Field"
           ]
         ]
       },

--- a/tests/test_mass_metadata_update_contract.py
+++ b/tests/test_mass_metadata_update_contract.py
@@ -1,0 +1,130 @@
+import json
+
+from modules import importer
+from modules import dependency_reasons
+
+
+def test_prepare_import_payload_accepts_mass_metadata_update():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "operations": {
+                        "mass_metadata_update": {
+                            "genre": {
+                                "source": ["tmdb", "imdb"],
+                                "mappings": {"Action & Adventure": "Action"},
+                            },
+                            "content_rating": {"source": "omdb"},
+                            "original_title": "mal_english",
+                            "collections": {"mode": "hide"},
+                            "labels": {"severity": "mild"},
+                            "ratings": {"audience": "tmdb"},
+                            "poster": {"source": ["trakt", "tmdb"], "ignore_locked": True},
+                            "logo": {"source": "tvdb"},
+                            "square_art": {"source": "tvdb"},
+                            "backup": {"path": "config/Movies_Backup.yml", "exclude": ["title"]},
+                        }
+                    }
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-attribute_mass_genre_update_order"] == '["tmdb", "imdb"]'
+    assert json.loads(libraries["mov-library_movies-attribute_genre_mapper"]) == {"Action & Adventure": "Action"}
+    assert libraries["mov-library_movies-attribute_mass_content_rating_update_order"] == '["omdb"]'
+    assert libraries["mov-library_movies-attribute_mass_original_title_update_order"] == '["mal_english"]'
+    assert libraries["mov-library_movies-attribute_mass_collection_mode"] == "hide"
+    assert libraries["mov-library_movies-attribute_mass_imdb_parental_labels"] == "mild"
+    assert libraries["mov-library_movies-attribute_mass_audience_rating_update_order"] == '["tmdb"]'
+    assert libraries["mov-library_movies-attribute_mass_poster_source"] == "trakt"
+    assert libraries["mov-library_movies-attribute_mass_poster_ignore_locked"] is True
+    assert libraries["mov-library_movies-attribute_mass_logo_source"] == "tvdb"
+    assert libraries["mov-library_movies-attribute_mass_square_art_source"] == "tvdb"
+    assert libraries["mov-library_movies-attribute_metadata_backup_path"] == "config/Movies_Backup.yml"
+    assert libraries["mov-library_movies-attribute_metadata_backup_exclude"] == '["title"]'
+    assert any("libraries.Movies.operations.mass_metadata_update" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_legacy_metadata_backup():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "operations": {
+                        "metadata_backup": {
+                            "path": "config/Movies_Backup.yml",
+                            "exclude": ["title", "summary"],
+                            "sync_tags": True,
+                        }
+                    }
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-attribute_metadata_backup_path"] == "config/Movies_Backup.yml"
+    assert libraries["mov-library_movies-attribute_metadata_backup_exclude"] == '["title", "summary"]'
+    assert libraries["mov-library_movies-attribute_sync_tags"] is True
+    assert any("libraries.Movies.operations.metadata_backup" in line for line in report.lines)
+
+
+def test_build_libraries_section_emits_mass_metadata_update(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_attributes={
+                "movies": {
+                    "mov-library_movies-attribute_mass_genre_update_order": '["tmdb"]',
+                    "mov-library_movies-attribute_genre_mapper": json.dumps({"Action & Adventure": "Action"}),
+                    "mov-library_movies-attribute_mass_content_rating_update_order": '["omdb"]',
+                    "mov-library_movies-attribute_mass_original_title_update_order": '["mal_english"]',
+                    "mov-library_movies-attribute_mass_collection_mode": "hide",
+                    "mov-library_movies-attribute_mass_imdb_parental_labels": "mild",
+                    "mov-library_movies-attribute_mass_audience_rating_update_order": '["tmdb"]',
+                    "mov-library_movies-attribute_mass_poster_source": "trakt",
+                    "mov-library_movies-attribute_mass_poster_ignore_locked": True,
+                    "mov-library_movies-attribute_mass_logo_source": "tvdb",
+                    "mov-library_movies-attribute_mass_square_art_source": "tvdb",
+                    "mov-library_movies-attribute_metadata_backup_path": "config/Movies_Backup.yml",
+                    "mov-library_movies-attribute_metadata_backup_exclude": '["title"]',
+                }
+            },
+        )
+
+    operations = libraries_section["libraries"]["Movies"]["operations"]
+    mass_metadata = operations["mass_metadata_update"]
+    assert mass_metadata["genre"]["source"] == "tmdb"
+    assert mass_metadata["genre"]["mappings"] == {"Action & Adventure": "Action"}
+    assert mass_metadata["content_rating"]["source"] == "omdb"
+    assert mass_metadata["original_title"] == "mal_english"
+    assert mass_metadata["collections"] == {"mode": "hide"}
+    assert mass_metadata["labels"] == "mild"
+    assert mass_metadata["ratings"]["audience"] == "tmdb"
+    assert mass_metadata["poster"] == {"ignore_locked": True, "source": "trakt"}
+    assert mass_metadata["logo"] == {"source": "tvdb"}
+    assert mass_metadata["square_art"] == {"source": "tvdb"}
+    assert mass_metadata["backup"] == {"path": "config/Movies_Backup.yml", "exclude": ["title"]}
+    assert "mass_genre_update" not in operations
+    assert "mass_content_rating_update" not in operations
+    assert "metadata_backup" not in operations
+
+
+def test_trakt_dependency_detects_mass_metadata_image_sources():
+    reasons = dependency_reasons._libraries_data_trakt_dependency_reasons(
+        {
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_mass_poster_source": "trakt",
+        }
+    )
+
+    assert any("mass_poster uses trakt" in reason for reason in reasons)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
Adds support for Kometa’s grouped `operations.mass_metadata_update` model while preserving import compatibility with older legacy operation shapes.

**Changes**
- Export migrated metadata operations under `operations.mass_metadata_update` instead of separate legacy keys.
- Import `mass_metadata_update` back into existing Quickstart library attribute fields.
- Import legacy `metadata_backup` and newer `mass_image_update` structures.
- Add `mass_logo_update` and `mass_square_art_update` attribute definitions to the Libraries UI JSON.
- Expand mass poster/background/logo source options to match local Kometa support.
- Keep unsupported square-art TMDb source out of the dropdown.
- Add Trakt dependency detection for select-backed mass metadata image sources.
- Add regression tests covering grouped import, grouped export, legacy backup import, and Trakt dependency detection.

**Validation**
- `venv\Scripts\python.exe -m pytest tests\test_mass_metadata_update_contract.py`
- `venv\Scripts\python.exe -m pytest tests\test_importer_library_services.py tests\test_importer_edge_cases.py tests\test_mass_metadata_update_contract.py`
- `venv\Scripts\python.exe -m pytest tests\test_workspace_dependency_logic.py -k "dependency_reason or dependency_hint or trakt"`
- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k "build_libraries_section"`
- `quickstart_attributes.json` JSON parse check passed.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1559 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
