### PR TITLE
Validate fix for logscan

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -45,6 +45,7 @@ class LogscanAnalyzer:
         self.server_versions = []
         self.people_index_available = False
         self._people_index = None
+        self.validation_summary = {}
 
     def reset_server_versions(self):
         """Reset the server_versions list to an empty list."""
@@ -206,6 +207,9 @@ class LogscanAnalyzer:
 
     def extract_finished_runs(self, content):
         return logscan_finished_runs.extract_finished_runs(content)
+
+    def extract_validation_summary(self, content):
+        return logscan_finished_runs.extract_validation_summary(content)
 
     def _parse_run_time_from_line(self, line):
         return logscan_finished_runs.parse_run_time_from_line(line)
@@ -373,9 +377,16 @@ class LogscanAnalyzer:
         run_command=None,
         command_signature=None,
         section_runtimes=None,
+        validation_summary=None,
     ):
         started_at = self._normalize_started_at(self.started_at)
         finished_at = self.finished_at
+        validation_summary = validation_summary if isinstance(validation_summary, dict) else {}
+        validation_run = bool(validation_summary.get("validation_run"))
+        validation_result = validation_summary.get("validation_result")
+        validation_complete = validation_run and bool(validation_result)
+        if not finished_at and validation_summary.get("finished_at"):
+            finished_at = validation_summary.get("finished_at")
         if not finished_at and finished_runs:
             last_run = finished_runs[-1]
             if " - " in last_run:
@@ -388,7 +399,7 @@ class LogscanAnalyzer:
         run_time_seconds = None
         if isinstance(self.run_time, timedelta):
             run_time_seconds = int(self.run_time.total_seconds())
-        run_complete = run_time_seconds is not None
+        run_complete = run_time_seconds is not None or validation_complete
         section_total_seconds = None
         section_delta_seconds = None
         if section_runtimes:
@@ -420,7 +431,7 @@ class LogscanAnalyzer:
             run_key_seed = "|".join(run_key_parts)
             run_key = hashlib.sha256(run_key_seed.encode("utf-8")).hexdigest()
 
-        return {
+        summary = {
             "run_key": run_key,
             "started_at": started_at,
             "finished_at": finished_at,
@@ -440,6 +451,11 @@ class LogscanAnalyzer:
             "log_counts": counts,
             "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         }
+        if validation_run:
+            summary["validation_run"] = True
+            summary["validation_level"] = validation_summary.get("validation_level")
+            summary["validation_result"] = validation_result
+        return summary
 
     def analyze_content(self, content, log_path=None, config_name=None, config_path=None, include_people_scan=True):
         self.reset_server_versions()
@@ -451,6 +467,7 @@ class LogscanAnalyzer:
         self.current_kometa_version = None
         self.kometa_newest_version = None
         self.people_index_available = False
+        self.validation_summary = {}
 
         raw_content = content or ""
         self._raw_content = raw_content
@@ -460,6 +477,8 @@ class LogscanAnalyzer:
         header_lines = self.extract_header_lines(cleaned_content)
         finished_lines = self.extract_last_lines(cleaned_content)
         finished_runs = self.extract_finished_runs(cleaned_content)
+        validation_summary = self.extract_validation_summary(raw_content)
+        self.validation_summary = validation_summary if isinstance(validation_summary, dict) else {}
         self.extract_plex_config(cleaned_content)
         run_command_raw = self.extract_run_command(cleaned_content)
         command_signature = self.compute_command_signature(run_command_raw)
@@ -518,6 +537,7 @@ class LogscanAnalyzer:
             run_command=run_command,
             command_signature=command_signature,
             section_runtimes=section_runtimes,
+            validation_summary=validation_summary,
         )
         if summary:
             summary["analysis_counts"] = analysis_counts

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -211,6 +211,9 @@ class LogscanAnalyzer:
     def extract_validation_summary(self, content):
         return logscan_finished_runs.extract_validation_summary(content)
 
+    def extract_log_timestamp_bounds(self, content):
+        return logscan_finished_runs.extract_log_timestamp_bounds(content)
+
     def _parse_run_time_from_line(self, line):
         return logscan_finished_runs.parse_run_time_from_line(line)
 
@@ -378,13 +381,17 @@ class LogscanAnalyzer:
         command_signature=None,
         section_runtimes=None,
         validation_summary=None,
+        timestamp_bounds=None,
     ):
         started_at = self._normalize_started_at(self.started_at)
         finished_at = self.finished_at
         validation_summary = validation_summary if isinstance(validation_summary, dict) else {}
+        timestamp_bounds = timestamp_bounds if isinstance(timestamp_bounds, dict) else {}
         validation_run = bool(validation_summary.get("validation_run"))
         validation_result = validation_summary.get("validation_result")
         validation_complete = validation_run and bool(validation_result)
+        if not started_at and timestamp_bounds.get("started_at"):
+            started_at = timestamp_bounds.get("started_at")
         if not finished_at and validation_summary.get("finished_at"):
             finished_at = validation_summary.get("finished_at")
         if not finished_at and finished_runs:
@@ -397,9 +404,16 @@ class LogscanAnalyzer:
                 finished_at = finished_at.split(":", 1)[1].strip()
 
         run_time_seconds = None
+        run_time_source = None
         if isinstance(self.run_time, timedelta):
             run_time_seconds = int(self.run_time.total_seconds())
-        run_complete = run_time_seconds is not None or validation_complete
+            run_time_source = "kometa"
+        if not finished_at and timestamp_bounds.get("finished_at"):
+            finished_at = timestamp_bounds.get("finished_at")
+        run_complete = run_time_source == "kometa" or validation_complete
+        if run_time_seconds is None and isinstance(timestamp_bounds.get("elapsed_seconds"), int):
+            run_time_seconds = timestamp_bounds.get("elapsed_seconds")
+            run_time_source = "log_timestamps"
         section_total_seconds = None
         section_delta_seconds = None
         if section_runtimes:
@@ -436,6 +450,7 @@ class LogscanAnalyzer:
             "started_at": started_at,
             "finished_at": finished_at,
             "run_time_seconds": run_time_seconds,
+            "run_time_source": run_time_source,
             "run_complete": run_complete,
             "section_runtime_total_seconds": section_total_seconds,
             "section_runtime_delta_seconds": section_delta_seconds,
@@ -479,6 +494,7 @@ class LogscanAnalyzer:
         finished_runs = self.extract_finished_runs(cleaned_content)
         validation_summary = self.extract_validation_summary(raw_content)
         self.validation_summary = validation_summary if isinstance(validation_summary, dict) else {}
+        timestamp_bounds = self.extract_log_timestamp_bounds(raw_content)
         self.extract_plex_config(cleaned_content)
         run_command_raw = self.extract_run_command(cleaned_content)
         command_signature = self.compute_command_signature(run_command_raw)
@@ -538,6 +554,7 @@ class LogscanAnalyzer:
             command_signature=command_signature,
             section_runtimes=section_runtimes,
             validation_summary=validation_summary,
+            timestamp_bounds=timestamp_bounds,
         )
         if summary:
             summary["analysis_counts"] = analysis_counts

--- a/modules/logscan_advisory_messages.py
+++ b/modules/logscan_advisory_messages.py
@@ -332,15 +332,20 @@ def build_advisory_messages(
     if kometa_time_recommendation:
         special_check_lines.append(kometa_time_recommendation)
 
-    # Extract Memory value:
-    kometa_mem_recommendation = analyzer.calculate_memory_recommendation(content)
-    if kometa_mem_recommendation:
-        special_check_lines.append(kometa_mem_recommendation)
+    validation_run = bool(getattr(analyzer, "validation_summary", {}).get("validation_run"))
+    kometa_mem_recommendation = None
+    kometa_db_cache_recommendation = None
+    if not validation_run:
+        # Validation-only logs do not include the full run header/system
+        # metrics, so normal-run tuning recommendations would be false
+        # positives.
+        kometa_mem_recommendation = analyzer.calculate_memory_recommendation(content)
+        if kometa_mem_recommendation:
+            special_check_lines.append(kometa_mem_recommendation)
 
-    # Extract DB Cache value:
-    kometa_db_cache_recommendation = analyzer.make_db_cache_recommendations(content)
-    if kometa_db_cache_recommendation:
-        special_check_lines.append(kometa_db_cache_recommendation)
+        kometa_db_cache_recommendation = analyzer.make_db_cache_recommendations(content)
+        if kometa_db_cache_recommendation:
+            special_check_lines.append(kometa_db_cache_recommendation)
 
     # Extract WSL information
     wsl_recommendation = analyzer.detect_wsl_and_recommendation(content)

--- a/modules/logscan_finished_runs.py
+++ b/modules/logscan_finished_runs.py
@@ -132,6 +132,35 @@ def extract_validation_summary(content: str) -> Optional[dict]:
     }
 
 
+def extract_log_timestamp_bounds(content: str) -> dict:
+    """Return first/last log-line timestamps and elapsed seconds when available."""
+    if not content:
+        return {}
+
+    first_timestamp = None
+    last_timestamp = None
+    for line in content.splitlines():
+        match = _LOG_TIMESTAMP_RE.search(line)
+        if not match:
+            continue
+        try:
+            parsed = datetime.strptime(match.group(1).strip(), "%Y-%m-%d %H:%M:%S")
+        except Exception:
+            continue
+        if first_timestamp is None:
+            first_timestamp = parsed
+        last_timestamp = parsed
+
+    if first_timestamp is None or last_timestamp is None:
+        return {}
+
+    return {
+        "started_at": first_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "finished_at": last_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "elapsed_seconds": max(0, int((last_timestamp - first_timestamp).total_seconds())),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Run-time parsing
 # ---------------------------------------------------------------------------

--- a/modules/logscan_finished_runs.py
+++ b/modules/logscan_finished_runs.py
@@ -83,6 +83,56 @@ def extract_finished_runs(content: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Validation-only run parsing
+# ---------------------------------------------------------------------------
+
+
+_VALIDATION_REPORT_RE = re.compile(r"\bValidation\s+Report(?:\s*\(([^)]*)\))?", re.IGNORECASE)
+_VALIDATION_RESULT_RE = re.compile(r"\[validator\.py:\d+\].*?\bResult:\s*([^|]+)", re.IGNORECASE)
+_LOG_TIMESTAMP_RE = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),")
+
+
+def extract_validation_summary(content: str) -> Optional[dict]:
+    """Return terminal validation-run metadata when a Kometa validate log is complete.
+
+    Kometa ``--validate`` runs do not always emit the normal ``Finished Run`` /
+    ``Run Time:`` block.  They do emit a validation report with a terminal
+    ``validator.py`` / ``Result: ...`` line.  Any validator result means the
+    validation command finished and should not be treated as an incomplete run.
+    """
+    if not content:
+        return None
+
+    validation_level = None
+    validation_result = None
+    last_timestamp = None
+
+    for line in content.splitlines():
+        timestamp_match = _LOG_TIMESTAMP_RE.search(line)
+        if timestamp_match:
+            last_timestamp = timestamp_match.group(1).strip()
+
+        report_match = _VALIDATION_REPORT_RE.search(line)
+        if report_match:
+            if report_match.group(1):
+                validation_level = report_match.group(1).strip().lower()
+
+        result_match = _VALIDATION_RESULT_RE.search(line)
+        if result_match:
+            validation_result = result_match.group(1).strip().lower()
+
+    if not validation_result:
+        return None
+
+    return {
+        "validation_run": True,
+        "validation_level": validation_level,
+        "validation_result": validation_result,
+        "finished_at": last_timestamp,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Run-time parsing
 # ---------------------------------------------------------------------------
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -428,7 +428,8 @@ ACTIVE_WORK_POLICIES = {
     ],
 }
 LOG_STATS_CACHE = {"mtime": None, "size": None, "stats": None}
-LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "data": None}
+LOGSCAN_ANALYSIS_CACHE_VERSION = 3
+LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "version": LOGSCAN_ANALYSIS_CACHE_VERSION, "data": None}
 LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "aux_signature": None, "data": None}
 
 VALIDATION_DOC_BASE = "/step/"
@@ -4040,7 +4041,7 @@ def logscan_analyze():
         return jsonify({"error": f"Failed to stat log: {str(e)}"}), 500
 
     cached = LOGSCAN_ANALYSIS_CACHE
-    if cached.get("mtime") == stats.st_mtime and cached.get("size") == stats.st_size:
+    if cached.get("version") == LOGSCAN_ANALYSIS_CACHE_VERSION and cached.get("mtime") == stats.st_mtime and cached.get("size") == stats.st_size:
         data = cached.get("data") or {}
         data["cached"] = True
         return jsonify(data)
@@ -4096,8 +4097,8 @@ def logscan_analyze():
             if _logscan_needs_reingest(cache_logs, log_path.parent):
                 _start_logscan_auto_reingest(log_path.parent)
 
-    LOGSCAN_ANALYSIS_CACHE.update({"mtime": stats.st_mtime, "size": stats.st_size, "data": result})
     result["cached"] = False
+    LOGSCAN_ANALYSIS_CACHE.update({"mtime": stats.st_mtime, "size": stats.st_size, "version": LOGSCAN_ANALYSIS_CACHE_VERSION, "data": dict(result)})
     return jsonify(result)
 
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2075,13 +2075,10 @@ fieldset:disabled .btn {
     box-shadow: 0 0 10px rgba(var(--accent-color), 0.35);
 }
 
-.accordion-item.template-variable-section-has-overrides > .accordion-header {
+.accordion-item.template-variable-section-has-overrides > .accordion-header > .accordion-button,
+.accordion-header.template-variable-section-has-overrides > .accordion-button {
     border-left: 4px solid var(--theme-primary) !important;
-}
-
-.accordion-header.template-variable-section-has-overrides {
-    border-left: 4px solid var(--theme-primary) !important;
-    padding-left: 10px !important;
+    padding-left: calc(var(--bs-accordion-btn-padding-x, 1.25rem) + 6px) !important;
 }
 
 .template-override-summary,

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -9438,6 +9438,21 @@ function getLibraryCardOverrideTotal (card) {
   return getLibrarySectionOverrideTotal(card, false) + getLibrarySectionOverrideTotal(card, true)
 }
 
+function syncDirectLibraryAccordionOverrideSignals (card) {
+  if (!card) return
+  const accordion = card.querySelector('.accordion')
+  const items = Array.from(accordion?.children || []).filter(item => item.classList?.contains('accordion-item'))
+  items.forEach(item => {
+    const collapse = Array.from(item.children).find(child => child.classList?.contains('accordion-collapse'))
+    const header = Array.from(item.children).find(child => child.classList?.contains('accordion-header')) || item.querySelector(':scope > .accordion-header')
+    const count = getAccordionCollapseOverrideCount(collapse)
+    const hasSignal = getAccordionCollapseHasActiveSignal(collapse)
+    item.classList.toggle('template-variable-section-has-overrides', hasSignal)
+    header?.classList.toggle('template-variable-section-has-overrides', hasSignal)
+    setOverrideSummaryBadge(getOrCreateAccordionOverrideBadge(header), count)
+  })
+}
+
 function getLibraryCardHasConfigurationSignal (card) {
   if (!card) return false
   if (getLibraryCardOverrideTotal(card) > 0) return true
@@ -9451,6 +9466,7 @@ function getLibraryCardHasConfigurationSignal (card) {
 
 function updateLibraryAggregateOverrideSummaries (card) {
   if (!card) return
+  syncDirectLibraryAccordionOverrideSignals(card)
   const coreCount = getLibrarySectionOverrideTotal(card, false)
   const advancedCount = getLibrarySectionOverrideTotal(card, true)
   setOverrideSummaryBadge(card.querySelector('[data-library-core-summary]'), coreCount)

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -410,8 +410,8 @@ def test_template_variable_sections_show_override_rail():
     assert ".collection-variable-section.template-variable-section-has-overrides" in styles
     assert ".overlay-variable-section.template-variable-section-has-overrides" in styles
     assert ".template-toggle-group.template-variable-section-has-overrides" in styles
-    assert ".accordion-item.template-variable-section-has-overrides > .accordion-header" in styles
-    assert ".accordion-header.template-variable-section-has-overrides" in styles
+    assert ".accordion-header.template-variable-section-has-overrides > .accordion-button" in styles
+    assert ".accordion-header.template-variable-section-has-overrides {\n    border-left:" not in styles
     assert ".template-variable-field-has-override" in styles
     assert "[data-template-string-list].template-variable-field-has-override" in styles
     assert "background: linear-gradient(90deg, rgba(var(--accent-color), 0.08), transparent 34%);" in styles

--- a/tests/test_logscan_finished_runs.py
+++ b/tests/test_logscan_finished_runs.py
@@ -16,6 +16,7 @@ import pytest
 from modules.logscan_finished_runs import (
     extract_finished_runs,
     extract_last_lines,
+    extract_validation_summary,
     find_last_run_time_index,
     format_contiguous_lines,
     parse_final_run_metadata,
@@ -113,6 +114,94 @@ class TestExtractFinishedRuns:
         assert len(result) == 2
         assert "collections" in result[0]
         assert "overlays" in result[1]
+
+
+# ---------------------------------------------------------------------------
+# extract_validation_summary
+# ---------------------------------------------------------------------------
+
+
+class TestExtractValidationSummary:
+    def test_passed_validation_report_is_terminal(self):
+        content = "\n".join(
+            [
+                "[2026-07-24 18:24:37,827] [kometa.py:441] [INFO] | Validation Report (full)",
+                "[2026-07-24 18:24:38,100] [validator.py:100] [INFO] | Result: PASSED",
+            ]
+        )
+
+        result = extract_validation_summary(content)
+
+        assert result == {
+            "validation_run": True,
+            "validation_level": "full",
+            "validation_result": "passed",
+            "finished_at": "2026-07-24 18:24:38",
+        }
+
+    def test_passed_validation_report_preserves_warning_suffix(self):
+        content = "\n".join(
+            [
+                "[2026-07-24 18:24:37,827] [validator.py:452] [INFO] | Validation Report (structure+schema)",
+                "[2026-07-24 18:24:38,100] [validator.py:485] [INFO] | Result: PASSED with 2 warning(s)",
+            ]
+        )
+
+        result = extract_validation_summary(content)
+
+        assert result is not None
+        assert result["validation_level"] == "structure+schema"
+        assert result["validation_result"] == "passed with 2 warning(s)"
+
+    def test_failed_validation_report_is_terminal(self):
+        content = "\n".join(
+            [
+                "[2026-07-24 18:24:37,827] [kometa.py:441] [INFO] | Validation Report (structure)",
+                "[2026-07-24 18:24:38,100] [validator.py:100] [INFO] | Result: FAILED",
+            ]
+        )
+
+        result = extract_validation_summary(content)
+
+        assert result is not None
+        assert result["validation_level"] == "structure"
+        assert result["validation_result"] == "failed"
+
+    def test_validator_result_without_report_line_is_terminal(self):
+        content = "\n".join(
+            [
+                "[2026-07-24 23:12:08,515] [validator.py:481] [INFO] |",
+                "[2026-07-24 23:12:08,515] [validator.py:482] [INFO] | ===============================================================",
+                "[2026-07-24 23:12:08,515] [validator.py:485] [INFO] | Result: FAILED",
+                "[2026-07-24 23:12:08,516] [validator.py:486] [INFO] | ===============================================================",
+            ]
+        )
+
+        result = extract_validation_summary(content)
+
+        assert result is not None
+        assert result["validation_run"] is True
+        assert result["validation_level"] is None
+        assert result["validation_result"] == "failed"
+        assert result["finished_at"] == "2026-07-24 23:12:08"
+
+    def test_validator_result_text_does_not_have_to_be_passed_or_failed(self):
+        content = "\n".join(
+            [
+                "[2026-07-24 18:24:37,827] [validator.py:452] [INFO] | Validation Report (syntax)",
+                "[2026-07-24 18:24:38,100] [validator.py:485] [INFO] | Result: SKIPPED",
+            ]
+        )
+
+        result = extract_validation_summary(content)
+
+        assert result is not None
+        assert result["validation_result"] == "skipped"
+
+    def test_incomplete_validation_report_without_result_is_not_terminal(self):
+        content = "[2026-07-24 18:24:37,827] [kometa.py:441] [INFO] | Validation Report (syntax)"
+
+        assert extract_validation_summary(content) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_logscan_runtime_parse.py
+++ b/tests/test_logscan_runtime_parse.py
@@ -40,7 +40,8 @@ def test_analyze_content_marks_validate_passed_log_complete_without_runtime():
 
     assert isinstance(summary, dict)
     assert summary.get("run_complete") is True
-    assert summary.get("run_time_seconds") is None
+    assert summary.get("run_time_seconds") == 1
+    assert summary.get("run_time_source") == "log_timestamps"
     assert summary.get("validation_run") is True
     assert summary.get("validation_level") == "full"
     assert summary.get("validation_result") == "passed"
@@ -63,10 +64,33 @@ def test_analyze_content_marks_validate_failed_log_complete_without_runtime():
 
     assert isinstance(summary, dict)
     assert summary.get("run_complete") is True
+    assert summary.get("run_time_seconds") == 1
+    assert summary.get("run_time_source") == "log_timestamps"
     assert summary.get("validation_run") is True
     assert summary.get("validation_result") == "failed"
     assert not any(rec.get("first_line") == "INFO - Run incomplete" for rec in result.get("recommendations", []))
     assert not any("Memory value not found" in rec.get("message", "") for rec in result.get("recommendations", []))
+
+
+def test_analyze_content_uses_log_timestamp_bounds_without_marking_incomplete_run_complete():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-07-24 18:24:37,827] [kometa.py:441] [INFO] | New log started",
+            "[2026-07-24 18:26:10,100] [metadata.py:100] [INFO] | Still processing",
+        ]
+    )
+
+    result = analyzer.analyze_content(content, include_people_scan=False)
+    summary = result.get("summary")
+
+    assert isinstance(summary, dict)
+    assert summary.get("started_at") == "2026-07-24 18:24:37"
+    assert summary.get("finished_at") == "2026-07-24 18:26:10"
+    assert summary.get("run_time_seconds") == 93
+    assert summary.get("run_time_source") == "log_timestamps"
+    assert summary.get("run_complete") is False
+    assert any("Run incomplete" in rec.get("first_line", "") for rec in result.get("recommendations", []))
 
 
 def test_library_runtime_does_not_become_finished_run_total():

--- a/tests/test_logscan_runtime_parse.py
+++ b/tests/test_logscan_runtime_parse.py
@@ -26,6 +26,49 @@ def test_analyze_content_marks_complete_for_day_runtime():
     assert summary.get("run_time_seconds") == (1 * 24 * 3600) + (2 * 3600) + (20 * 60) + 31
 
 
+def test_analyze_content_marks_validate_passed_log_complete_without_runtime():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-07-24 18:24:37,827] [kometa.py:441] [INFO] | Validation Report (full)",
+            "[2026-07-24 18:24:38,100] [validator.py:100] [INFO] | Result: PASSED",
+        ]
+    )
+
+    result = analyzer.analyze_content(content, include_people_scan=False)
+    summary = result.get("summary")
+
+    assert isinstance(summary, dict)
+    assert summary.get("run_complete") is True
+    assert summary.get("run_time_seconds") is None
+    assert summary.get("validation_run") is True
+    assert summary.get("validation_level") == "full"
+    assert summary.get("validation_result") == "passed"
+    assert summary.get("finished_at") == "2026-07-24 18:24:38"
+    assert not any(rec.get("first_line") == "INFO - Run incomplete" for rec in result.get("recommendations", []))
+    assert not any("Memory value not found" in rec.get("message", "") for rec in result.get("recommendations", []))
+
+
+def test_analyze_content_marks_validate_failed_log_complete_without_runtime():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-07-24 18:24:37,827] [kometa.py:441] [INFO] | Validation Report (structure)",
+            "[2026-07-24 18:24:38,100] [validator.py:100] [INFO] | Result: FAILED",
+        ]
+    )
+
+    result = analyzer.analyze_content(content, include_people_scan=False)
+    summary = result.get("summary")
+
+    assert isinstance(summary, dict)
+    assert summary.get("run_complete") is True
+    assert summary.get("validation_run") is True
+    assert summary.get("validation_result") == "failed"
+    assert not any(rec.get("first_line") == "INFO - Run incomplete" for rec in result.get("recommendations", []))
+    assert not any("Memory value not found" in rec.get("message", "") for rec in result.get("recommendations", []))
+
+
 def test_library_runtime_does_not_become_finished_run_total():
     analyzer = LogscanAnalyzer()
     content = "\n".join(


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes logscan handling for Kometa validation-only runs.

Summary:
- Treats `validator.py` result lines as terminal validation runs, even when there is no normal Kometa `Finished Run` block.
- Preserves validation result text so `PASSED`, `FAILED`, and other result variants can be surfaced correctly.
- Suppresses normal full-run system recommendations for validation-only logs, avoiding false positives like `Memory value not found in content`.
- Fixes `/logscan/analyze` cache finalization and bumps the cache version so corrected analysis is recomputed.

Validation:
- Added regression coverage for validation logs with and without a visible `Validation Report` line.
- Confirmed validation-only logs no longer emit `INFO - Run incomplete`.
- Ran focused tests: `116 passed`.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
