### PR TITLE
fix trimmed spaces and install persistence

### DIFF
--- a/modules/helpers/_install_mode.py
+++ b/modules/helpers/_install_mode.py
@@ -26,12 +26,14 @@ def _get_persisted_kometa_runtime_section() -> dict:
 
 def get_kometa_install_mode() -> str:
     mode = None
-    if has_app_context():
-        mode = app.config.get("KOMETA_INSTALL_MODE")
+    if not mode and has_request_context():
+        # The active config owns this setting. app.config is process-global and
+        # can be stale after another request/config rebuilds Kometa context.
+        mode = _get_persisted_kometa_runtime_section().get("install_mode")
     if not mode and has_request_context():
         mode = session.get("kometa_install_mode")
-    if not mode and has_request_context():
-        mode = _get_persisted_kometa_runtime_section().get("install_mode")
+    if not mode and has_app_context():
+        mode = app.config.get("KOMETA_INSTALL_MODE")
     normalized = str(mode or "").strip().lower()
     if normalized in {"existing", "external"}:
         return normalized

--- a/modules/helpers/_kometa_paths.py
+++ b/modules/helpers/_kometa_paths.py
@@ -25,9 +25,9 @@ def get_kometa_root_path() -> Path:
     """
     Resolve the Kometa root folder consistently.
     Priority:
-        1) app.config["KOMETA_ROOT"] if it differs from the managed default
+        1) persisted existing-install override for the active config
         2) session["kometa_root"] if it differs from the managed default
-        3) persisted existing-install override for the active config
+        3) app.config["KOMETA_ROOT"] if it differs from the managed default
         4) managed default under <CONFIG_DIR>/kometa
     """
     from modules.helpers._install_mode import _managed_kometa_root_default, get_kometa_install_mode, _get_persisted_kometa_runtime_section
@@ -35,15 +35,7 @@ def get_kometa_root_path() -> Path:
     managed_default = str(_managed_kometa_root_default())
     base = None
     install_mode = get_kometa_install_mode()
-    if has_app_context():
-        configured = app.config.get("KOMETA_ROOT")
-        if configured and os.path.normpath(str(configured)) != managed_default:
-            base = configured
-    if not base and has_request_context():
-        session_root = session.get("kometa_root")
-        if session_root and os.path.normpath(str(session_root)) != managed_default:
-            base = session_root
-    if not base and has_request_context():
+    if has_request_context():
         try:
             section = _get_persisted_kometa_runtime_section()
             if isinstance(section, dict):
@@ -53,6 +45,14 @@ def get_kometa_root_path() -> Path:
                     base = existing_root
         except Exception:
             base = None
+    if not base and has_request_context():
+        session_root = session.get("kometa_root")
+        if session_root and os.path.normpath(str(session_root)) != managed_default:
+            base = session_root
+    if not base and has_app_context():
+        configured = app.config.get("KOMETA_ROOT")
+        if configured and os.path.normpath(str(configured)) != managed_default:
+            base = configured
     if not base:
         if has_app_context():
             base = app.config.get("KOMETA_ROOT")
@@ -61,12 +61,12 @@ def get_kometa_root_path() -> Path:
     if not base:
         if install_mode == "external":
             config_dir = None
-            if has_app_context():
-                config_dir = app.config.get("KOMETA_CONFIG_DIR")
-            if not config_dir and has_request_context():
-                config_dir = session.get("kometa_config_dir")
             if not config_dir and has_request_context():
                 config_dir = _get_persisted_kometa_runtime_section().get("external_config_root")
+            if not config_dir and has_request_context():
+                config_dir = session.get("kometa_config_dir")
+            if not config_dir and has_app_context():
+                config_dir = app.config.get("KOMETA_CONFIG_DIR")
             if config_dir:
                 return Path(os.path.normpath(str(config_dir))).resolve()
         base = managed_default
@@ -89,15 +89,15 @@ def get_kometa_config_dir() -> Path:
         return get_kometa_root_path() / "config"
 
     configured = None
-    if has_app_context():
-        configured = app.config.get("KOMETA_CONFIG_DIR")
-    if not configured and has_request_context():
-        configured = session.get("kometa_config_dir")
     if not configured and has_request_context():
         section = _get_persisted_kometa_runtime_section()
         mode = str(section.get("install_mode") or "").strip().lower()
         if mode == "external":
             configured = section.get("external_config_root")
+    if not configured and has_request_context():
+        configured = session.get("kometa_config_dir")
+    if not configured and has_app_context():
+        configured = app.config.get("KOMETA_CONFIG_DIR")
     if configured:
         return Path(os.path.normpath(str(configured))).resolve()
     return get_kometa_root_path() / "config"
@@ -123,10 +123,6 @@ def get_kometa_log_dir() -> Path:
         return get_kometa_config_dir() / "logs"
 
     configured = None
-    if has_app_context():
-        configured = app.config.get("KOMETA_LOG_DIR")
-    if not configured and has_request_context():
-        configured = session.get("kometa_log_dir")
     if not configured and has_request_context():
         section = _get_persisted_kometa_runtime_section()
         mode = str(section.get("install_mode") or "").strip().lower()
@@ -136,6 +132,10 @@ def get_kometa_log_dir() -> Path:
                 config_dir = section.get("external_config_root") or ""
                 if config_dir:
                     return Path(os.path.normpath(str(config_dir))).resolve() / "logs"
+    if not configured and has_request_context():
+        configured = session.get("kometa_log_dir")
+    if not configured and has_app_context():
+        configured = app.config.get("KOMETA_LOG_DIR")
     if configured:
         return Path(os.path.normpath(str(configured))).resolve()
     return get_kometa_config_dir() / "logs"

--- a/modules/helpers/_plex.py
+++ b/modules/helpers/_plex.py
@@ -16,6 +16,10 @@ from modules import persistence
 from modules.helpers._logging import ts_log
 
 
+def _normalize_library_identifier(value):
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
 def get_top_imdb_items(library_id, media_type, placeholder_id=None):
     ts_log("Fetching Plex credentials for '010-plex'", level="DEBUG")
     plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
@@ -27,8 +31,9 @@ def get_top_imdb_items(library_id, media_type, placeholder_id=None):
         ts_log(f"Section: key={section.key}, title={section.title}", level="DEBUG")
 
     ts_log(f"Searching for section with ID or title: {library_id}", level="DEBUG")
+    normalized_library_id = _normalize_library_identifier(library_id)
     section = next(
-        (s for s in plex.library.sections() if str(s.key) == str(library_id) or s.title.lower() == str(library_id).lower()),
+        (s for s in plex.library.sections() if str(s.key) == str(library_id) or _normalize_library_identifier(getattr(s, "title", "")) == normalized_library_id),
         None,
     )
 

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -27,6 +27,13 @@ TRANSIENT_FORM_FIELDS = {
     "importMode",
 }
 
+KOMETA_INSTALL_SELECTION_FIELDS = (
+    "install_mode",
+    "existing_root",
+    "external_config_root",
+    "external_log_root",
+)
+
 
 def _normalize_plex_db_cache_value(value):
     if value is None or isinstance(value, bool):
@@ -217,6 +224,40 @@ def clean_form_data(form_data):
     return clean_data
 
 
+def _preserve_kometa_install_selection(data, clean_data):
+    if not isinstance(data, dict):
+        return data
+    incoming_section = data.get("kometa")
+    if not isinstance(incoming_section, dict):
+        return data
+
+    # The Start page owns these fields through /save-kometa-install-mode.
+    # Generic Kometa-page saves often contain only final-page controls, so they
+    # must not reset an existing/external install back to the managed default.
+    if any(field in clean_data or field in incoming_section for field in KOMETA_INSTALL_SELECTION_FIELDS):
+        return data
+
+    try:
+        _validated, _user_entered, stored_payload = database.retrieve_section_data(session["config_name"], "kometa")
+    except Exception:
+        return data
+
+    stored_section = stored_payload.get("kometa", {}) if isinstance(stored_payload, dict) else {}
+    if not isinstance(stored_section, dict):
+        return data
+
+    preserved = {field: stored_section.get(field) for field in KOMETA_INSTALL_SELECTION_FIELDS if field in stored_section}
+    if not preserved:
+        return data
+
+    merged_section = dict(incoming_section)
+    for field, value in preserved.items():
+        if value is not None:
+            merged_section[field] = value
+    data["kometa"] = merged_section
+    return data
+
+
 def save_settings(raw_source, form_data):
     # Extract the source and source_name
     source, source_name = extract_names(raw_source)
@@ -258,6 +299,8 @@ def save_settings(raw_source, form_data):
         helpers.ts_log(f"Cleaned asset_directory: {clean_data['asset_directory']}", level="DEBUG")
 
     data = helpers.build_config_dict(source_name, clean_data)
+    if source_name == "kometa":
+        data = _preserve_kometa_install_selection(data, clean_data)
 
     if app.config["QS_DEBUG"]:
         helpers.ts_log(f"Final data structure to save: {data}", level="DEBUG")

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -6710,6 +6710,7 @@ def test_check_kometa_update_existing_mode_allows_status_check(client, tmp_path,
 
 
 def test_get_kometa_config_dir_prefers_persisted_external_selection(app, tmp_path):
+    from pathlib import Path
     from flask import session
     from modules import database, helpers
 
@@ -6733,13 +6734,14 @@ def test_get_kometa_config_dir_prefers_persisted_external_selection(app, tmp_pat
     )
 
     with app.test_request_context("/step/900-kometa"):
+        managed_root = (Path(helpers.CONFIG_DIR) / "kometa").resolve()
         app.config["KOMETA_INSTALL_MODE"] = "managed"
-        app.config["KOMETA_CONFIG_DIR"] = ""
-        app.config["KOMETA_LOG_DIR"] = ""
+        app.config["KOMETA_CONFIG_DIR"] = str(managed_root / "config")
+        app.config["KOMETA_LOG_DIR"] = str(managed_root / "config" / "logs")
         session["config_name"] = config_name
         session["kometa_install_mode"] = "managed"
-        session["kometa_config_dir"] = ""
-        session["kometa_log_dir"] = ""
+        session["kometa_config_dir"] = str(managed_root / "config")
+        session["kometa_log_dir"] = str(managed_root / "config" / "logs")
         assert helpers.get_kometa_config_dir() == external_config.resolve()
         assert helpers.get_kometa_log_dir() == external_logs.resolve()
 
@@ -6768,6 +6770,56 @@ def test_get_kometa_root_path_prefers_persisted_existing_selection(app, tmp_path
         session["config_name"] = config_name
         session["kometa_root"] = managed_default
         assert helpers.get_kometa_root_path() == existing_root.resolve()
+
+
+def test_get_kometa_install_mode_prefers_persisted_selection(app, tmp_path):
+    from flask import session
+    from modules import database, helpers
+
+    config_name = "pytest_persisted_existing_mode"
+    existing_root = tmp_path / "persisted-existing-mode"
+    existing_root.mkdir(parents=True, exist_ok=True)
+
+    database.save_section_data(
+        name=config_name,
+        section="kometa",
+        validated=False,
+        user_entered=True,
+        data={"kometa": {"install_mode": "existing", "existing_root": str(existing_root)}},
+    )
+
+    with app.test_request_context("/step/900-kometa"):
+        app.config["KOMETA_INSTALL_MODE"] = "managed"
+        session["config_name"] = config_name
+        session["kometa_install_mode"] = "managed"
+        assert helpers.get_kometa_install_mode() == "existing"
+
+
+def test_save_kometa_page_preserves_existing_install_selection(app, tmp_path):
+    from flask import session
+    from modules import database, persistence
+
+    config_name = "pytest_save_kometa_preserve_existing"
+    existing_root = tmp_path / "preserve-existing-kometa"
+    existing_root.mkdir(parents=True, exist_ok=True)
+
+    database.save_section_data(
+        name=config_name,
+        section="kometa",
+        validated=True,
+        user_entered=True,
+        data={"kometa": {"install_mode": "existing", "existing_root": str(existing_root)}},
+    )
+
+    with app.test_request_context("/step/900-kometa"):
+        session["config_name"] = config_name
+        persistence.save_settings("900-kometa", {"header_style": "single line"})
+
+    _validated, _user_entered, stored = database.retrieve_section_data(config_name, "kometa")
+    kometa = stored["kometa"]
+    assert kometa["install_mode"] == "existing"
+    assert kometa["existing_root"] == str(existing_root)
+    assert kometa["header_style"] == "single line"
 
 
 def test_normalize_config_name_for_storage_strips_yaml_filename_suffix():

--- a/tests/test_plex_helpers.py
+++ b/tests/test_plex_helpers.py
@@ -13,11 +13,10 @@ class _Item:
 
 
 class _Section:
-    key = "1"
-    title = "Movies"
-
-    def __init__(self, items):
+    def __init__(self, items, title="Movies", key="1"):
         self._items = items
+        self.title = title
+        self.key = key
 
     def search(self, sort=None, maxresults=None):
         assert sort == "audienceRating:desc"
@@ -70,3 +69,16 @@ def test_get_top_imdb_items_continues_until_each_relevant_source_has_top_ten(mon
 
     assert len(result) == 20
     assert [item["tmdb_movie"] for item in result if item["tmdb_movie"]] == [str(900 + index) for index in range(10)]
+
+
+def test_get_top_imdb_items_matches_plex_section_titles_with_outer_spaces(monkeypatch):
+    items = [_Item("Movie", ["imdb://tt1234567", "tmdb://42"])]
+    section = _Section(items, title=" Movies")
+
+    monkeypatch.setattr(_plex.persistence, "get_stored_plex_credentials", lambda page: ("http://plex", "token"))
+    monkeypatch.setattr(_plex, "PlexServer", lambda url, token: _Plex(section))
+
+    result, _saved_item = _plex.get_top_imdb_items("Movies", "movie")
+
+    assert result[0]["title"] == "Movie"
+    assert result[0]["imdb_id"] == "tt1234567"


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
This branch fixes several library/Kometa regressions and improves separator placeholder handling.

**Changes**
- Preserved Kometa install ownership when saving from the Kometa page so `Existing direct install` and external paths no longer reset back to Quickstart-managed mode.
- Updated Kometa runtime/path helpers to prefer the active config’s persisted install mode over stale process-global state.
- Fixed separator placeholder top-item lookup when Plex library titles contain leading/trailing whitespace, for example Plex reports `" Movies"` but Quickstart stores `Movies`.
- Added regression tests for persisted Kometa install mode/path behavior and Plex section title whitespace matching.

**Validation**
- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k "kometa"`
- `venv\Scripts\python.exe -m pytest tests\test_plex_helpers.py tests\test_separator_placeholder_route.py`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
