### PR TITLE
more details on separator id logic

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -1,5 +1,7 @@
 """Library-page routes: card fragments, autosave, dependency hints, copy."""
 
+import time
+
 from flask import Blueprint, jsonify, render_template, request, session
 from werkzeug.datastructures import MultiDict
 
@@ -24,6 +26,9 @@ from modules.dependency_reasons import (
 # bodies for the `import quickstart as _qs` calls.
 
 bp = Blueprint("library_routes", __name__)
+
+_TOP_PLACEHOLDER_CACHE_TTL_SECONDS = 600
+_top_placeholder_cache = {}
 
 
 # --- top-level imdb items route -------------------------------------------
@@ -51,8 +56,40 @@ def get_top_imdb_items_route(library_name):
             }
         )
 
-    # Call with placeholder_id
-    items, saved_item = helpers.get_top_imdb_items(library_name, media_type, placeholder_id)
+    cache_key = (str(media_type or "").strip().lower(), str(library_name or "").strip().lower())
+    now = time.time()
+    cached = _top_placeholder_cache.get(cache_key)
+    if cached and now - cached.get("created", 0) < _TOP_PLACEHOLDER_CACHE_TTL_SECONDS:
+        return jsonify(
+            {
+                "status": "success",
+                "items": cached.get("items", []),
+                "saved_item": cached.get("saved_item"),
+                "cached": True,
+            }
+        )
+
+    try:
+        items, saved_item = helpers.get_top_imdb_items(library_name, media_type, placeholder_id)
+    except Exception as e:
+        helpers.ts_log(
+            f"Separator placeholder top-item lookup failed for library='{library_name}' type='{media_type}': {e}",
+            level="ERROR",
+        )
+        return jsonify(
+            {
+                "status": "lookup_unavailable",
+                "items": [],
+                "saved_item": None,
+                "message": ("Unable to load top audience-rated Plex items. " "Check Plex connectivity, library metadata, and database health, then try again."),
+            }
+        )
+
+    _top_placeholder_cache[cache_key] = {
+        "created": now,
+        "items": items,
+        "saved_item": saved_item,
+    }
 
     return jsonify({"status": "success", "items": items, "saved_item": saved_item})
 

--- a/static/local-js/modules/separatorPreview.js
+++ b/static/local-js/modules/separatorPreview.js
@@ -143,7 +143,7 @@ function writeSeparatorLookupLabel (select) {
   hidden.dispatchEvent(new Event('change', { bubbles: true }))
 }
 
-function setPlaceholderPicklistOptions (select, items) {
+function setPlaceholderPicklistOptions (select, items, lookupError = '') {
   if (!select) return
   const source = String(select.dataset.separatorPlaceholderInput || '').trim()
   const savedValue = String(select.dataset.separatorPlaceholderValue || select.value || '').trim()
@@ -164,13 +164,15 @@ function setPlaceholderPicklistOptions (select, items) {
   select.replaceChildren()
   const blank = document.createElement('option')
   blank.value = ''
-  blank.textContent = options.length ? '-- Choose a top audience-rated item --' : `No top items with ${placeholderValueLabel(source)} IDs found`
+  blank.textContent = lookupError || (options.length ? '-- Choose a top audience-rated item --' : `No top items with ${placeholderValueLabel(source)} IDs found`)
   select.appendChild(blank)
 
   if (savedValue && !seen.has(savedValue)) {
     const saved = document.createElement('option')
     saved.value = savedValue
-    saved.textContent = `Saved ${placeholderValueLabel(source)} ID: ${savedValue}`
+    saved.textContent = lookupError
+      ? `Saved ${placeholderValueLabel(source)} ID: ${savedValue} (not revalidated)`
+      : `Saved ${placeholderValueLabel(source)} ID: ${savedValue}`
     saved.dataset.lookupLabel = ''
     select.appendChild(saved)
   }
@@ -221,17 +223,31 @@ function loadSeparatorPlaceholderPicklists (wrapper) {
         if (!response.ok) throw new Error(`Top item lookup failed (${response.status})`)
         return response.json()
       })
-      .then(data => Array.isArray(data?.items) ? data.items : [])
+      .then(data => {
+        const items = Array.isArray(data?.items) ? data.items : []
+        if (data?.status && data.status !== 'success') {
+          return {
+            items,
+            error: String(data?.message || 'Top item lookup unavailable. Check Plex and try again.').trim()
+          }
+        }
+        return { items, error: '' }
+      })
       .catch(error => {
-        console.error('[Separator Placeholder] Failed to load top items:', error)
-        return []
+        console.warn('[Separator Placeholder] Failed to load top items:', error)
+        return {
+          items: [],
+          error: 'Top item lookup unavailable. Check Plex and try again.'
+        }
       })
     separatorPlaceholderPicklistCache.set(cacheKey, request)
   }
 
-  request.then(items => {
+  request.then(result => {
+    const items = Array.isArray(result) ? result : (Array.isArray(result?.items) ? result.items : [])
+    const lookupError = Array.isArray(result) ? '' : String(result?.error || '').trim()
     wrapper.querySelectorAll('.separator-placeholder-picklist').forEach(select => {
-      setPlaceholderPicklistOptions(select, items)
+      setPlaceholderPicklistOptions(select, items, lookupError)
     })
   })
 }

--- a/tests/js/modules/separatorPreview.test.js
+++ b/tests/js/modules/separatorPreview.test.js
@@ -17,6 +17,7 @@ import * as separatorPreview from '../../../static/local-js/modules/separatorPre
 // Silence chatty debug output from the DOM manipulators.
 vi.spyOn(console, 'log').mockImplementation(() => {})
 vi.spyOn(console, 'error').mockImplementation(() => {})
+vi.spyOn(console, 'warn').mockImplementation(() => {})
 
 afterEach(() => {
   document.body.innerHTML = ''
@@ -240,5 +241,42 @@ describe('separatorPreview: smoke tests', () => {
     expect(tmdbField.classList.contains('d-none')).toBe(false)
     const tmdbOptions = Array.from(document.getElementById('tmdb_picklist').querySelectorAll('option')).map(option => option.value)
     expect(tmdbOptions).toContain('603')
+  })
+
+  it('initializeOverlays: keeps saved picklist value when top item lookup is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        status: 'lookup_unavailable',
+        items: [],
+        message: 'Unable to load top audience-rated Plex items.'
+      })
+    }))
+    document.body.innerHTML = `
+      <form id="configForm">
+        <select name="mov-library_1-template_variables[use_separator]">
+          <option value="gold" selected>gold</option>
+        </select>
+        <div data-separator-placeholder-wrapper="true" data-library-id="Unavailable Movies" data-library-prefix="mov-library_1" data-library-type="movie">
+          <select class="separator-placeholder-source">
+            <option value="imdb" selected>IMDb ID</option>
+            <option value="tmdb_movie">TMDb Movie ID</option>
+          </select>
+          <div class="separator-placeholder-field" data-placeholder-source="imdb">
+            <select id="imdb_picklist" class="separator-placeholder-picklist" data-separator-placeholder-input="imdb" data-separator-placeholder-value="tt0108052"></select>
+            <input type="hidden" id="imdb_picklist__lookup_labels">
+          </div>
+        </div>
+      </form>
+    `
+
+    separatorPreview.initializeOverlays('mov-library_1', true)
+    await flushAsyncWork()
+
+    const select = document.getElementById('imdb_picklist')
+    const options = Array.from(select.querySelectorAll('option')).map(option => option.textContent)
+    expect(select.value).toBe('tt0108052')
+    expect(options[0]).toBe('Unable to load top audience-rated Plex items.')
+    expect(options[1]).toContain('not revalidated')
   })
 })

--- a/tests/test_separator_placeholder_route.py
+++ b/tests/test_separator_placeholder_route.py
@@ -1,0 +1,49 @@
+from blueprints import library_routes
+
+
+def _plex_settings():
+    return {
+        "plex": {
+            "tmp_movie_libraries": "Movies",
+            "tmp_show_libraries": "TV Shows",
+        }
+    }
+
+
+def test_top_item_route_returns_controlled_failure(client, monkeypatch):
+    library_routes._top_placeholder_cache.clear()
+    monkeypatch.setattr(library_routes.persistence, "retrieve_settings", lambda section: _plex_settings())
+
+    def fail_lookup(*_args, **_kwargs):
+        raise RuntimeError("Plex search failed")
+
+    monkeypatch.setattr(library_routes.helpers, "get_top_imdb_items", fail_lookup)
+
+    response = client.get("/get_top_imdb_items/Movies?type=movie")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "lookup_unavailable"
+    assert payload["items"] == []
+    assert "Plex" in payload["message"]
+
+
+def test_top_item_route_caches_successful_lookup(client, monkeypatch):
+    library_routes._top_placeholder_cache.clear()
+    monkeypatch.setattr(library_routes.persistence, "retrieve_settings", lambda section: _plex_settings())
+    calls = {"count": 0}
+
+    def lookup(*_args, **_kwargs):
+        calls["count"] += 1
+        return ([{"title": "Movie", "imdb_id": "tt123", "tmdb_movie": "1", "tvdb_show": ""}], None)
+
+    monkeypatch.setattr(library_routes.helpers, "get_top_imdb_items", lookup)
+
+    first = client.get("/get_top_imdb_items/Movies?type=movie")
+    second = client.get("/get_top_imdb_items/Movies?type=movie")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert "cached" not in first.get_json()
+    assert second.get_json()["cached"] is True
+    assert calls["count"] == 1


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
Hardens separator placeholder lookup so remote/flaky Plex top-item searches do not break the Libraries page or clear existing separator placeholder values.

**Changes**
- Wrapped `/get_top_imdb_items/<library>` Plex lookup in controlled error handling.
- Return `lookup_unavailable` with an empty item list instead of raw `500` when Plex search fails.
- Log the failed Plex lookup with library/type context for troubleshooting.
- Cache successful top-item lookups for 10 minutes per library/type to reduce repeated remote Plex calls.
- Keep separator placeholder UI picklist-only; no manual free-text input was added.
- Preserve existing saved placeholder IDs when lookup fails, labeling them as not revalidated instead of clearing them.
- Updated frontend handling so lookup failures show a controlled unavailable state rather than a console error.

**Validation**
- `venv\Scripts\python.exe -m pytest tests\test_separator_placeholder_route.py tests\test_plex_helpers.py`
- `npx vitest run tests\js\modules\separatorPreview.test.js`
- `npx standard static\local-js\modules\separatorPreview.js tests\js\modules\separatorPreview.test.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
