### PR TITLE
duplicate config v1

### DIFF
--- a/blueprints/config_routes.py
+++ b/blueprints/config_routes.py
@@ -312,3 +312,85 @@ def rename_config():
         session["config_name"] = new_name
 
     return jsonify(success=True, old_name=old_name, new_name=new_name, files=file_result)
+
+
+@bp.route("/duplicate-config", methods=["POST"])
+def duplicate_config():
+    import quickstart
+
+    wants_json = request.is_json or "application/json" in str(request.headers.get("Accept", "")).lower()
+    data = request.get_json(silent=True) if request.is_json else None
+    data = data or request.form or {}
+
+    def respond(payload, status=200):
+        if wants_json:
+            return jsonify(payload), status
+        category = "success" if payload.get("success") else "error"
+        flash(payload.get("message") or ("Config duplicated." if payload.get("success") else "Duplicate failed."), category)
+        return redirect(url_for("start"), code=303)
+
+    source_name = str(data.get("source_name", "")).strip()
+    new_name = config_management.sanitize_config_name(data.get("new_name"))
+    if not source_name or not new_name:
+        return respond({"success": False, "message": "Source and new config names are required."}, 400)
+    if source_name.lower() == new_name.lower():
+        return respond({"success": False, "message": "New config name must be different."}, 400)
+
+    available = database.get_unique_config_names() or []
+    if source_name not in available:
+        return respond({"success": False, "message": "Source config not found."}, 404)
+    if any(name.lower() == new_name.lower() for name in available):
+        return respond({"success": False, "message": "Config name already exists."}, 400)
+
+    file_check = config_management.duplicate_config_files(source_name, new_name, dry_run=True)
+    if not file_check.get("success"):
+        return respond({"success": False, "message": "Config files are not safe to duplicate.", "details": file_check}, 400)
+
+    file_result = config_management.duplicate_config_files(source_name, new_name)
+    if not file_result.get("success"):
+        return respond({"success": False, "message": "Failed to duplicate config files.", "details": file_result}, 500)
+
+    try:
+        db_result = database.duplicate_config(
+            source_name,
+            new_name,
+            transform_data=lambda _section, data_blob: config_management.rewrite_config_references(
+                data_blob,
+                source_name,
+                new_name,
+            ),
+        )
+    except Exception as exc:
+        helpers.ts_log(f"Failed to duplicate database rows: {exc}", level="ERROR")
+        cleanup = helpers.delete_config_artifacts(new_name, kometa_root=app.config.get("KOMETA_ROOT", "."))
+        response = {"success": False, "message": "Failed to duplicate database rows."}
+        if app.config["QS_DEBUG"]:
+            response["cleanup"] = cleanup
+        return respond(response, 500)
+
+    if not db_result.get("success"):
+        cleanup = helpers.delete_config_artifacts(new_name, kometa_root=app.config.get("KOMETA_ROOT", "."))
+        response = {"success": False, "message": db_result.get("message") or "Failed to duplicate config."}
+        if app.config["QS_DEBUG"]:
+            response["cleanup"] = cleanup
+        return respond(response, 400)
+
+    session["config_name"] = new_name
+    available = database.get_unique_config_names() or []
+    try:
+        menu_templates = helpers.get_menu_list()
+        workspace_status = quickstart._build_workspace_status_context(new_name, menu_templates, available_configs=available)
+    except Exception:
+        workspace_status = {}
+
+    return respond(
+        {
+            "success": True,
+            "message": f"Duplicated '{source_name}' to '{new_name}'.",
+            "source_name": source_name,
+            "new_name": new_name,
+            "files": file_result,
+            "database": db_result,
+            "workspace_status": workspace_status,
+        }
+    )

--- a/modules/config_management.py
+++ b/modules/config_management.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from pathlib import Path
 
 from flask import current_app as app
@@ -15,6 +16,133 @@ def sanitize_config_name(raw_name: str | None) -> str:
 def normalize_config_filename(config_name: str | None) -> str:
     name = (config_name or "").strip().lower().replace(" ", "_")
     return name or "default"
+
+
+def rewrite_config_references(value, old_name: str, new_name: str):
+    old_norm = normalize_config_filename(old_name)
+    new_norm = normalize_config_filename(new_name)
+    old_root = str(helpers.get_managed_config_artifact_root(old_norm))
+    new_root = str(helpers.get_managed_config_artifact_root(new_norm))
+    replacements = (
+        (f"config/{old_norm}/", f"config/{new_norm}/"),
+        (f"config\\{old_norm}\\", f"config\\{new_norm}\\"),
+        (f"{old_norm}_config.yml", f"{new_norm}_config.yml"),
+        (f"{old_norm}_config.yaml", f"{new_norm}_config.yaml"),
+        (old_root, new_root),
+        (old_root.replace("\\", "/"), new_root.replace("\\", "/")),
+    )
+
+    if isinstance(value, dict):
+        rewritten = {}
+        for key, item in value.items():
+            if key == "config_name" and str(item or "").strip().lower() in {old_name.lower(), old_norm}:
+                rewritten[key] = new_name
+            else:
+                rewritten[key] = rewrite_config_references(item, old_name, new_name)
+        return rewritten
+    if isinstance(value, list):
+        return [rewrite_config_references(item, old_name, new_name) for item in value]
+    if isinstance(value, str):
+        text = value
+        for old, new in replacements:
+            text = text.replace(old, new)
+        return text
+    return value
+
+
+def _rewrite_file_config_references(path: Path, old_name: str, new_name: str) -> None:
+    if path.suffix.lower() not in {".yml", ".yaml", ".json", ".txt", ".md"}:
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return
+    rewritten = rewrite_config_references(text, old_name, new_name)
+    if rewritten != text:
+        path.write_text(rewritten, encoding="utf-8")
+
+
+def duplicate_config_files(source_name: str, new_name: str, dry_run: bool = False) -> dict:
+    result = {"success": False, "copied": [], "skipped": [], "errors": []}
+    source_norm = normalize_config_filename(source_name)
+    new_norm = normalize_config_filename(new_name)
+    if source_norm == new_norm:
+        result["errors"].append("Source and target filenames are identical.")
+        return result
+
+    config_dir = Path(helpers.CONFIG_DIR)
+    kometa_root = Path(app.config.get("KOMETA_ROOT", "."))
+    source_config_file = config_dir / f"{source_norm}_config.yml"
+    new_config_file = config_dir / f"{new_norm}_config.yml"
+    source_kometa_file = kometa_root / "config" / f"{source_norm}_config.yml"
+    new_kometa_file = kometa_root / "config" / f"{new_norm}_config.yml"
+    source_managed_root = helpers.get_managed_config_artifact_root(source_norm)
+    new_managed_root = helpers.get_managed_config_artifact_root(new_norm)
+    source_legacy_dirs = helpers.get_legacy_managed_library_artifact_paths(source_norm)
+    new_managed_dirs = helpers.get_managed_library_artifact_paths(new_norm)
+
+    for target in (new_config_file, new_kometa_file, new_managed_root, *new_managed_dirs):
+        if target.exists():
+            result["errors"].append(f"Target already exists: {target}")
+    if result["errors"]:
+        return result
+
+    if dry_run:
+        result["success"] = True
+        return result
+
+    completed: list[Path] = []
+    try:
+        if source_config_file.exists():
+            new_config_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_config_file, new_config_file)
+            _rewrite_file_config_references(new_config_file, source_norm, new_norm)
+            completed.append(new_config_file)
+            result["copied"].append(str(new_config_file))
+        else:
+            result["skipped"].append(str(source_config_file))
+
+        if source_kometa_file.exists():
+            new_kometa_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_kometa_file, new_kometa_file)
+            _rewrite_file_config_references(new_kometa_file, source_norm, new_norm)
+            completed.append(new_kometa_file)
+            result["copied"].append(str(new_kometa_file))
+        else:
+            result["skipped"].append(str(source_kometa_file))
+
+        if source_managed_root.exists():
+            new_managed_root.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source_managed_root, new_managed_root)
+            for copied_file in new_managed_root.rglob("*"):
+                if copied_file.is_file():
+                    _rewrite_file_config_references(copied_file, source_norm, new_norm)
+            completed.append(new_managed_root)
+            result["copied"].append(str(new_managed_root))
+
+        for source_legacy, new_managed in zip(source_legacy_dirs, new_managed_dirs):
+            if source_legacy.exists() and not new_managed.exists():
+                new_managed.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(source_legacy, new_managed)
+                for copied_file in new_managed.rglob("*"):
+                    if copied_file.is_file():
+                        _rewrite_file_config_references(copied_file, source_norm, new_norm)
+                completed.append(new_managed)
+                result["copied"].append(str(new_managed))
+    except Exception as exc:
+        result["errors"].append(f"Duplicate failed: {exc}")
+        for target in reversed(completed):
+            try:
+                if target.is_dir():
+                    shutil.rmtree(target)
+                elif target.exists():
+                    target.unlink()
+            except Exception as cleanup_exc:
+                result["errors"].append(f"Rollback failed for {target}: {cleanup_exc}")
+        return result
+
+    result["success"] = True
+    return result
 
 
 def rename_config_files(old_name: str, new_name: str, dry_run: bool = False) -> dict:

--- a/modules/database.py
+++ b/modules/database.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import pickle
@@ -770,3 +771,68 @@ def rename_config(old_name, new_name):
 
     updated["success"] = True
     return updated
+
+
+def duplicate_config(source_name, target_name, transform_data=None):
+    if not source_name or not target_name or source_name == target_name:
+        return {"success": False, "message": "Invalid config name."}
+    copied = {"section_data": 0, "analytics_preferences": 0}
+    with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
+        connection.row_factory = sqlite3.Row
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(persisted_section_table_create())
+            cursor.execute(analytics_preferences_table_create())
+
+            existing = cursor.execute(
+                "SELECT 1 FROM section_data WHERE name == ? LIMIT 1",
+                (target_name,),
+            ).fetchone()
+            if existing:
+                return {"success": False, "message": "Target config already exists."}
+
+            cursor.execute(
+                "SELECT section, validated, user_entered, data FROM section_data WHERE name == ?",
+                (source_name,),
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return {"success": False, "message": "Source config not found."}
+
+            for row in rows:
+                data_blob = None
+                if row["data"] is not None:
+                    data_blob = pickle.loads(row["data"])
+                    data_blob, _changed = _strip_transient_section_keys(data_blob)
+                    data_blob = copy.deepcopy(data_blob)
+                    if transform_data:
+                        data_blob = transform_data(row["section"], data_blob)
+                cursor.execute(
+                    """INSERT INTO section_data(name, section, validated, user_entered, data)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (
+                        target_name,
+                        row["section"],
+                        helpers.booler(row["validated"]),
+                        helpers.booler(row["user_entered"]),
+                        pickle.dumps(data_blob),
+                    ),
+                )
+                copied["section_data"] += 1
+
+            analytics_row = cursor.execute(
+                "SELECT preferences FROM analytics_preferences WHERE config_name == ?",
+                (source_name,),
+            ).fetchone()
+            if analytics_row:
+                cursor.execute(
+                    """INSERT OR REPLACE INTO analytics_preferences (
+                        config_name,
+                        preferences,
+                        updated_at
+                    ) VALUES (?, ?, datetime('now'))""",
+                    (target_name, analytics_row["preferences"]),
+                )
+                copied["analytics_preferences"] = cursor.rowcount
+
+    copied["success"] = True
+    return copied

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cachelib==0.14.0
 Flask==3.1.3
 Flask-Session==0.8.0
-GitPython==3.1.55
+GitPython==3.1.57
 gunicorn==26.0.0
 jsonschema==4.26.0
 namesgenerator==0.3

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -115,6 +115,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const renameConfigNewName = document.getElementById('renameConfigNewName')
   const renameConfigError = document.getElementById('renameConfigError')
   const confirmRenameConfig = document.getElementById('confirmRenameConfig')
+  const duplicateConfigButton = document.getElementById('duplicateConfigButton')
+  const duplicateConfigModalEl = document.getElementById('duplicateConfigModal')
+  const duplicateConfigSource = document.getElementById('duplicateConfigSource')
+  const duplicateConfigNewName = document.getElementById('duplicateConfigNewName')
+  const duplicateConfigError = document.getElementById('duplicateConfigError')
+  const confirmDuplicateConfig = document.getElementById('confirmDuplicateConfig')
   const importConfigModalEl = document.getElementById('importConfigModal')
   const importConfigFile = document.getElementById('importConfigFile')
   const importConfigName = document.getElementById('importConfigName')
@@ -430,6 +436,7 @@ document.addEventListener('DOMContentLoaded', function () {
     resetConfigButton.disabled = isAddConfig
     if (deleteConfigButton) deleteConfigButton.disabled = isAddConfig
     if (renameConfigButton) renameConfigButton.disabled = isAddConfig
+    if (duplicateConfigButton) duplicateConfigButton.disabled = getAvailableConfigs().length === 0
 
     const box = document.getElementById('newConfigInput')
     if (box) box.classList.toggle('d-none', !(isAddConfig || onlyAddConfigAvailable))
@@ -1250,6 +1257,158 @@ document.addEventListener('DOMContentLoaded', function () {
       } catch (err) {
         confirmRenameConfig.disabled = false
         setRenameError(err.message || 'Rename failed.')
+      }
+    })
+  }
+
+  function setDuplicateError (message) {
+    if (!duplicateConfigError) return
+    if (!message) {
+      duplicateConfigError.classList.add('d-none')
+      duplicateConfigError.textContent = ''
+      return
+    }
+    duplicateConfigError.classList.remove('d-none')
+    duplicateConfigError.textContent = message
+  }
+
+  function suggestDuplicateName (sourceName) {
+    const base = sanitizeConfigName(sourceName || 'config') || 'config'
+    let candidate = `${base}_copy`
+    let suffix = 2
+    while (isDuplicateName(candidate)) {
+      candidate = `${base}_copy_${suffix}`
+      suffix += 1
+    }
+    return candidate
+  }
+
+  function getCurrentDuplicateSourceName () {
+    const managedSelection = configSelector?.value && configSelector.value !== 'add_config'
+      ? configSelector.value
+      : ''
+    return managedSelection || activeConfigInput?.value || window.pageInfo?.config_name || ''
+  }
+
+  function prepareDuplicateConfigModal () {
+    const currentName = getCurrentDuplicateSourceName()
+    if (duplicateConfigSource && currentName) {
+      duplicateConfigSource.value = currentName
+    }
+    if (duplicateConfigNewName) {
+      duplicateConfigNewName.value = suggestDuplicateName(duplicateConfigSource?.value || currentName)
+      removeValidationMessages(duplicateConfigNewName)
+    }
+    setDuplicateError('')
+    updateDuplicateState()
+  }
+
+  function updateDuplicateState () {
+    if (!duplicateConfigSource || !duplicateConfigNewName || !confirmDuplicateConfig) return false
+    const sourceName = duplicateConfigSource.value || ''
+    const sanitized = sanitizeConfigName(duplicateConfigNewName.value)
+    duplicateConfigNewName.value = sanitized
+    removeValidationMessages(duplicateConfigNewName)
+    confirmDuplicateConfig.disabled = true
+    setDuplicateError('')
+
+    if (!sourceName) {
+      setDuplicateError('Select a source config.')
+      return false
+    }
+    if (!sanitized) return false
+    if (sanitized.toLowerCase() === sourceName.toLowerCase()) {
+      applyValidationStyles(duplicateConfigNewName, 'error', 'Name must be different.')
+      setDuplicateError('New name must be different.')
+      return false
+    }
+    if (isDuplicateName(sanitized)) {
+      applyValidationStyles(duplicateConfigNewName, 'error', 'Name already exists.')
+      setDuplicateError('Config name already exists.')
+      return false
+    }
+    applyValidationStyles(duplicateConfigNewName, 'success')
+    confirmDuplicateConfig.disabled = false
+    return true
+  }
+
+  if (duplicateConfigModalEl) {
+    duplicateConfigModalEl.addEventListener('show.bs.modal', () => {
+      prepareDuplicateConfigModal()
+    })
+    duplicateConfigModalEl.addEventListener('shown.bs.modal', () => {
+      updateDuplicateState()
+      duplicateConfigNewName?.focus()
+      duplicateConfigNewName?.select()
+    })
+  }
+
+  if (duplicateConfigButton) {
+    duplicateConfigButton.addEventListener('click', () => {
+      prepareDuplicateConfigModal()
+      window.setTimeout(updateDuplicateState, 0)
+    })
+  }
+
+  if (duplicateConfigSource) {
+    duplicateConfigSource.addEventListener('change', () => {
+      if (duplicateConfigNewName) {
+        duplicateConfigNewName.value = suggestDuplicateName(duplicateConfigSource.value)
+      }
+      updateDuplicateState()
+    })
+  }
+
+  if (duplicateConfigNewName) {
+    duplicateConfigNewName.addEventListener('input', updateDuplicateState)
+    duplicateConfigNewName.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return
+      event.preventDefault()
+      if (confirmDuplicateConfig && !confirmDuplicateConfig.disabled) {
+        confirmDuplicateConfig.click()
+      }
+    })
+  }
+
+  if (confirmDuplicateConfig) {
+    confirmDuplicateConfig.addEventListener('click', async (event) => {
+      event.preventDefault()
+      const sourceName = duplicateConfigSource?.value || ''
+      const newName = sanitizeConfigName(duplicateConfigNewName?.value || '')
+      if (!sourceName) {
+        setDuplicateError('Select a source config.')
+        return
+      }
+      if (!newName) {
+        setDuplicateError('Enter a new config name.')
+        return
+      }
+
+      const originalHtml = confirmDuplicateConfig.innerHTML
+      confirmDuplicateConfig.disabled = true
+      confirmDuplicateConfig.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Duplicating...'
+      try {
+        const res = await fetch('/duplicate-config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ source_name: sourceName, new_name: newName })
+        })
+        const data = await res.json()
+        if (!res.ok || !data.success) {
+          throw new Error(data.message || 'Duplicate failed.')
+        }
+        upsertConfigOption(data.new_name)
+        applyActiveConfigUi(data.new_name)
+        showToast('success', `Duplicated '${sourceName}' to '${data.new_name}'.`)
+        const modal = bootstrap.Modal.getInstance(duplicateConfigModalEl)
+        if (modal) modal.hide()
+        window.setTimeout(() => window.location.reload(), 900)
+      } catch (err) {
+        confirmDuplicateConfig.disabled = false
+        setDuplicateError(err.message || 'Duplicate failed.')
+      } finally {
+        confirmDuplicateConfig.innerHTML = originalHtml
+        updateDuplicateState()
       }
     })
   }

--- a/templates/partials/_config_workspace_modal.html
+++ b/templates/partials/_config_workspace_modal.html
@@ -1,5 +1,13 @@
 {% set show_new_config = page_info['config_name'] not in available_configs %}
 {% set can_merge = available_configs | length > 0 %}
+{% set duplicate_source_config = page_info.config_name if page_info.config_name in available_configs else (available_configs[0] if available_configs else '') %}
+{% set duplicate_suggestion = namespace(value=(duplicate_source_config ~ '_copy') if duplicate_source_config else '', suffix=2) %}
+{% for _ in range((available_configs | length) + 2) %}
+  {% if duplicate_suggestion.value in available_configs %}
+    {% set duplicate_suggestion.value = duplicate_source_config ~ '_copy_' ~ duplicate_suggestion.suffix %}
+    {% set duplicate_suggestion.suffix = duplicate_suggestion.suffix + 1 %}
+  {% endif %}
+{% endfor %}
 <form id="qs-config-workspace-form" class="d-none" aria-hidden="true"></form>
 
 <div class="modal fade" id="configSwitchModal" tabindex="-1" aria-labelledby="configSwitchModalLabel" aria-hidden="true">
@@ -80,6 +88,11 @@
             <button type="button" class="btn btn-secondary" id="renameConfigButton" data-bs-toggle="modal"
               data-bs-target="#renameConfigModal">
               <i class="bi bi-pencil-square"></i> Rename
+            </button>
+
+            <button type="button" class="btn btn-secondary" id="duplicateConfigButton" data-bs-toggle="modal"
+              data-bs-target="#duplicateConfigModal">
+              <i class="bi bi-copy"></i> Duplicate
             </button>
 
             <button type="button" class="btn btn-secondary" id="importConfigButton" data-bs-toggle="modal"
@@ -228,6 +241,39 @@
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-primary" id="confirmRenameConfig" disabled>Rename</button>
       </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="duplicateConfigModal" tabindex="-1" aria-labelledby="duplicateConfigModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="duplicateConfigModalLabel">Duplicate Config</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form id="duplicateConfigForm" action="{{ url_for('config_routes.duplicate_config') }}" method="post">
+      <div class="modal-body">
+        <div class="form-floating mb-3">
+          <select id="duplicateConfigSource" name="source_name" class="form-select">
+            {% for name in available_configs %}
+            <option value="{{ name }}" {% if name == duplicate_source_config %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+          </select>
+          <label for="duplicateConfigSource">Source Config</label>
+        </div>
+        <div class="form-floating">
+          <input type="text" class="form-control" id="duplicateConfigNewName" name="new_name" placeholder="Enter the duplicate config name" value="{{ duplicate_suggestion.value }}">
+          <label for="duplicateConfigNewName">New Config Name</label>
+        </div>
+        <div class="form-text">Lowercase letters, numbers, and underscore only. The duplicate becomes the active config after it is created.</div>
+        <div id="duplicateConfigError" class="text-danger small mt-2 d-none"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary" id="confirmDuplicateConfig" {% if not duplicate_suggestion.value %}disabled{% endif %}>Duplicate</button>
+      </div>
+      </form>
     </div>
   </div>
 </div>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -5325,6 +5325,145 @@ def test_rename_config_moves_managed_library_file_directories(client, isolated_c
     assert old_name not in database.get_unique_config_names()
 
 
+def test_duplicate_config_copies_database_and_managed_artifacts(client, isolated_config_dir, app):
+    from modules import database
+    from pathlib import Path
+
+    source_name = "duplicate_source"
+    new_name = "duplicate_target"
+    kometa_path = Path(app.config["KOMETA_ROOT"]) / "config"
+    kometa_path.mkdir(parents=True, exist_ok=True)
+
+    (isolated_config_dir / f"{source_name}_config.yml").write_text(
+        f"libraries:\n  Movies:\n    collection_files:\n      - file: config/{source_name}/collection_files/mov-library_movies/movies.yml\n",
+        encoding="utf-8",
+    )
+    (kometa_path / f"{source_name}_config.yml").write_text(
+        f"metadata_path: config/{source_name}/metadata_files/mov-library_movies/movies.yml\n",
+        encoding="utf-8",
+    )
+    metadata_dir = isolated_config_dir / source_name / "metadata_files" / "mov-library_movies"
+    collection_dir = isolated_config_dir / source_name / "collection_files" / "mov-library_movies"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    (metadata_dir / "movies.yml").write_text(
+        f"metadata:\n  Test:\n    file: config/{source_name}/metadata_files/mov-library_movies/movies.yml\n",
+        encoding="utf-8",
+    )
+    (collection_dir / "movies.yml").write_text("collections:\n  Test:\n    sort_title: Test\n", encoding="utf-8")
+
+    database.save_section_data(
+        name=source_name,
+        section="start",
+        validated=True,
+        user_entered=True,
+        data={"start": {"config_name": source_name}},
+    )
+    database.save_section_data(
+        name=source_name,
+        section="025-libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies": {
+                    "metadata_files": [f"config/{source_name}/metadata_files/mov-library_movies/movies.yml"],
+                    "collection_files": [f"config/{source_name}/collection_files/mov-library_movies/movies.yml"],
+                }
+            }
+        },
+    )
+    database.save_analytics_preferences(source_name, {"panels": {"summary": False}, "issues": {}})
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = source_name
+
+    resp = client.post("/duplicate-config", json={"source_name": source_name, "new_name": new_name})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["source_name"] == source_name
+    assert payload["new_name"] == new_name
+
+    assert source_name in database.get_unique_config_names()
+    assert new_name in database.get_unique_config_names()
+
+    source_validated, _source_user_entered, source_data = database.retrieve_section_data(source_name, "025-libraries")
+    target_validated, target_user_entered, target_data = database.retrieve_section_data(new_name, "025-libraries")
+    assert source_validated is True
+    assert target_validated is True
+    assert target_user_entered is True
+    assert f"config/{source_name}/" in source_data["libraries"]["mov-library_movies"]["metadata_files"][0]
+    assert f"config/{new_name}/" in target_data["libraries"]["mov-library_movies"]["metadata_files"][0]
+    assert f"config/{new_name}/" in target_data["libraries"]["mov-library_movies"]["collection_files"][0]
+
+    _validated, _user_entered, start_data = database.retrieve_section_data(new_name, "start")
+    assert isinstance(start_data.get("start"), dict)
+
+    copied_metadata = isolated_config_dir / new_name / "metadata_files" / "mov-library_movies" / "movies.yml"
+    copied_collection = isolated_config_dir / new_name / "collection_files" / "mov-library_movies" / "movies.yml"
+    assert copied_metadata.exists()
+    assert copied_collection.exists()
+    assert f"config/{new_name}/metadata_files" in copied_metadata.read_text(encoding="utf-8")
+    assert f"config/{new_name}/collection_files" in (isolated_config_dir / f"{new_name}_config.yml").read_text(encoding="utf-8")
+    assert f"config/{new_name}/metadata_files" in (kometa_path / f"{new_name}_config.yml").read_text(encoding="utf-8")
+
+    with client.session_transaction() as sess:
+        assert sess["config_name"] == new_name
+
+
+def test_duplicate_config_rejects_existing_target(client, isolated_config_dir):
+    from modules import database
+
+    database.save_section_data(
+        name="duplicate_source",
+        section="start",
+        validated=True,
+        user_entered=True,
+        data={"start": {"config_name": "duplicate_source"}},
+    )
+    database.save_section_data(
+        name="duplicate_target",
+        section="start",
+        validated=True,
+        user_entered=True,
+        data={"start": {"config_name": "duplicate_target"}},
+    )
+
+    resp = client.post("/duplicate-config", json={"source_name": "duplicate_source", "new_name": "duplicate_target"})
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["success"] is False
+    assert "already exists" in payload["message"]
+
+
+def test_duplicate_config_form_post_redirects_and_activates_config(client, isolated_config_dir):
+    from modules import database
+
+    database.save_section_data(
+        name="duplicate_source",
+        section="start",
+        validated=True,
+        user_entered=True,
+        data={"start": {"config_name": "duplicate_source"}},
+    )
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = "duplicate_source"
+
+    resp = client.post(
+        "/duplicate-config",
+        data={"source_name": "duplicate_source", "new_name": "duplicate_source_copy"},
+    )
+
+    assert resp.status_code == 303
+    assert resp.headers["Location"].endswith("/")
+    assert "duplicate_source_copy" in database.get_unique_config_names()
+
+    with client.session_transaction() as sess:
+        assert sess["config_name"] == "duplicate_source_copy"
+
+
 def test_prune_invalid_section_rows_removes_blank_config_entries(isolated_config_dir):
     import sqlite3
     from modules import database


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Adds config duplication from the shared Manage Configs modal so users can clone an existing Quickstart config without exporting/importing manually.

## Changes

- Added a `/duplicate-config` backend route.
- Copies database rows from the source config to the new config.
- Copies managed config artifacts and rewrites config-name path references.
- Makes the duplicated config active after creation.
- Suggests `<source>_copy`, then `<source>_copy_2`, `_copy_3`, etc. when needed.
- Added a server-rendered fallback so Duplicate works even if page JS does not bind correctly.
- Keeps the AJAX path for spinner/toast behavior when JS is active.
- Added regression coverage for JSON and form-submit duplicate flows.

## Validation

- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k "duplicate_config"`
- `npx eslint static\local-js\001-start.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
