### PR TITLE
import with anchors

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from modules import helpers
 
@@ -104,9 +105,52 @@ def sanitize_config_name(raw_name: str | None) -> str:
     return re.sub(r"[^a-z0-9_]", "", raw_name.strip().lower())
 
 
+def _dealias_yaml_value(value: Any, active_ids: set[int] | None = None) -> Any:
+    """Clone parsed YAML values so aliases cannot share mutable objects.
+
+    ruamel resolves anchors and merge keys for us, but plain aliases can still
+    point at the same Python dict/list.  Import normalization mutates nested
+    values in a few places, so each occurrence needs an independent object.
+    """
+    if active_ids is None:
+        active_ids = set()
+    if isinstance(value, dict):
+        value_id = id(value)
+        if value_id in active_ids:
+            raise ValueError("Recursive YAML aliases are not supported.")
+        active_ids.add(value_id)
+        try:
+            return {_dealias_yaml_value(key, active_ids): _dealias_yaml_value(item, active_ids) for key, item in value.items()}
+        finally:
+            active_ids.remove(value_id)
+    if isinstance(value, list):
+        value_id = id(value)
+        if value_id in active_ids:
+            raise ValueError("Recursive YAML aliases are not supported.")
+        active_ids.add(value_id)
+        try:
+            return [_dealias_yaml_value(item, active_ids) for item in value]
+        finally:
+            active_ids.remove(value_id)
+    if isinstance(value, tuple):
+        value_id = id(value)
+        if value_id in active_ids:
+            raise ValueError("Recursive YAML aliases are not supported.")
+        active_ids.add(value_id)
+        try:
+            return tuple(_dealias_yaml_value(item, active_ids) for item in value)
+        finally:
+            active_ids.remove(value_id)
+    return value
+
+
 def load_yaml_config(raw_text: str) -> dict:
     yaml = YAML(typ="safe", pure=True)
-    loaded = yaml.load(raw_text)
+    try:
+        loaded = yaml.load(raw_text)
+        loaded = _dealias_yaml_value(loaded)
+    except (ValueError, YAMLError):
+        return {}
     return loaded if isinstance(loaded, dict) else {}
 
 

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -3,6 +3,65 @@ import json
 from modules import importer
 
 
+def test_load_yaml_config_resolves_merge_anchors():
+    parsed = importer.load_yaml_config("""
+radarr_defaults: &radarr_defaults
+  quality_profile: HD-1080p
+  root_folder_path: /movies
+
+libraries:
+  Movies:
+    radarr:
+      <<: *radarr_defaults
+      tag: kometa
+  4K Movies:
+    radarr:
+      <<: *radarr_defaults
+      quality_profile: 4K
+""")
+
+    assert parsed["libraries"]["Movies"]["radarr"] == {
+        "quality_profile": "HD-1080p",
+        "root_folder_path": "/movies",
+        "tag": "kometa",
+    }
+    assert parsed["libraries"]["4K Movies"]["radarr"] == {
+        "quality_profile": "4K",
+        "root_folder_path": "/movies",
+    }
+
+
+def test_load_yaml_config_dealiases_shared_anchor_objects():
+    parsed = importer.load_yaml_config("""
+common_tags: &common_tags
+  - kometa
+  - imported
+
+libraries:
+  Movies:
+    radarr:
+      tag: *common_tags
+  TV Shows:
+    sonarr:
+      tag: *common_tags
+""")
+
+    movie_tags = parsed["libraries"]["Movies"]["radarr"]["tag"]
+    show_tags = parsed["libraries"]["TV Shows"]["sonarr"]["tag"]
+
+    assert movie_tags == ["kometa", "imported"]
+    assert show_tags == ["kometa", "imported"]
+    assert movie_tags is not show_tags
+    movie_tags.append("movie-only")
+    assert show_tags == ["kometa", "imported"]
+
+
+def test_load_yaml_config_rejects_recursive_yaml_aliases():
+    parsed = importer.load_yaml_config("recursive: &recursive [*recursive]\n")
+
+    assert parsed == {}
+
+
 def test_prepare_import_payload_unknown_section():
     payload, report = importer.prepare_import_payload({"mystery": {"foo": "bar"}}, set(), set())
     assert payload == {}

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -28,6 +28,31 @@ def test_prepare_import_payload_maps_library_radarr_overrides():
     assert any("libraries.Movies.radarr.url" in line for line in report.lines)
 
 
+def test_prepare_import_payload_maps_library_values_from_yaml_anchors():
+    config_data = importer.load_yaml_config("""
+radarr_defaults: &radarr_defaults
+  url: http://radarr.local:7878
+  quality_profile: HD-1080p
+  search: true
+
+libraries:
+  Movies:
+    radarr:
+      <<: *radarr_defaults
+      add_existing: false
+""")
+
+    payload, report = importer.prepare_import_payload(config_data, {"Movies"}, set())
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-attribute_radarr_url"] == "http://radarr.local:7878"
+    assert libraries["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
+    assert libraries["mov-library_movies-attribute_radarr_search"] == "true"
+    assert libraries["mov-library_movies-attribute_radarr_add_existing"] == "false"
+    assert any("libraries.Movies.radarr.quality_profile" in line for line in report.lines)
+
+
 def test_prepare_import_payload_maps_library_sonarr_overrides():
     payload, report = importer.prepare_import_payload(
         {


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Adds safe YAML anchor support for config imports.

## Changes

- Import parsing now supports YAML anchors, aliases, and `<<` merge keys through the existing `ruamel.yaml` loader.
- Adds a recursive de-alias normalization pass after parsing so repeated YAML aliases do not share mutable Python objects during import processing.
- Rejects recursive YAML aliases safely by treating the config as unparseable instead of risking runaway recursion or mutation bugs.
- Keeps export behavior unchanged: imported anchors are expanded into normal Quickstart-generated YAML rather than preserved as anchors.

## Testing

- Added importer tests for:
  - Merge anchor resolution.
  - Shared alias de-aliasing.
  - Recursive alias rejection.
  - Anchor-derived library values mapping through `prepare_import_payload()`.
- Verified with:
  - `venv\Scripts\python.exe -m pytest tests\test_importer_edge_cases.py tests\test_importer_library_services.py`
  - Importer-focused suite: `60 passed`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1363 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
