### PR TITLE
plex page fixes

### DIFF
--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -112,7 +112,10 @@ def validate_plex():
     except Exception as e:
         helpers.ts_log(f"Failed to fetch Plex telemetry during validation: {e}", level="WARNING")
 
-    merged = {**plex_data, **telemetry}
+    # Keep validator fields authoritative for the Plex page contract. Telemetry
+    # uses display strings like "2048 MB", while the page's db_cache input needs
+    # the numeric value returned by validate_plex_server.
+    merged = {**telemetry, **plex_data}
     return jsonify(merged)
 
 

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -4,6 +4,7 @@ import secrets
 import json
 import datetime
 import copy
+import re
 
 from flask import current_app as app
 from flask import has_request_context, session
@@ -25,6 +26,22 @@ TRANSIENT_FORM_FIELDS = {
     "newConfigName",
     "importMode",
 }
+
+
+def _normalize_plex_db_cache_value(value):
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return ""
+    match = re.search(r"\d+", text)
+    if match:
+        return int(match.group(0))
+    return value
 
 
 def _get_iso_reference_lists():
@@ -152,6 +169,9 @@ def clean_form_data(form_data):
             clean_data[key] = None
 
         elif isinstance(value, str):
+            if key == "plex_db_cache":
+                clean_data[key] = _normalize_plex_db_cache_value(value)
+                continue
             if key.endswith("template_overlay_runtimes[text]") and value == "":
                 clean_data[key] = ""
                 continue
@@ -478,6 +498,11 @@ def retrieve_settings(target):
             if isinstance(auth, dict) and "force_refresh" in auth and "force_refresh" not in section:
                 section["force_refresh"] = auth.pop("force_refresh")
             section.setdefault("force_refresh", False)
+
+    if source_name == "plex":
+        section = data[source_name]
+        if isinstance(section, dict) and "db_cache" in section:
+            section["db_cache"] = _normalize_plex_db_cache_value(section.get("db_cache"))
 
     # Only modify if the target is 'libraries'
     if source_name == "libraries":

--- a/modules/process_maintenance.py
+++ b/modules/process_maintenance.py
@@ -45,6 +45,8 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 
+from flask import has_request_context
+
 from modules import database, helpers, persistence
 from modules.process_control_state import MAINTENANCE_STATE, MAINTENANCE_STATE_LOCK
 from modules.process_pending_start import peek_pending_kometa_start
@@ -83,11 +85,11 @@ def get_maintenance_window_from_db(config_name=None):
         _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex_telemetry")
         telemetry = data.get("plex_telemetry", {}) if isinstance(data, dict) else {}
         window_str = telemetry.get("maintenance_window")
-        if not window_str:
+        if not window_str and has_request_context():
             legacy_telemetry = persistence.retrieve_settings("plex_telemetry")
             if isinstance(legacy_telemetry, dict):
                 window_str = legacy_telemetry.get("plex_telemetry", {}).get("maintenance_window")
-        if not window_str:
+        if not window_str and has_request_context():
             legacy_plex = persistence.retrieve_settings("010-plex")
             if isinstance(legacy_plex, dict):
                 window_str = legacy_plex.get("plex", {}).get("telemetry", {}).get("maintenance_window")
@@ -105,7 +107,9 @@ def get_plex_credentials_from_db(config_name=None):
     if not config_name:
         return None, None
     try:
-        _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex")
+        validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex")
+        if validated is not True:
+            return None, None
         plex_data = data.get("plex", {}) if isinstance(data, dict) else {}
         plex_url = plex_data.get("url") or plex_data.get("plex_url")
         plex_token = plex_data.get("token") or plex_data.get("plex_token")

--- a/static/local-js/010-plex.js
+++ b/static/local-js/010-plex.js
@@ -7,6 +7,11 @@ import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 const hiddenSection = document.getElementById('hidden')
 const plexDbCache = document.getElementById('plexDbCache')
 
+function normalizeDbCacheValue (value) {
+  const match = String(value ?? '').match(/\d+/)
+  return match ? match[0] : ''
+}
+
 ;(function showSavedSectionsIfValidated () {
   const validated = document.getElementById('plex_validated')?.value.toLowerCase() === 'true'
   if (validated) {
@@ -49,15 +54,16 @@ function applyPlexResponse (data) {
   // validate round-trip, and reading the latest value is arguably more
   // correct (it reflects what the user actually wants right now).
   const dbCacheInput = document.getElementById('plex_db_cache')
-  const currentDbCache = dbCacheInput ? dbCacheInput.value : ''
-  const serverDbCache = data.db_cache
+  const currentDbCache = dbCacheInput ? normalizeDbCacheValue(dbCacheInput.value) : ''
+  const serverDbCache = normalizeDbCacheValue(data.db_cache)
+  if (!serverDbCache) return
 
   if (plexDbCache) {
     plexDbCache.textContent = 'Database cache value retrieved from server is: ' + serverDbCache + ' MB'
     plexDbCache.style.color = '#75b798'
     plexDbCache.style.display = 'block'
 
-    if (Number(currentDbCache) !== serverDbCache) {
+    if (currentDbCache && currentDbCache !== serverDbCache) {
       plexDbCache.textContent += '.\nWarning: The value in the input box (' + currentDbCache + ' MB) does not match the value retrieved from the server (' + serverDbCache + ' MB).'
       plexDbCache.style.color = '#ea868f'
     }

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4305,6 +4305,7 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
 
     telemetry = {
         "server_name": "Test Plex",
+        "db_cache": "2048 MB",
         "maintenance_window": "02:00 – 05:00",
         "platform": "Windows",
     }
@@ -4321,8 +4322,40 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
     assert resp.status_code == 200
     payload = resp.get_json()
     assert payload["validated"] is True
+    assert payload["db_cache"] == 2048
     assert payload["maintenance_window"] == "02:00 – 05:00"
     assert calls == {"save_settings": 1, "save_section": 1}
+
+
+def test_plex_page_normalizes_formatted_db_cache_on_load(client, isolated_config_dir):
+    from modules import database
+
+    config_name = "pytest_plex_formatted_db_cache"
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    database.save_section_data(
+        name=config_name,
+        section="plex",
+        validated=True,
+        user_entered=True,
+        data={
+            "validated": True,
+            "plex": {
+                "url": "http://plex.local:32400",
+                "token": "token",
+                "db_cache": "2048 MB",
+                "timeout": 60,
+            },
+        },
+    )
+
+    resp = client.get("/step/010-plex")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    match = re.search(r'id="plex_db_cache"[^>]+value="([^"]*)"', html)
+    assert match is not None
+    assert match.group(1) == "2048"
 
 
 def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):

--- a/tests/test_more_paths.py
+++ b/tests/test_more_paths.py
@@ -1,5 +1,7 @@
 import time
 
+from modules import process_maintenance
+
 
 class _FakeProc:
     def __init__(self, pid, cmdline):
@@ -30,6 +32,45 @@ def _reset_maintenance_state(qs_module):
                 "window_unavailable_since": None,
             }
         )
+
+
+def test_maintenance_window_db_lookup_skips_request_settings_outside_request(monkeypatch):
+    calls = {"legacy": 0}
+
+    def fake_retrieve_section_data(name, section):
+        assert name == "bad_plex_cfg"
+        assert section == "plex_telemetry"
+        return False, True, {"plex_telemetry": {}}
+
+    def fail_legacy_lookup(section):
+        calls["legacy"] += 1
+        raise RuntimeError("Working outside of request context.")
+
+    monkeypatch.setattr(process_maintenance.database, "retrieve_section_data", fake_retrieve_section_data)
+    monkeypatch.setattr(process_maintenance.persistence, "retrieve_settings", fail_legacy_lookup)
+
+    assert process_maintenance.get_maintenance_window_from_db("bad_plex_cfg") == (None, None, None)
+    assert calls["legacy"] == 0
+
+
+def test_maintenance_live_lookup_skips_unvalidated_plex_credentials(monkeypatch):
+    calls = {"plex": 0}
+
+    def fake_retrieve_section_data(name, section):
+        assert name == "bad_plex_cfg"
+        assert section == "plex"
+        return False, True, {"plex": {"url": "http://192.168.2.242:32400", "token": "bad"}}
+
+    def fail_live_lookup(*_args, **_kwargs):
+        calls["plex"] += 1
+        raise AssertionError("invalid Plex credentials should not be polled by maintenance refresh")
+
+    monkeypatch.setattr(process_maintenance.database, "retrieve_section_data", fake_retrieve_section_data)
+    monkeypatch.setattr(process_maintenance.helpers, "get_plex_maintenance_hours", fail_live_lookup)
+
+    assert process_maintenance.get_plex_credentials_from_db("bad_plex_cfg") == (None, None)
+    assert process_maintenance.get_maintenance_window_live("bad_plex_cfg") == (None, None, None)
+    assert calls["plex"] == 0
 
 
 def test_stop_kometa_non_kometa_pid_warning(tmp_path, client, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**

Fixes Plex validation and maintenance-window edge cases that caused confusing UI state and backend churn when Plex credentials were bad or telemetry returned formatted values.

**Changes**

- Prevented background maintenance polling from using unvalidated Plex credentials.
- Stopped request-context-only legacy settings reads from running in the background maintenance loop.
- Fixed `/validate_plex` merge order so numeric validator fields stay authoritative over telemetry display strings.
- Normalized Plex `db_cache` values like `2048 MB` back to numeric `2048` for saved/retrieved settings.
- Hardened Plex page JS so cache-size warnings and number inputs handle either numeric or formatted backend values.
- Added regression tests for invalid Plex maintenance polling, request-context fallback safety, and formatted Plex cache-size handling.

**Testing**

- `venv\Scripts\python.exe -m pytest tests\test_more_paths.py`
- `venv\Scripts\python.exe -m pytest tests\test_start_stop.py`
- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k "validate_plex or refresh_plex_libraries"`
- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k "validate_plex or plex_page_normalizes"`
- `npm run lint:eslint -- static/local-js/010-plex.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
