### PR TITLE
Route analytics log-keep reads through getAppConfig; add ESLint guard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -183,6 +183,24 @@ module.exports = [
       'no-var': 'error',
       'prefer-const': 'error',
       eqeqeq: ['error', 'always', { null: 'ignore' }],
+      // Guard the app-config accessor boundary (#1334 Step 5). All
+      // app-level config reads/writes go through getAppConfig /
+      // setAppConfig in modules/appConfig.js so that the bootstrap
+      // mechanism (inline object today; fetched payload or reactive
+      // store tomorrow) can change in exactly one place. Direct
+      // window.QS_AppConfig member access re-couples call sites to the
+      // current mechanism. The accessor module itself is exempted in
+      // an override block below.
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'window',
+          property: 'QS_AppConfig',
+          message:
+            'Do not read window.QS_AppConfig directly. Import ' +
+            'getAppConfig/setAppConfig from modules/appConfig.js instead.'
+        }
+      ],
       // Regression guards for the inline-handler / shim cleanup sprint.
       'no-restricted-syntax': [
         'error',
@@ -207,6 +225,14 @@ module.exports = [
     files: moduleFiles,
     languageOptions: {
       sourceType: 'module'
+    }
+  },
+  {
+    // The accessor module is the one place allowed to touch
+    // window.QS_AppConfig -- it owns the namespace.
+    files: ['static/local-js/modules/appConfig.js'],
+    rules: {
+      'no-restricted-properties': 'off'
     }
   }
 ]

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -1,4 +1,5 @@
 /* global bootstrap */
+import { getAppConfig } from './modules/appConfig.js'
 import { elementGroup } from './modules/elementGroup.js'
 
 const tableBody = document.querySelector('#logscan-trends-table tbody')
@@ -1670,10 +1671,10 @@ function renderArchiveStorageSummary (storage) {
   if (!tablePolicy) return
   const kometaKeepLimit = storage && Number.isFinite(storage.kometa_keep_limit)
     ? storage.kometa_keep_limit
-    : (parseInt((window.QS_AppConfig && window.QS_AppConfig.QS_KOMETA_LOG_KEEP) || '0', 10) || 0)
+    : (parseInt(getAppConfig('QS_KOMETA_LOG_KEEP', '0'), 10) || 0)
   const imagemaidKeepLimit = storage && Number.isFinite(storage.imagemaid_keep_limit)
     ? storage.imagemaid_keep_limit
-    : (parseInt((window.QS_AppConfig && window.QS_AppConfig.QS_IMAGEMAID_LOG_KEEP) || '0', 10) || 0)
+    : (parseInt(getAppConfig('QS_IMAGEMAID_LOG_KEEP', '0'), 10) || 0)
   const kometaRetentionLabel = storage && storage.kometa_retention_label
     ? storage.kometa_retention_label
     : (kometaKeepLimit > 0 ? `Keep last ${kometaKeepLimit} archived logs` : 'Keep all archived logs')


### PR DESCRIPTION
## What

Two related changes enforcing the app-config accessor boundary from the #1335 roadmap (Step 5):

1. **`static/local-js/905-analytics.js`** — the archive-storage summary (added in #1635) read `window.QS_AppConfig.QS_KOMETA_LOG_KEEP` / `QS_IMAGEMAID_LOG_KEEP` directly. Both reads now go through `getAppConfig()` from `modules/appConfig.js`, matching every other call site. The accessor already handles the missing-namespace case, so the `window.QS_AppConfig && ...` guard chains are gone too.

2. **`eslint.config.js`** — new `no-restricted-properties` rule banning direct `window.QS_AppConfig` member access, with an override exempting `modules/appConfig.js` (which owns the namespace). Future bypasses now fail lint instead of relying on review vigilance.

## Why

`window.QS_AppConfig` is an implementation detail of the current inline bootstrap. The accessor exists so a future change (fetched bootstrap, reactive store for Step 9 components) only touches one file. Direct reads re-couple call sites to the current mechanism.

## Verification

- `npm run lint:eslint` clean
- Full Vitest suite: 1546/1546 passing
- Rule confirmed to fire on a synthetic `window.QS_AppConfig.QS_DEBUG` read
- pre-commit hooks green

No behavior changes.