### PR TITLE
improve separator preview and green/red bars

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1886,6 +1886,11 @@ label {
     /* Space text from border */
 }
 
+html[data-qs-template="025-libraries"] .accordion-header.selected {
+    border-left: 0 !important;
+    padding-left: 0 !important;
+}
+
 /* Add a gray left border when an accordion has unknown items */
 .accordion-header.unknown {
     border-left: 4px solid #6c757d !important;
@@ -2092,6 +2097,15 @@ fieldset:disabled .btn {
     box-shadow: inset 7px 0 0 rgba(var(--accent-color), 0.08);
     background: linear-gradient(90deg, rgba(var(--accent-color), 0.08), transparent 34%);
     padding-left: 0.45rem;
+}
+
+.qs-playlist-key-toggle-card {
+    padding-left: 3.25rem;
+    padding-right: 1rem;
+}
+
+.qs-playlist-key-toggle-card .form-check-input {
+    flex: 0 0 auto;
 }
 
 .input-group.template-variable-field-has-override > .input-group-text:first-child,

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -37,6 +37,7 @@ let activeLibraryId = null
 let loadRequestId = 0
 let allowNextStepNavigation = false
 let lookupLabelAutosaveTimer = null
+let libraryCardInitializing = 0
 
 function setLibrariesButtonBusy (button, busy, label = 'Working...') {
   if (!button) return
@@ -6020,6 +6021,60 @@ function refreshPickerLabels () {
   updateConfiguredCounts()
 }
 
+function isLibraryCardInitializing (card) {
+  return libraryCardInitializing > 0 || card?.dataset?.libraryInitializing === 'true'
+}
+
+function setLibraryIncludedFromUserEdit (card, libraryId) {
+  if (!libraryPicker || !card || !libraryId) return
+  const toggle = card.querySelector('.include-library-toggle')
+  if (!toggle || toggle.checked || toggle.disabled) return
+  const targetInputId = toggle.dataset.targetInput
+  const targetInput = targetInputId ? document.getElementById(targetInputId) : null
+  const option = libraryPicker.querySelector(`option[value="${libraryId}"]`)
+  toggle.checked = true
+  if (targetInput) targetInput.value = toggle.value
+  if (option) option.dataset.configured = 'true'
+  toggle.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+function shouldAutoIncludeLibraryEditTarget (target) {
+  if (!target || !target.closest) return false
+  if (target.closest('[data-resetting="true"]')) return false
+  if (target.closest('.external-yaml-editor-modal')) return false
+  if (target.matches('.include-library-toggle, .library-advanced-toggle, .accordion-button')) return false
+  if (target.matches('[data-bs-toggle="collapse"], [data-bs-toggle="modal"], [data-bs-dismiss]')) return false
+  if (target.matches('[data-toggle-secret-visibility], [data-collection-details-toggle], [data-overlay-details-toggle]')) return false
+  if (target.matches('[data-external-yaml-edit], [data-external-yaml-create], [data-external-yaml-choose]')) return false
+
+  if (target.matches('[data-playlist-key-toggle]')) return true
+  if (target.matches('[data-template-string-add], [data-template-mapping-add], [data-add-asset-directory]')) return true
+  if (target.matches('[data-add-collection-file], [data-add-metadata-file], [data-add-overlay-file], [data-add-playlist-file]')) return true
+  if (target.matches('[data-remove-collection-file], [data-remove-metadata-file], [data-remove-overlay-file], [data-remove-playlist-file]')) return true
+  if (target.matches('.library-remove-asset-directory')) return true
+
+  const field = target.matches('input, select, textarea') ? target : target.closest('input, select, textarea')
+  if (!field || field.disabled || !field.name) return false
+  if (field.type === 'file') return false
+  if (field.type === 'hidden' && isInternalTemplateMetadataField(field)) return false
+  if (field.dataset?.skipYaml === 'true' || field.dataset?.skipOverrideCount === 'true') return false
+  if (field.classList.contains('include-library-toggle')) return false
+  return true
+}
+
+function wireAutoIncludeOnLibraryEdits (card, libraryId) {
+  if (!card || card.dataset.autoIncludeOnEditBound === 'true') return
+  const maybeInclude = event => {
+    if (!event.isTrusted || isLibraryCardInitializing(card)) return
+    if (!shouldAutoIncludeLibraryEditTarget(event.target)) return
+    setLibraryIncludedFromUserEdit(card, libraryId)
+  }
+  card.addEventListener('input', maybeInclude)
+  card.addEventListener('change', maybeInclude)
+  card.addEventListener('click', maybeInclude)
+  card.dataset.autoIncludeOnEditBound = 'true'
+}
+
 function wireIncludeToggle (card, libraryId) {
   if (!libraryPicker || !card) return
   const toggle = card.querySelector('.include-library-toggle')
@@ -6033,7 +6088,7 @@ function wireIncludeToggle (card, libraryId) {
   function syncStatus () {
     if (!status) return
     const included = toggle.checked
-    status.textContent = included ? 'Included in YAML' : 'Excluded from YAML'
+    status.textContent = included ? 'Included in config' : 'Excluded from config'
     status.classList.toggle('bg-success', included)
     status.classList.toggle('bg-secondary', !included)
     if (playlistToggle) {
@@ -6341,81 +6396,89 @@ function moveCurrentToCache () {
 }
 
 function initializeLibraryCardControls (card, libraryId) {
-  initPlaylistKeyToggleGroups(card)
-  initPlaylistUserPickers(card)
-  initPlaylistFilesEditors(card)
-  initSecretVisibilityToggles(card)
-  syncHiddenCheckboxPairs(card)
-  wireIncludeToggle(card, libraryId)
-  wireAdvancedToggle(card)
-  wireLibraryServiceValidationButtons(card)
-  refreshPickerLabels()
-  initTooltips(card)
-  sortLanguageSelects(card)
-  setupOverlayLanguageWeightBuilders(card)
-  initNumericOnlyInputs(card)
-  setupCollectionTemplateFieldRules(card)
-  initStylePreviewGrids(card)
-  initRelativeYearInputs(card)
-  initScheduleBuilders(card)
-  initLibraryAssetDirectoryInputs(card)
-  wireOffsetReset(card)
-  wireRatingsOffsetSync(card)
-  initSortablesInScope(card)
-  setupCustomStringListHandlers('mass_genre_update', card)
-  setupCustomStringListHandlers('radarr_remove_by_tag', card)
-  setupCustomStringListHandlers('sonarr_remove_by_tag', card)
-  setupCustomStringListHandlers('metadata_backup', card)
-  setupCustomStringListHandlers('mass_content_rating_update', card)
-  setupCustomStringListHandlers('mass_genre_mapper', card)
-  setupTemplateStringListHandlers(card)
-  setupTemplateMappingListHandlers(card)
-  setupMappingListHandlers('genre_mapper', card)
-  setupMappingListHandlers('content_rating_mapper', card)
-  wireOverlayDetailToggles(card)
-  wireOverlayVariableSectionToggles(card)
-  wireCollectionDetailToggles(card)
-  wireCollectionVariableSectionToggles(card)
-  setupParentChildToggleVisibility(card)
-  if (typeof setupParentChildToggleSync === 'function') {
-    setupParentChildToggleSync()
+  libraryCardInitializing += 1
+  if (card) card.dataset.libraryInitializing = 'true'
+  try {
+    initPlaylistKeyToggleGroups(card)
+    initPlaylistUserPickers(card)
+    initPlaylistFilesEditors(card)
+    initSecretVisibilityToggles(card)
+    syncHiddenCheckboxPairs(card)
+    wireIncludeToggle(card, libraryId)
+    wireAutoIncludeOnLibraryEdits(card, libraryId)
+    wireAdvancedToggle(card)
+    wireLibraryServiceValidationButtons(card)
+    refreshPickerLabels()
+    initTooltips(card)
+    sortLanguageSelects(card)
+    setupOverlayLanguageWeightBuilders(card)
+    initNumericOnlyInputs(card)
+    setupCollectionTemplateFieldRules(card)
+    initStylePreviewGrids(card)
+    initRelativeYearInputs(card)
+    initScheduleBuilders(card)
+    initLibraryAssetDirectoryInputs(card)
+    wireOffsetReset(card)
+    wireRatingsOffsetSync(card)
+    initSortablesInScope(card)
+    setupCustomStringListHandlers('mass_genre_update', card)
+    setupCustomStringListHandlers('radarr_remove_by_tag', card)
+    setupCustomStringListHandlers('sonarr_remove_by_tag', card)
+    setupCustomStringListHandlers('metadata_backup', card)
+    setupCustomStringListHandlers('mass_content_rating_update', card)
+    setupCustomStringListHandlers('mass_genre_mapper', card)
+    setupTemplateStringListHandlers(card)
+    setupTemplateMappingListHandlers(card)
+    setupMappingListHandlers('genre_mapper', card)
+    setupMappingListHandlers('content_rating_mapper', card)
+    wireOverlayDetailToggles(card)
+    wireOverlayVariableSectionToggles(card)
+    wireCollectionDetailToggles(card)
+    wireCollectionVariableSectionToggles(card)
+    setupParentChildToggleVisibility(card)
+    if (typeof setupParentChildToggleSync === 'function') {
+      setupParentChildToggleSync()
+    }
+    setupAddMissingDependencies(card)
+    wireOverlayTemplateSections(card)
+    wireCollectionTemplateSections(card)
+    wireOverlayVariableSections(card)
+    wireCollectionVariableSections(card)
+    wireLibraryOverrideScopes(card)
+    wireLazyCollectionGroups(card)
+    updateLazySectionOverrideSummaries(card)
+    refreshTemplateOverrideState(card)
+    wireOffsetReset(card)
+    if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
+      OverlayHandler.initializeOverlayBoards(card)
+    }
+    if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayPositioners) {
+      OverlayHandler.initializeOverlayPositioners(card)
+    }
+    if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeJumpButtons) {
+      OverlayHandler.initializeJumpButtons(card)
+    }
+    if (typeof EventHandler !== 'undefined') {
+      EventHandler.attachLibraryListeners(card)
+    }
+    if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
+      PathValidation.attach(card)
+    }
+    if (typeof URLValidation !== 'undefined' && URLValidation.attach) {
+      URLValidation.attach(card)
+    }
+    if (typeof ValidationHandler !== 'undefined' && ValidationHandler.updateValidationState) {
+      ValidationHandler.updateValidationState()
+    }
+    wireFontUploads(card)
+    wireFontPreviews(card)
+    wireFontPickerButtons(card)
+    bindDependencyRequirementHintLiveRefresh(card)
+    scheduleDependencyRequirementHintRefresh(0)
+  } finally {
+    libraryCardInitializing = Math.max(0, libraryCardInitializing - 1)
+    if (card) delete card.dataset.libraryInitializing
   }
-  setupAddMissingDependencies(card)
-  wireOverlayTemplateSections(card)
-  wireCollectionTemplateSections(card)
-  wireOverlayVariableSections(card)
-  wireCollectionVariableSections(card)
-  wireLibraryOverrideScopes(card)
-  wireLazyCollectionGroups(card)
-  updateLazySectionOverrideSummaries(card)
-  refreshTemplateOverrideState(card)
-  wireOffsetReset(card)
-  if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
-    OverlayHandler.initializeOverlayBoards(card)
-  }
-  if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayPositioners) {
-    OverlayHandler.initializeOverlayPositioners(card)
-  }
-  if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeJumpButtons) {
-    OverlayHandler.initializeJumpButtons(card)
-  }
-  if (typeof EventHandler !== 'undefined') {
-    EventHandler.attachLibraryListeners(card)
-  }
-  if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
-    PathValidation.attach(card)
-  }
-  if (typeof URLValidation !== 'undefined' && URLValidation.attach) {
-    URLValidation.attach(card)
-  }
-  if (typeof ValidationHandler !== 'undefined' && ValidationHandler.updateValidationState) {
-    ValidationHandler.updateValidationState()
-  }
-  wireFontUploads(card)
-  wireFontPreviews(card)
-  wireFontPickerButtons(card)
-  bindDependencyRequirementHintLiveRefresh(card)
-  scheduleDependencyRequirementHintRefresh(0)
 }
 
 function wireLazyLibrarySections (card) {
@@ -6629,6 +6692,20 @@ function restorePreviousLibrarySelection (previousLibraryId) {
 
 wireFontPickerModal()
 
+function isUncheckedTemplateParentToggle (field) {
+  if (!field || field.type !== 'checkbox' || field.dataset?.radioGroup === 'true') return false
+  if (field.dataset?.default !== undefined) return false
+  return !field.checked && Boolean(field.matches('[data-template-group], .overlay-toggle'))
+}
+
+function shouldOmitDefaultFieldFromLibraryPayload (field) {
+  if (!field || !field.dataset || field.dataset.default === undefined) return false
+  if (field.classList?.contains('include-library-toggle') || field.classList?.contains('playlist-library-toggle')) return false
+  if (String(field.name || '').endsWith('-library') || String(field.name || '').endsWith('-playlist')) return false
+  if (isInternalTemplateMetadataField(field)) return false
+  return !isCollectionSectionFieldConfigured([field])
+}
+
 function buildPayloadFromCard (card) {
   const payload = {}
   const libraryId = activeLibraryId || String(card?.querySelector('[name]')?.name || '').split('-')[0]
@@ -6682,6 +6759,8 @@ function buildPayloadFromCard (card) {
     if (el.type === 'hidden' && checkboxNames.has(String(el.name || '').trim())) {
       return
     }
+    if (isUncheckedTemplateParentToggle(el)) return
+    if (shouldOmitDefaultFieldFromLibraryPayload(el)) return
 
     if (el.tagName === 'SELECT' && el.multiple) {
       payload[el.name] = Array.from(el.selectedOptions).map(opt => opt.value)
@@ -6691,7 +6770,10 @@ function buildPayloadFromCard (card) {
     if (el.type === 'checkbox') {
       if (el.dataset && el.dataset.radioGroup === 'true') {
         if (!Object.prototype.hasOwnProperty.call(payload, el.name)) {
-          payload[el.name] = radioCheckboxValues.get(el.name) || ''
+          const selectedValue = radioCheckboxValues.get(el.name) || ''
+          if (selectedValue) {
+            payload[el.name] = selectedValue
+          }
         }
         return
       }
@@ -6719,6 +6801,7 @@ function buildPayloadFromCard (card) {
       if (!el.name || el.disabled) return
       if (card.contains(el)) return
       if (checkboxNames.has(String(el.name || '').trim())) return
+      if (shouldOmitDefaultFieldFromLibraryPayload(el)) return
       payload[el.name] = el.value ?? ''
     })
   }
@@ -9124,11 +9207,20 @@ function isTrueDatasetValue (value) {
   return String(value || '').trim().toLowerCase() === 'true'
 }
 
+function checkboxCheckedDiffersFromDefault (field) {
+  if (!field || (field.type !== 'checkbox' && field.type !== 'radio')) return false
+  const defaultRaw = String(field.dataset?.default || '').trim().toLowerCase()
+  if (!defaultRaw) return field.checked
+  const normalizedValue = String(field.value || 'true').trim().toLowerCase()
+  const defaultChecked = defaultRaw === 'true' || defaultRaw === normalizedValue
+  return field.checked !== defaultChecked
+}
+
 function isTemplateGroupActiveForSignal (group) {
   if (!group) return false
   const toggle = group.querySelector('input[type="checkbox"][data-template-group], input[type="radio"][data-template-group], .overlay-toggle')
   if (!toggle) return false
-  return toggle.checked
+  return checkboxCheckedDiffersFromDefault(toggle)
 }
 
 function getLazyElementSignalCount (element) {
@@ -9341,13 +9433,29 @@ function getLibrarySectionOverrideTotal (card, advanced) {
   }, 0)
 }
 
+function getLibraryCardOverrideTotal (card) {
+  if (!card) return 0
+  return getLibrarySectionOverrideTotal(card, false) + getLibrarySectionOverrideTotal(card, true)
+}
+
+function getLibraryCardHasConfigurationSignal (card) {
+  if (!card) return false
+  if (getLibraryCardOverrideTotal(card) > 0) return true
+  if (card.querySelector('.template-variable-section-has-overrides, .template-variable-field-has-override')) return true
+  if (card.querySelector('[data-library-lazy-section][data-lazy-active="true"], [data-collection-group-lazy-collapse][data-lazy-active="true"]')) return true
+  return Array.from(card.querySelectorAll('[data-library-lazy-section][data-lazy-override-count], [data-collection-group-lazy-collapse][data-lazy-override-count]')).some(element => {
+    const count = Number(element.dataset.lazyOverrideCount || '0') || 0
+    return count > 0
+  })
+}
+
 function updateLibraryAggregateOverrideSummaries (card) {
   if (!card) return
   const coreCount = getLibrarySectionOverrideTotal(card, false)
   const advancedCount = getLibrarySectionOverrideTotal(card, true)
   setOverrideSummaryBadge(card.querySelector('[data-library-core-summary]'), coreCount)
   setOverrideSummaryBadge(card.querySelector('[data-library-advanced-summary]'), advancedCount)
-  setOverrideSummaryBadge(card.querySelector('[data-library-total-summary]'), coreCount + advancedCount)
+  setOverrideSummaryBadge(card.querySelector('[data-library-total-summary]'), getLibraryCardOverrideTotal(card))
 }
 
 function updateTemplateGroupOverrideSummary (section) {
@@ -9386,6 +9494,11 @@ function refreshTemplateOverrideState (scope) {
   if (root.matches?.('.library-settings-card')) {
     updateLibraryAggregateOverrideSummaries(root)
   }
+}
+
+window.QSLibraryValidation = {
+  hasConfiguredSignal: getLibraryCardHasConfigurationSignal,
+  refreshSummaries: refreshTemplateOverrideState
 }
 
 function getLibraryOverrideScopes (root) {

--- a/static/local-js/modules/accordionHighlights.js
+++ b/static/local-js/modules/accordionHighlights.js
@@ -54,6 +54,46 @@ export function hasLibraryFileEntries (accordionBody) {
   return Boolean(raw && raw !== '[]')
 }
 
+function isLibrariesTemplate () {
+  return String(window.QS_CURRENT_TEMPLATE || document.documentElement?.dataset?.qsTemplate || '').trim() === '025-libraries'
+}
+
+function clearLegacyLibraryAccordionSelections () {
+  document.querySelectorAll('.accordion-header.selected').forEach(header => {
+    header.classList.remove('selected')
+  })
+}
+
+function isHiddenForAccordionHighlight (field) {
+  return !field ||
+    field.disabled ||
+    field.type === 'hidden' ||
+    field.hidden ||
+    field.closest('.visually-hidden, .d-none, [hidden]')
+}
+
+function checkboxDiffersFromDefault (field) {
+  if (!field || (field.type !== 'checkbox' && field.type !== 'radio')) return false
+  const defaultRaw = String(field.dataset?.default || '').trim().toLowerCase()
+  if (!defaultRaw) return field.checked
+  const normalizedValue = String(field.value || 'true').trim().toLowerCase()
+  const defaultChecked = defaultRaw === 'true' || defaultRaw === normalizedValue
+  return field.checked !== defaultChecked
+}
+
+function fieldHasNonDefaultValue (field) {
+  if (isHiddenForAccordionHighlight(field)) return false
+  if (field.dataset?.skipOverrideCount === 'true' || field.dataset?.skipYaml === 'true') return false
+  if (field.type === 'checkbox' || field.type === 'radio') return checkboxDiffersFromDefault(field)
+  const value = String(field.value || '').trim().toLowerCase()
+  if (!value || value === 'none') return false
+  if (field.dataset?.default !== undefined) {
+    const defaultValue = String(field.dataset.default || '').trim().toLowerCase()
+    return value !== defaultValue
+  }
+  return true
+}
+
 /**
  * Walk up the ancestor chain from `element` adding `.selected` to each
  * `.accordion-header` we pass through. Stops early on:
@@ -67,6 +107,7 @@ export function hasLibraryFileEntries (accordionBody) {
  * level further up.
  */
 export function highlightParentAccordions (element) {
+  if (isLibrariesTemplate()) return
   while (element) {
     const parentAccordion = element.closest('.accordion-item')
     if (!parentAccordion) break
@@ -119,6 +160,10 @@ export function highlightParentAccordions (element) {
  * Skips `.accordion-item` elements whose id contains `-previewOverlays`.
  */
 export function removeHighlightIfEmpty (element) {
+  if (isLibrariesTemplate()) {
+    clearLegacyLibraryAccordionSelections()
+    return
+  }
   if (!element) return
   const accordionItem = element.closest('.accordion-item')
   if (!accordionItem) return
@@ -133,12 +178,11 @@ export function removeHighlightIfEmpty (element) {
     return
   }
 
-  const hasSelections = accordionBody?.querySelector(
-    "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
-    "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
-    "select[data-user-modified='true'] option:checked:not([value='']):not([value='none']), " +
-    '.list-group li'
-  ) !== null
+  const hasSelections = Array.from(accordionBody?.querySelectorAll(
+    "input[type='checkbox']:not(.readonly-toggle):not(.template-child-toggle), " +
+    "input[type='radio'], " +
+    "select[data-user-modified='true']"
+  ) || []).some(fieldHasNonDefaultValue) || accordionBody?.querySelector('.list-group li') !== null
   const bodyHasLibraryFileEntries = hasLibraryFileEntries(accordionBody)
 
   // If this accordion has collection toggles and none are enabled, force no highlight.
@@ -170,6 +214,10 @@ export function removeHighlightIfEmpty (element) {
  * Preview-Overlays accordions never highlight themselves.
  */
 export function updateAccordionHighlights () {
+  if (isLibrariesTemplate()) {
+    clearLegacyLibraryAccordionSelections()
+    return
+  }
   console.log('\u{1F50D} [DEBUG] Updating accordion highlights...')
 
   document.querySelectorAll('.accordion-item').forEach((accordion) => {
@@ -191,11 +239,10 @@ export function updateAccordionHighlights () {
 
     if (accordionBody) {
       // 1. Check for directly selected inputs (checkboxes, radios, list selections)
-      isCheckedOrSelected = accordionBody.querySelector(
-        "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
-        "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
-        '.list-group li'
-      ) !== null
+      isCheckedOrSelected = Array.from(accordionBody.querySelectorAll(
+        "input[type='checkbox']:not(.readonly-toggle):not(.template-child-toggle), " +
+        "input[type='radio']"
+      )).some(fieldHasNonDefaultValue) || accordionBody.querySelector('.list-group li') !== null
 
       // 1b. Any non-empty inputs/selects also count as activity
       // Suppress value-based highlighting for true Collection/Overlay sections,
@@ -215,13 +262,7 @@ export function updateAccordionHighlights () {
           accordionBody.querySelectorAll("input[type='text'], input[type='number'], input[type='date']")
         )
         const selects = Array.from(accordionBody.querySelectorAll('select'))
-        hasValue = textInputs.some((input) => {
-          const v = (input.value || '').trim().toLowerCase()
-          return v && v !== 'none'
-        }) || selects.some((sel) => {
-          const v = (sel.value || '').trim().toLowerCase()
-          return v && v !== 'none'
-        })
+        hasValue = textInputs.some(fieldHasNonDefaultValue) || selects.some(fieldHasNonDefaultValue)
       }
 
       // 2. Check for modified template selects, but only if toggle is still ON
@@ -268,11 +309,10 @@ export function updateAccordionHighlights () {
       if (isPreview) return false
 
       // Only highlight if child toggle is on or has modified select tied to an enabled toggle
-      const hasActiveToggle = child.querySelector(
-        "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
-        "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
-        '.list-group li'
-      )
+      const hasActiveToggle = Array.from(child.querySelectorAll(
+        "input[type='checkbox']:not(.readonly-toggle):not(.template-child-toggle), " +
+        "input[type='radio']"
+      )).some(fieldHasNonDefaultValue) || child.querySelector('.list-group li') !== null
       if (hasActiveToggle) return true
 
       const hasModifiedSelectWithToggle = Array.from(

--- a/static/local-js/modules/separatorPreview.js
+++ b/static/local-js/modules/separatorPreview.js
@@ -90,6 +90,7 @@ function updateSeparatorPreview (fieldId, selectedStyle) {
     separatorPreviewContainer.style.display = 'block'
     console.log(`[DEBUG] Separator preview updated to: ${imageUrl}`)
   } else {
+    separatorPreviewImage.removeAttribute('src')
     separatorPreviewContainer.style.display = 'none'
   }
 }

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -33,7 +33,7 @@ function hasLibraryConfigurationSignal (libraryContainer) {
   }
 
   if (libraryContainer.querySelector('.template-variable-section-has-overrides, .template-variable-field-has-override')) return true
-  if (libraryContainer.querySelector('.accordion-header.selected')) return true
+  if (Array.from(libraryContainer.querySelectorAll('.accordion-header.selected')).some(header => !header.closest('[data-qs-minimal-yaml="false"]'))) return true
 
   const totalSummary = libraryContainer.querySelector('[data-library-total-summary]')
   if (totalSummary && !totalSummary.classList.contains('d-none') && /\d/.test(totalSummary.textContent || '')) return true

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -22,6 +22,28 @@ function optionLabel (option) {
     .trim()
 }
 
+function hasLibraryConfigurationSignal (libraryContainer) {
+  if (!libraryContainer) return false
+  const card = libraryContainer.closest?.('.library-settings-card') || libraryContainer.querySelector?.('.library-settings-card') || libraryContainer
+  if (
+    window.QSLibraryValidation &&
+    typeof window.QSLibraryValidation.hasConfiguredSignal === 'function'
+  ) {
+    return window.QSLibraryValidation.hasConfiguredSignal(card)
+  }
+
+  if (libraryContainer.querySelector('.template-variable-section-has-overrides, .template-variable-field-has-override')) return true
+  if (libraryContainer.querySelector('.accordion-header.selected')) return true
+
+  const totalSummary = libraryContainer.querySelector('[data-library-total-summary]')
+  if (totalSummary && !totalSummary.classList.contains('d-none') && /\d/.test(totalSummary.textContent || '')) return true
+
+  return Array.from(libraryContainer.querySelectorAll('[data-lazy-override-count], [data-lazy-active]')).some(element => {
+    const count = Number(element.dataset.lazyOverrideCount || '0') || 0
+    return count > 0 || element.dataset.lazyActive === 'true'
+  })
+}
+
 export const ValidationHandler = {
   updateValidationState: function () {
     console.log('[DEBUG] Running validation state update.')
@@ -64,7 +86,7 @@ export const ValidationHandler = {
     } else {
       console.log('[DEBUG] Validation Failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
-        'Please review your selections: ensure you have picked at least one library, selected an item inside each chosen library, and if using Separators, selected a valid <strong>Placeholder ID</strong>. Items needing attention are highlighted in red below.',
+        'Please review your selections: ensure you have picked at least one library, configured content inside each included library, and if using Separators, selected a valid <strong>Placeholder ID</strong>. Items needing attention are highlighted in red below.',
         'danger',
         { html: true }
       )
@@ -160,7 +182,7 @@ export const ValidationHandler = {
       return false
     }
 
-    // Validate that all selected libraries have at least one highlight
+    // Validate that all selected libraries have configured content.
     const validateLibraries = () => {
       const selectedLibraries = [
         ...ValidationHandler.getSelectedLibraryIds('mov'),
@@ -184,18 +206,17 @@ export const ValidationHandler = {
           return true
         }
 
-        const hasSelectedHeader = Array.from(libraryContainer.querySelectorAll('.accordion-header.selected'))
-          .some(header => !header.closest('[data-qs-minimal-yaml="false"]'))
-        console.log(`[DEBUG] Library "${libraryId}-container" has selected header highlight: ${hasSelectedHeader}`)
+        const hasConfiguredContent = hasLibraryConfigurationSignal(libraryContainer)
+        console.log(`[DEBUG] Library "${libraryId}-container" has configured content signal: ${hasConfiguredContent}`)
 
-        if (!hasSelectedHeader) {
+        if (!hasConfiguredContent) {
           invalidLibraries.push(libraryId)
         } else {
           // If the library is valid, remove red border
           libraryContainer.style.border = ''
         }
 
-        return hasSelectedHeader
+        return hasConfiguredContent
       })
 
       if (!isValid) {
@@ -290,7 +311,7 @@ export const ValidationHandler = {
     } else {
       console.log('[DEBUG] Some validations failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
-        'Each selected library must have at least one highlighted item, a valid separator placeholder must be selected if a separator is enabled, and any path or URL fields must be valid.',
+        'Each included library must have configured content, a valid separator placeholder must be selected if a separator is enabled, and any path or URL fields must be valid.',
         'danger'
       )
       ValidationHandler.disableNavigation(false)

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -270,10 +270,10 @@
       <div class="modal-body">
         <p class="text-muted small mb-2" id="copyLibrarySubtitle"></p>
         <div class="alert alert-info small mb-3" role="alert">
-          Mirroring copies the selected library settings, but it does not include target libraries in the final YAML automatically.
-          Target libraries stay excluded because enabling <strong>Include in YAML</strong> runs the normal library validation flow.
+          Mirroring copies the selected library settings, but it does not include target libraries in the final config automatically.
+          Target libraries stay excluded because enabling <strong>Include in config</strong> runs the normal library validation flow.
           That gives Quickstart a chance to catch library-specific mirrored values that may not apply to the target, such as placeholder IDs.
-          After mirroring, open each target library, review the copied settings, and enable <strong>Include in YAML</strong> if you want that mirrored library in the final config.
+          After mirroring, open each target library, review the copied settings, and enable <strong>Include in config</strong> if you want that mirrored library in the final config.
         </div>
         <div class="d-flex justify-content-end gap-2 mb-2">
           <button type="button" class="btn btn-sm btn-outline-secondary" id="copySelectAll">Select all</button>

--- a/templates/partials/_library_card.html
+++ b/templates/partials/_library_card.html
@@ -19,7 +19,7 @@
           data-target-input="{{ library.id }}-library-value" value="{{ library.name }}"
           {% if include_checked %}checked{% endif %}>
         <label class="form-check-label small text-white-50 mb-0" for="{{ library.id }}-include"
-          title="Controls whether this library is written to the YAML output and validated.">Include in YAML</label>
+          title="Controls whether this library is written to the final config and validated.">Include in config</label>
       </div>
       <span class="badge include-status bg-secondary" data-include-status></span>
       <button type="button" class="btn btn-outline-secondary btn-sm btn-overlay copy-library-btn" data-library-id="{{ library.id }}"
@@ -61,7 +61,7 @@
           data-target-input="{{ library.id }}-library-value" value="{{ library.name }}"
           {% if include_checked %}checked{% endif %}>
         <label class="form-check-label small text-white-50 mb-0" for="{{ library.id }}-include"
-          title="Controls whether this library is written to the YAML output and validated.">Include in YAML</label>
+          title="Controls whether this library is written to the final config and validated.">Include in config</label>
       </div>
       <span class="badge include-status bg-secondary" data-include-status></span>
       <button type="button" class="btn btn-outline-secondary btn-sm btn-overlay copy-library-btn" data-library-id="{{ library.id }}"

--- a/templates/partials/_library_playlist_template_variables.html
+++ b/templates/partials/_library_playlist_template_variables.html
@@ -142,9 +142,9 @@ playlist-template_variables[{{ field_key }}]
   <div class="row g-2">
     {% for entry in entries %}
     <div class="col-12 col-lg-6">
-      <label class="form-check form-switch border rounded px-3 py-2 h-100 d-flex align-items-start gap-2">
+      <label class="form-check form-switch border rounded py-2 h-100 d-flex align-items-start gap-2 qs-playlist-key-toggle-card">
         <input class="form-check-input mt-1" type="checkbox" data-playlist-key-toggle data-playlist-key="{{ entry.key }}">
-        <span class="d-flex flex-column">
+        <span class="d-flex flex-column min-w-0">
           <span class="fw-semibold">{{ entry.label }}</span>
           <span class="small text-muted">{{ entry.key }}</span>
         </span>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -459,8 +459,8 @@ prefix if yml_location == "top_level" else
             </div>
             {% endif %}
             {% if preview_image and prefix == "use_separator" %}
-            <div id="{{ field_id }}-separatorPreviewContainer" class="mt-3 d-flex justify-content-start">
-                <img id="{{ field_id }}-separatorPreviewImage" src="" alt="{{ field_id }} Separator Preview"
+            <div id="{{ field_id }}-separatorPreviewContainer" class="mt-3 justify-content-start" style="display: none;">
+                <img id="{{ field_id }}-separatorPreviewImage" alt="{{ field_id }} Separator Preview"
                     class="img-fluid" style="max-width: 320px; width: 100%; height: auto; border: 1px solid #ccc;">
             </div>
             {% endif %}

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -149,10 +149,10 @@ def test_libraries_lookup_label_autosave_uses_narrow_payload():
 def test_mirror_modal_explains_targets_stay_excluded():
     template = LIBRARIES_TEMPLATE_PATH.read_text(encoding="utf-8")
 
-    assert "does not include target libraries in the final YAML automatically" in template
+    assert "does not include target libraries in the final config automatically" in template
     assert "runs the normal library validation flow" in template
     assert "placeholder IDs" in template
-    assert "enable <strong>Include in YAML</strong>" in template
+    assert "enable <strong>Include in config</strong>" in template
 
 
 def test_playlist_toggle_preserves_mirrored_state_when_excluded():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
This branch tightens the Libraries page UX and validation behavior after the lazy-load/refactor work. It removes stale “selected header” validation assumptions, improves user-facing wording, prevents false invalid states, and fixes separator preview rendering for `None`.

**Changes**
- Replaced Libraries validation’s old `.accordion-header.selected` check with current configured-content signals: override counts, active lazy sections, active template groups, and summary state.
- Updated library include wording from YAML implementation language to user-facing config language:
  - `Include in config`
  - `Included in config`
  - `Excluded from config`
- Updated mirror modal copy to explain that mirrored target libraries stay excluded from the final config until reviewed and included.
- Hid separator preview images when separator style is `None`, avoiding broken image placeholders.
- Preserved existing export/autosave behavior; these are UI/validation wording fixes only.

**Validation**
- `npx eslint static/local-js/025-libraries.js static/local-js/validationHandler.js static/local-js/modules/accordionHighlights.js static/local-js/modules/separatorPreview.js`
- `pytest tests/test_collection_details_contract.py::test_mirror_modal_explains_targets_stay_excluded`
- Targeted library route tests for autosave/lazy-load/reset behavior passed.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
