### PR TITLE
Fix playlist row button order to match the other three kinds

### DIFF
--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -497,21 +497,18 @@ const libraryFileRowKinds = {
     domPrefix: 'metadata-file',
     typeOptions: ['file', 'folder', 'git', 'repo', 'url'],
     placeholder: 'config/metadata.yml, config/metadata/, user/file.yml, or https://example.com/metadata.yml',
-    editButtonFirst: false,
     updateValidateButton: (row, validated) => updateMetadataFileValidateButton(row, validated)
   },
   collection_files: {
     domPrefix: 'collection-file',
     typeOptions: ['file', 'folder', 'git', 'repo', 'url'],
     placeholder: 'config/collections.yml, config/collections/, user/file.yml, or https://example.com/collections.yml',
-    editButtonFirst: false,
     updateValidateButton: (row, validated) => updateCollectionFileValidateButton(row, validated)
   },
   overlay_files: {
     domPrefix: 'overlay-file',
     typeOptions: ['file', 'folder', 'git', 'repo', 'url'],
     placeholder: 'config/overlays.yml, config/overlays/, user/file.yml, or https://example.com/overlays.yml',
-    editButtonFirst: false,
     updateValidateButton: (row, validated) => updateOverlayFileValidateButton(row, validated)
   },
   playlist_files: {
@@ -519,10 +516,6 @@ const libraryFileRowKinds = {
     // NB: no 'folder' -- playlists are single-file.
     typeOptions: ['file', 'git', 'repo', 'url'],
     placeholder: 'config/playlists.yml, user/playlists.yml, or https://example.com/playlists.yml',
-    // NB: playlist row has Edit before Validate (see #1659); the other
-    // three have Validate before Edit. Preserved as-is for zero
-    // behaviour drift.
-    editButtonFirst: true,
     updateValidateButton: (row, validated) => updatePlaylistFileValidateButton(row, validated)
   }
 }
@@ -538,9 +531,7 @@ function buildLibraryFileRow (kind, entry = {}) {
   const validateBtn = `<button type="button" class="btn btn-success btn-sm" data-validate-${config.domPrefix}>Validate</button>`
   const editBtn = `<button type="button" class="btn btn-outline-primary btn-sm" data-external-yaml-edit data-external-yaml-kind="${kind}">Edit</button>`
   const removeBtn = `<button type="button" class="btn btn-danger btn-sm" data-remove-${config.domPrefix}>Remove</button>`
-  const actionButtons = config.editButtonFirst
-    ? `${editBtn}\n          ${validateBtn}\n          ${removeBtn}`
-    : `${validateBtn}\n          ${editBtn}\n          ${removeBtn}`
+  const actionButtons = `${validateBtn}\n          ${editBtn}\n          ${removeBtn}`
   wrapper.innerHTML = `
     <div class="card-body">
       <div class="row g-3 align-items-end">


### PR DESCRIPTION
Stacked on #1674 (must merge #1674 first).

## Why

Every non-playlist library file row (metadata / collection / overlay) renders its action buttons as `[Validate, Edit, Remove]`. The playlist row alone renders `[Edit, Validate, Remove]`.

Almost certainly a #1659 copy-paste drift — there's no product reason for playlist rows to be different, and the visual inconsistency shows up on the same page for anyone who scrolls between sections. #1674 explicitly preserved the drift ("this PR is a pure dedupe, fixing behaviour belongs elsewhere"). This is elsewhere.

## What changed

- Removed `editButtonFirst: true` from the `playlist_files` kind config.
- The `editButtonFirst` flag was only true for one kind; with playlist flipped, it's now `false` for every kind — dead configuration. Deleted the flag from all four kind entries and simplified the `actionButtons` ternary in `buildLibraryFileRow` to a straight-line template.

## Verification

- `npx eslint` — clean
- `npm run build` — clean (Vite chunk 223.97 → 223.83 kB)

## Net

+1 / −10 in one file. Tiny.
