### PR TITLE
fix 404 (NOT FOUND)

### DIFF
--- a/modules/helpers/_vite_manifest.py
+++ b/modules/helpers/_vite_manifest.py
@@ -59,6 +59,7 @@ _MANIFEST_PATH = os.path.join(
     ".vite",
     "manifest.json",
 )
+_DIST_DIR = os.path.dirname(os.path.dirname(_MANIFEST_PATH))
 
 # Thread-safe lazy load: read the manifest once, cache the dict.
 _manifest_cache: dict | None = None
@@ -140,7 +141,10 @@ def asset_url(name: str) -> str:
     key = f"static/local-js/{name}.js"
     entry = manifest.get(key)
     if entry and "file" in entry:
-        return f"/static/dist/{entry['file']}"
+        built_file = str(entry["file"]).lstrip("/")
+        built_path = os.path.join(_DIST_DIR, *built_file.split("/"))
+        if os.path.exists(built_path):
+            return f"/static/dist/{built_file}"
     return f"/static/local-js/{name}.js"
 
 

--- a/tests/test_vite_manifest.py
+++ b/tests/test_vite_manifest.py
@@ -59,9 +59,18 @@ def fake_manifest(tmp_path, monkeypatch):
     before calling ``reload_manifest()`` + ``asset_url()``.
     """
     manifest_path = tmp_path / "manifest.json"
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
     monkeypatch.setattr(_vite_manifest, "_MANIFEST_PATH", str(manifest_path))
+    monkeypatch.setattr(_vite_manifest, "_DIST_DIR", str(dist_dir))
     reload_manifest()
     return manifest_path
+
+
+def _touch_dist_file(path):
+    built_path = Path(_vite_manifest._DIST_DIR) / path
+    built_path.parent.mkdir(parents=True, exist_ok=True)
+    built_path.write_text("// built\n", encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +123,7 @@ class TestLoadManifest:
 
 class TestAssetUrlWithManifest:
     def test_returns_hashed_dist_path_for_entry(self, fake_manifest):
+        _touch_dist_file("000-base-DKccW2Od.js")
         fake_manifest.write_text(
             json.dumps(
                 {
@@ -128,6 +138,7 @@ class TestAssetUrlWithManifest:
 
     def test_prefers_dist_over_source_when_both_exist(self, fake_manifest):
         """Manifest entry always wins; we never inspect the source path."""
+        _touch_dist_file("010-plex-xyz789.js")
         fake_manifest.write_text(
             json.dumps(
                 {
@@ -149,6 +160,7 @@ class TestAssetUrlWithManifest:
         references these directly, but if it ever did the lookup should
         still work.)
         """
+        _touch_dist_file("chunks/imageHandler-abc.js")
         fake_manifest.write_text(
             json.dumps(
                 {
@@ -173,6 +185,11 @@ class TestAssetUrlWithManifest:
                 }
             )
         )
+        assert asset_url("000-base") == "/static/local-js/000-base.js"
+
+    def test_manifest_entry_missing_built_file_falls_back(self, fake_manifest):
+        """A stale manifest without its dist file must not emit a guaranteed 404 URL."""
+        fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-stale.js"}}))
         assert asset_url("000-base") == "/static/local-js/000-base.js"
 
 
@@ -215,6 +232,7 @@ class TestManifestCaching:
         is invoked for the manifest path across many ``asset_url()``
         calls.
         """
+        _touch_dist_file("000-base-abc.js")
         fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-abc.js"}}))
 
         real_open = open
@@ -234,10 +252,12 @@ class TestManifestCaching:
 
     def test_reload_manifest_forces_fresh_read(self, fake_manifest):
         """After reload_manifest(), the next asset_url() call re-reads disk."""
+        _touch_dist_file("000-base-v1.js")
         fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-v1.js"}}))
         assert asset_url("000-base") == "/static/dist/000-base-v1.js"
 
         # Rewrite the manifest and reload.
+        _touch_dist_file("000-base-v2.js")
         fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-v2.js"}}))
         reload_manifest()
 
@@ -245,6 +265,7 @@ class TestManifestCaching:
 
     def test_reload_without_manifest_still_falls_back(self, fake_manifest):
         """A manifest that appears and then disappears must fall back cleanly."""
+        _touch_dist_file("000-base-v1.js")
         fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-v1.js"}}))
         assert asset_url("000-base") == "/static/dist/000-base-v1.js"
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -78,6 +78,10 @@ function discoverModuleEntries (dir) {
 
 export default defineConfig({
   root: rootDir,
+  // Flask serves Vite output from /static/dist/. Without this, built entry
+  // modules import chunks from the site root (e.g. /chunks/foo.js), which
+  // 404s behind Quickstart's Flask static route.
+  base: '/static/dist/',
   // Tell Vite where to resolve bare specifiers relative to. Today everything
   // is relative-path imports, but once we add npm packages (Alpine for
   // Step 6) this will matter.


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes Vite asset routing for bundled frontend modules.

The browser was requesting built chunks from root paths like `/chunks/...`, which 404s because Quickstart serves Vite output from `/static/dist/`. This caused pages to fail loading dynamic modules such as separator preview, accordion highlights, overlay handling, and event handling.

Changes:
- Set Vite `base` to `/static/dist/` so generated dynamic imports resolve under the Flask static dist path.
- Hardened Vite manifest asset resolution to fall back to source JS when a manifest entry points to a missing built file.
- Added regression coverage for valid manifest entries and missing built artifact fallback.

Validation:
- `venv\Scripts\python.exe -m pytest tests\test_vite_manifest.py`
- `npm run build`
- Verified built JS no longer contains root-relative chunk/module imports.
## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
