### PR TITLE
Extract shared library-files-editor subsystem (43 → 1 impl)

### DIFF
--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6,6 +6,7 @@
 // delegates to.
 import { updateAccordionHighlights } from '/static/local-js/modules/accordionHighlights.js'
 import { initExternalYamlEditorSubsystem } from '/static/local-js/modules/externalYamlEditor.js'
+import { createLibraryFilesEditor } from '/static/local-js/modules/libraryFilesEditor.js'
 
 // Load all helper modules in parallel. These publish their symbols
 // via window.* shims (same pattern as pathValidation.js).
@@ -596,607 +597,6 @@ function buildPlaylistFileRow (entry = {}) {
   return buildLibraryFileRow('playlist_files', entry)
 }
 
-function updateMetadataFileValidateButton (row, isValidated) {
-  if (!row) return
-  const button = row.querySelector('[data-validate-metadata-file]')
-  if (!button) return
-  const state = String(row.dataset.metadataFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
-  button.classList.remove('btn-success', 'btn-secondary')
-  if (state === 'success') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validated'
-    return
-  }
-  if (state === 'blocked') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Needs Repo'
-    return
-  }
-  if (state === 'loading') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validating...'
-    return
-  }
-  button.disabled = false
-  button.classList.add('btn-success')
-  button.textContent = 'Validate'
-}
-
-function setMetadataFileButtonState (row, state) {
-  if (!row) return
-  row.dataset.metadataFileButtonState = state || 'idle'
-  updateMetadataFileValidateButton(row, state === 'success')
-}
-
-function updateMetadataCustomRepoStatus (editor) {
-  if (!editor) return
-  const target = editor.querySelector('[data-metadata-custom-repo-status]')
-  if (!target) return
-
-  target.replaceChildren()
-  target.className = 'alert small mb-3'
-  if (!metadataCustomRepoBase) {
-    target.classList.add('alert-warning')
-    target.append('Custom Repo is not configured. ')
-    target.append('Use ')
-    appendMetadataSettingsLink(target, 'alert-link fw-semibold')
-    target.append(' to configure and save it before using ')
-    const code = document.createElement('code')
-    code.textContent = 'repo'
-    target.appendChild(code)
-    target.append(' metadata files.')
-    return
-  }
-
-  target.classList.add('alert-secondary')
-  const label = document.createElement('div')
-  label.className = 'fw-semibold mb-1'
-  label.textContent = 'Custom Repo base used for repo entries'
-  target.appendChild(label)
-
-  const baseValue = document.createElement('code')
-  baseValue.textContent = metadataCustomRepoBase
-  target.appendChild(baseValue)
-
-  if (metadataCustomRepoRaw && metadataCustomRepoRaw !== metadataCustomRepoBase) {
-    const savedValue = document.createElement('div')
-    savedValue.className = 'mt-2'
-    savedValue.append('Saved Custom Repo value: ')
-    const savedCode = document.createElement('code')
-    savedCode.textContent = metadataCustomRepoRaw
-    savedValue.appendChild(savedCode)
-    target.appendChild(savedValue)
-  }
-
-  const hint = document.createElement('div')
-  hint.className = 'mt-2'
-  hint.append('Change it in ')
-  appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
-  hint.append('.')
-  target.appendChild(hint)
-}
-
-function applyMetadataFileDependencyState (row, opts = {}) {
-  if (!row) return false
-  const skipStatus = Boolean(opts.skipStatus)
-  const type = row.querySelector('[data-metadata-file-type]')?.value || ''
-  if (type !== 'repo') {
-    if (row.dataset.metadataFileDependency === 'repo-missing') {
-      row.dataset.metadataFileDependency = ''
-    }
-    return false
-  }
-
-  if (metadataCustomRepoBase) {
-    if (row.dataset.metadataFileDependency === 'repo-missing') {
-      row.dataset.metadataFileDependency = ''
-    }
-    return false
-  }
-
-  row.dataset.metadataFileDependency = 'repo-missing'
-  setMetadataFileButtonState(row, 'blocked')
-  if (!skipStatus) {
-    setMetadataFileStatus(row, 'error', metadataRepoDependencyMessage)
-  }
-  return true
-}
-
-function renderMetadataFileStatusMessage (target, message) {
-  target.replaceChildren()
-  if (!message) return
-
-  if (typeof message === 'object' && message !== null) {
-    const text = String(message.text || message.message || '').trim()
-    const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
-    if (text) {
-      const summary = document.createElement('div')
-      appendInlineCodeText(summary, text)
-      target.appendChild(summary)
-    }
-    if (files.length) {
-      if (files.length <= 5) {
-        const list = document.createElement('ul')
-        list.className = 'mb-0 mt-1 ps-3'
-        files.forEach(file => {
-          const item = document.createElement('li')
-          appendInlineCodeText(item, file, { wrapPlainInCode: true })
-          list.appendChild(item)
-        })
-        target.appendChild(list)
-      } else {
-        const details = document.createElement('details')
-        details.className = 'mt-1'
-        const summary = document.createElement('summary')
-        summary.className = 'cursor-pointer'
-        summary.textContent = 'Show files'
-        details.appendChild(summary)
-        const list = document.createElement('ul')
-        list.className = 'mb-0 mt-1 ps-3'
-        files.forEach(file => {
-          const item = document.createElement('li')
-          appendInlineCodeText(item, file, { wrapPlainInCode: true })
-          list.appendChild(item)
-        })
-        details.appendChild(list)
-        target.appendChild(details)
-      }
-    }
-    return
-  }
-
-  const text = String(message || '').trim()
-  if (!text) return
-
-  if (text === metadataRepoDependencyMessage) {
-    target.append('Metadata file repo entries require Custom Repo to be configured and saved first within the ')
-    appendMetadataSettingsLink(target)
-    target.append(' page.')
-    return
-  }
-
-  appendInlineCodeText(target, text)
-}
-
-function setMetadataFileStatus (row, kind, message) {
-  if (!row) return
-  const target = row.querySelector('[data-metadata-file-status]')
-  if (!target) return
-  row.dataset.metadataFileState = kind || ''
-  target.className = 'mt-2 small'
-  if (!message) {
-    target.classList.add('d-none')
-    target.textContent = ''
-    if (applyMetadataFileDependencyState(row, { skipStatus: true })) {
-      setMetadataFileButtonState(row, 'blocked')
-    } else {
-      setMetadataFileButtonState(row, 'idle')
-    }
-    const editor = row.closest('[data-metadata-files-editor]')
-    if (editor) updateMetadataFilesAccordionState(editor)
-    return
-  }
-  target.classList.remove('d-none')
-  if (kind === 'success') {
-    target.classList.add('text-success')
-  } else if (kind === 'error') {
-    target.classList.add('text-danger')
-  } else {
-    target.classList.add('text-warning')
-  }
-  renderMetadataFileStatusMessage(target, message)
-  if (kind === 'success') {
-    setMetadataFileButtonState(row, 'success')
-  } else if (row.dataset.metadataFileDependency === 'repo-missing') {
-    setMetadataFileButtonState(row, 'blocked')
-  } else {
-    setMetadataFileButtonState(row, 'idle')
-  }
-  const editor = row.closest('[data-metadata-files-editor]')
-  if (editor) updateMetadataFilesAccordionState(editor)
-}
-
-function updateMetadataFilesAccordionState (editor) {
-  if (!editor) return
-  const accordionItem = editor.closest('.accordion-item')
-  const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
-  if (!accordionHeader) return
-
-  const rows = Array.from(editor.querySelectorAll('[data-metadata-file-row]'))
-  const hasEntries = rows.some(row => {
-    const type = row.querySelector('[data-metadata-file-type]')?.value || ''
-    const location = row.querySelector('[data-metadata-file-location]')?.value || ''
-    return Boolean(normalizeMetadataFileEntry({ type, location }))
-  })
-  const hasInvalid = rows.some(row => {
-    const state = String(row.dataset.metadataFileState || '').trim().toLowerCase()
-    return state === 'error' || state === 'warning'
-  })
-
-  accordionHeader.classList.remove('invalid')
-  if (hasInvalid) {
-    accordionHeader.classList.add('invalid')
-    return
-  }
-
-  accordionHeader.classList.remove('warning')
-  if (hasEntries) {
-    accordionHeader.classList.add('selected')
-  } else {
-    accordionHeader.classList.remove('selected')
-  }
-}
-
-function applyMetadataFileServerErrors (editor, errors) {
-  if (!editor || !Array.isArray(errors) || !errors.length) return false
-  const rows = Array.from(editor.querySelectorAll('[data-metadata-file-row]'))
-  rows.forEach(row => setMetadataFileStatus(row, '', ''))
-  let applied = false
-  errors.forEach(error => {
-    const text = String(error || '').trim()
-    const match = text.match(/metadata_files\[(\d+)\]:\s*(.+)$/i)
-    if (!match) return
-    const index = Number(match[1]) - 1
-    const message = match[2] || 'Validation failed.'
-    if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
-    setMetadataFileStatus(rows[index], 'error', message)
-    applied = true
-  })
-  return applied
-}
-
-function syncMetadataFilesEditor (editor, emitEvents = true) {
-  if (!editor) return []
-  const hidden = editor.querySelector('input[type="hidden"][name$="-metadata_files"]')
-  if (!hidden) return []
-  const rows = Array.from(editor.querySelectorAll('[data-metadata-file-row]'))
-  const entries = rows.map(row => {
-    const type = row.querySelector('[data-metadata-file-type]')?.value
-    const location = row.querySelector('[data-metadata-file-location]')?.value
-    const validated = String(row.dataset.metadataFileState || '').trim().toLowerCase() === 'success'
-    return normalizeMetadataFileEntry({ type, location, validated })
-  }).filter(Boolean)
-  hidden.value = JSON.stringify(entries)
-  if (emitEvents) {
-    hidden.dispatchEvent(new Event('input', { bubbles: true }))
-    hidden.dispatchEvent(new Event('change', { bubbles: true }))
-  }
-  updateMetadataFilesAccordionState(editor)
-  return entries
-}
-
-function renderMetadataFilesEditor (editor) {
-  if (!editor) return
-  const hidden = editor.querySelector('input[type="hidden"][name$="-metadata_files"]')
-  const list = editor.querySelector('[data-metadata-files-list]')
-  if (!hidden || !list) return
-  updateMetadataCustomRepoStatus(editor)
-  const entries = parseMetadataFilesValue(hidden.value)
-  list.replaceChildren()
-  entries.forEach(entry => list.appendChild(buildMetadataFileRow(entry)))
-  list.querySelectorAll('[data-metadata-file-row]').forEach(row => {
-    if (applyMetadataFileDependencyState(row)) return
-    if (String(row.dataset.metadataFileState || '').trim().toLowerCase() === 'success') {
-      setMetadataFileButtonState(row, 'success')
-    } else {
-      setMetadataFileButtonState(row, 'idle')
-    }
-  })
-  syncMetadataFilesEditor(editor, false)
-  updateMetadataFilesAccordionState(editor)
-}
-
-function initMetadataFilesEditors (scope) {
-  const root = scope || document
-  root.querySelectorAll('[data-metadata-files-editor]').forEach(editor => {
-    if (editor.dataset.metadataFilesReady === 'true') return
-    renderMetadataFilesEditor(editor)
-    editor.dataset.metadataFilesReady = 'true'
-  })
-}
-
-
-function updateCollectionFileValidateButton (row, isValidated) {
-  if (!row) return
-  const button = row.querySelector('[data-validate-collection-file]')
-  if (!button) return
-  const state = String(row.dataset.collectionFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
-  button.classList.remove('btn-success', 'btn-secondary')
-  if (state === 'success') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validated'
-    return
-  }
-  if (state === 'blocked') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Needs Repo'
-    return
-  }
-  if (state === 'loading') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validating...'
-    return
-  }
-  button.disabled = false
-  button.classList.add('btn-success')
-  button.textContent = 'Validate'
-}
-
-function setCollectionFileButtonState (row, state) {
-  if (!row) return
-  row.dataset.collectionFileButtonState = state || 'idle'
-  updateCollectionFileValidateButton(row, state === 'success')
-}
-
-function updateCollectionCustomRepoStatus (editor) {
-  if (!editor) return
-  const target = editor.querySelector('[data-collection-custom-repo-status]')
-  if (!target) return
-
-  target.replaceChildren()
-  target.className = 'alert small mb-3'
-  if (!metadataCustomRepoBase) {
-    target.classList.add('alert-warning')
-    target.append('Custom Repo is not configured. ')
-    target.append('Use ')
-    appendMetadataSettingsLink(target, 'alert-link fw-semibold')
-    target.append(' to configure and save it before using ')
-    const code = document.createElement('code')
-    code.textContent = 'repo'
-    target.appendChild(code)
-    target.append(' collection files.')
-    return
-  }
-
-  target.classList.add('alert-secondary')
-  const label = document.createElement('div')
-  label.className = 'fw-semibold mb-1'
-  label.textContent = 'Custom Repo base used for repo entries'
-  target.appendChild(label)
-
-  const baseValue = document.createElement('code')
-  baseValue.textContent = metadataCustomRepoBase
-  target.appendChild(baseValue)
-
-  if (metadataCustomRepoRaw && metadataCustomRepoRaw !== metadataCustomRepoBase) {
-    const savedValue = document.createElement('div')
-    savedValue.className = 'mt-2'
-    savedValue.append('Saved Custom Repo value: ')
-    const savedCode = document.createElement('code')
-    savedCode.textContent = metadataCustomRepoRaw
-    savedValue.appendChild(savedCode)
-    target.appendChild(savedValue)
-  }
-
-  const hint = document.createElement('div')
-  hint.className = 'mt-2'
-  hint.append('Change it in ')
-  appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
-  hint.append('.')
-  target.appendChild(hint)
-}
-
-function applyCollectionFileDependencyState (row, opts = {}) {
-  if (!row) return false
-  const skipStatus = Boolean(opts.skipStatus)
-  const type = row.querySelector('[data-collection-file-type]')?.value || ''
-  if (type !== 'repo') {
-    if (row.dataset.collectionFileDependency === 'repo-missing') {
-      row.dataset.collectionFileDependency = ''
-    }
-    return false
-  }
-
-  if (metadataCustomRepoBase) {
-    if (row.dataset.collectionFileDependency === 'repo-missing') {
-      row.dataset.collectionFileDependency = ''
-    }
-    return false
-  }
-
-  row.dataset.collectionFileDependency = 'repo-missing'
-  setCollectionFileButtonState(row, 'blocked')
-  if (!skipStatus) {
-    setCollectionFileStatus(row, 'error', collectionRepoDependencyMessage)
-  }
-  return true
-}
-
-function renderCollectionFileStatusMessage (target, message) {
-  target.replaceChildren()
-  if (!message) return
-
-  if (typeof message === 'object' && message !== null) {
-    const text = String(message.text || message.message || '').trim()
-    const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
-    if (text) {
-      const summary = document.createElement('div')
-      appendInlineCodeText(summary, text)
-      target.appendChild(summary)
-    }
-    if (files.length) {
-      if (files.length <= 5) {
-        const list = document.createElement('ul')
-        list.className = 'mb-0 mt-1 ps-3'
-        files.forEach(file => {
-          const item = document.createElement('li')
-          appendInlineCodeText(item, file, { wrapPlainInCode: true })
-          list.appendChild(item)
-        })
-        target.appendChild(list)
-      } else {
-        const details = document.createElement('details')
-        details.className = 'mt-1'
-        const summary = document.createElement('summary')
-        summary.className = 'cursor-pointer'
-        summary.textContent = 'Show files'
-        details.appendChild(summary)
-        const list = document.createElement('ul')
-        list.className = 'mb-0 mt-1 ps-3'
-        files.forEach(file => {
-          const item = document.createElement('li')
-          appendInlineCodeText(item, file, { wrapPlainInCode: true })
-          list.appendChild(item)
-        })
-        details.appendChild(list)
-        target.appendChild(details)
-      }
-    }
-    return
-  }
-
-  const text = String(message || '').trim()
-  if (!text) return
-
-  if (text === collectionRepoDependencyMessage) {
-    target.append('Collection file repo entries require Custom Repo to be configured and saved first within the ')
-    appendMetadataSettingsLink(target)
-    target.append(' page.')
-    return
-  }
-
-  appendInlineCodeText(target, text)
-}
-
-function setCollectionFileStatus (row, kind, message) {
-  if (!row) return
-  const target = row.querySelector('[data-collection-file-status]')
-  if (!target) return
-  row.dataset.collectionFileState = kind || ''
-  target.className = 'mt-2 small'
-  if (!message) {
-    target.classList.add('d-none')
-    target.textContent = ''
-    if (applyCollectionFileDependencyState(row, { skipStatus: true })) {
-      setCollectionFileButtonState(row, 'blocked')
-    } else {
-      setCollectionFileButtonState(row, 'idle')
-    }
-    const editor = row.closest('[data-collection-files-editor]')
-    if (editor) updateCollectionFilesAccordionState(editor)
-    return
-  }
-  target.classList.remove('d-none')
-  if (kind === 'success') {
-    target.classList.add('text-success')
-  } else if (kind === 'error') {
-    target.classList.add('text-danger')
-  } else {
-    target.classList.add('text-warning')
-  }
-  renderCollectionFileStatusMessage(target, message)
-  if (kind === 'success') {
-    setCollectionFileButtonState(row, 'success')
-  } else if (row.dataset.collectionFileDependency === 'repo-missing') {
-    setCollectionFileButtonState(row, 'blocked')
-  } else {
-    setCollectionFileButtonState(row, 'idle')
-  }
-  const editor = row.closest('[data-collection-files-editor]')
-  if (editor) updateCollectionFilesAccordionState(editor)
-}
-
-function updateCollectionFilesAccordionState (editor) {
-  if (!editor) return
-  const accordionItem = editor.closest('.accordion-item')
-  const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
-  if (!accordionHeader) return
-
-  const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
-  const hasEntries = rows.some(row => normalizeMetadataFileEntry({
-    type: row.querySelector('[data-collection-file-type]')?.value || '',
-    location: row.querySelector('[data-collection-file-location]')?.value || ''
-  }))
-  const hasInvalid = rows.some(row => {
-    const state = String(row.dataset.collectionFileState || '').trim().toLowerCase()
-    return state === 'error' || state === 'warning'
-  })
-
-  accordionHeader.classList.remove('warning')
-  accordionHeader.classList.toggle('invalid', hasInvalid)
-  if (!hasInvalid && hasEntries) {
-    accordionHeader.classList.add('selected')
-  } else {
-    accordionHeader.classList.remove('selected')
-    if (!hasEntries && !hasInvalid) {
-      updateAccordionHighlights()
-    }
-  }
-}
-
-function applyCollectionFileServerErrors (editor, errors) {
-  if (!editor || !Array.isArray(errors) || !errors.length) return false
-  const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
-  rows.forEach(row => setCollectionFileStatus(row, '', ''))
-  let applied = false
-  errors.forEach(error => {
-    const text = String(error || '').trim()
-    const match = text.match(/collection_files\[(\d+)\]:\s*(.+)$/i)
-    if (!match) return
-    const index = Number(match[1]) - 1
-    const message = match[2] || 'Validation failed.'
-    if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
-    setCollectionFileStatus(rows[index], 'error', message)
-    applied = true
-  })
-  return applied
-}
-
-function syncCollectionFilesEditor (editor, emitEvents = true) {
-  if (!editor) return []
-  const hidden = editor.querySelector('input[type="hidden"][name$="-collection_files"]')
-  if (!hidden) return []
-  const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
-  const entries = rows.map(row => {
-    const type = row.querySelector('[data-collection-file-type]')?.value
-    const location = row.querySelector('[data-collection-file-location]')?.value
-    const validated = String(row.dataset.collectionFileState || '').trim().toLowerCase() === 'success'
-    return normalizeMetadataFileEntry({ type, location, validated })
-  }).filter(Boolean)
-  hidden.value = JSON.stringify(entries)
-  if (emitEvents) {
-    hidden.dispatchEvent(new Event('input', { bubbles: true }))
-    hidden.dispatchEvent(new Event('change', { bubbles: true }))
-  }
-  updateCollectionFilesAccordionState(editor)
-  return entries
-}
-
-function renderCollectionFilesEditor (editor) {
-  if (!editor) return
-  const hidden = editor.querySelector('input[type="hidden"][name$="-collection_files"]')
-  const list = editor.querySelector('[data-collection-files-list]')
-  if (!hidden || !list) return
-  updateCollectionCustomRepoStatus(editor)
-  const entries = parseMetadataFilesValue(hidden.value)
-  list.replaceChildren()
-  entries.forEach(entry => list.appendChild(buildCollectionFileRow(entry)))
-  list.querySelectorAll('[data-collection-file-row]').forEach(row => {
-    if (applyCollectionFileDependencyState(row)) return
-    if (String(row.dataset.collectionFileState || '').trim().toLowerCase() === 'success') {
-      setCollectionFileButtonState(row, 'success')
-    } else {
-      setCollectionFileButtonState(row, 'idle')
-    }
-  })
-  syncCollectionFilesEditor(editor, false)
-  updateCollectionFilesAccordionState(editor)
-}
-
-function initCollectionFilesEditors (scope) {
-  const root = scope || document
-  root.querySelectorAll('[data-collection-files-editor]').forEach(editor => {
-    if (editor.dataset.collectionFilesReady === 'true') return
-    renderCollectionFilesEditor(editor)
-    editor.dataset.collectionFilesReady = 'true'
-  })
-}
 
 document.addEventListener('click', async function (event) {
   const addButton = event.target.closest('[data-add-metadata-file]')
@@ -1393,305 +793,6 @@ if (libraryContainer && typeof MutationObserver !== 'undefined') {
 }
 
 
-function updateOverlayFileValidateButton (row, isValidated) {
-  if (!row) return
-  const button = row.querySelector('[data-validate-overlay-file]')
-  if (!button) return
-  const state = String(row.dataset.overlayFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
-  button.classList.remove('btn-success', 'btn-secondary')
-  if (state === 'success') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validated'
-    return
-  }
-  if (state === 'blocked') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Needs Repo'
-    return
-  }
-  if (state === 'loading') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validating...'
-    return
-  }
-  button.disabled = false
-  button.classList.add('btn-success')
-  button.textContent = 'Validate'
-}
-
-function setOverlayFileButtonState (row, state) {
-  if (!row) return
-  row.dataset.overlayFileButtonState = state || 'idle'
-  updateOverlayFileValidateButton(row, state === 'success')
-}
-
-function updateOverlayCustomRepoStatus (editor) {
-  if (!editor) return
-  const target = editor.querySelector('[data-overlay-custom-repo-status]')
-  if (!target) return
-
-  target.replaceChildren()
-  target.className = 'alert small mb-3'
-  if (!metadataCustomRepoBase) {
-    target.classList.add('alert-warning')
-    target.append('Custom Repo is not configured. ')
-    target.append('Use ')
-    appendMetadataSettingsLink(target, 'alert-link fw-semibold')
-    target.append(' to configure and save it before using ')
-    const code = document.createElement('code')
-    code.textContent = 'repo'
-    target.appendChild(code)
-    target.append(' overlay files.')
-    return
-  }
-
-  target.classList.add('alert-secondary')
-  const label = document.createElement('div')
-  label.className = 'fw-semibold mb-1'
-  label.textContent = 'Custom Repo base used for repo entries'
-  target.appendChild(label)
-
-  const baseValue = document.createElement('code')
-  baseValue.textContent = metadataCustomRepoBase
-  target.appendChild(baseValue)
-
-  if (metadataCustomRepoRaw && metadataCustomRepoRaw !== metadataCustomRepoBase) {
-    const savedValue = document.createElement('div')
-    savedValue.className = 'mt-2'
-    savedValue.append('Saved Custom Repo value: ')
-    const savedCode = document.createElement('code')
-    savedCode.textContent = metadataCustomRepoRaw
-    savedValue.appendChild(savedCode)
-    target.appendChild(savedValue)
-  }
-
-  const hint = document.createElement('div')
-  hint.className = 'mt-2'
-  hint.append('Change it in ')
-  appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
-  hint.append('.')
-  target.appendChild(hint)
-}
-
-function applyOverlayFileDependencyState (row, opts = {}) {
-  if (!row) return false
-  const skipStatus = Boolean(opts.skipStatus)
-  const type = row.querySelector('[data-overlay-file-type]')?.value || ''
-  if (type !== 'repo') {
-    if (row.dataset.overlayFileDependency === 'repo-missing') {
-      row.dataset.overlayFileDependency = ''
-    }
-    return false
-  }
-
-  if (metadataCustomRepoBase) {
-    if (row.dataset.overlayFileDependency === 'repo-missing') {
-      row.dataset.overlayFileDependency = ''
-    }
-    return false
-  }
-
-  row.dataset.overlayFileDependency = 'repo-missing'
-  setOverlayFileButtonState(row, 'blocked')
-  if (!skipStatus) {
-    setOverlayFileStatus(row, 'error', overlayRepoDependencyMessage)
-  }
-  return true
-}
-
-function renderOverlayFileStatusMessage (target, message) {
-  target.replaceChildren()
-  if (!message) return
-
-  if (typeof message === 'object' && message !== null) {
-    const text = String(message.text || message.message || '').trim()
-    const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
-    if (text) {
-      const summary = document.createElement('div')
-      appendInlineCodeText(summary, text)
-      target.appendChild(summary)
-    }
-    if (files.length) {
-      if (files.length <= 5) {
-        const list = document.createElement('ul')
-        list.className = 'mb-0 mt-1 ps-3'
-        files.forEach(file => {
-          const item = document.createElement('li')
-          appendInlineCodeText(item, file, { wrapPlainInCode: true })
-          list.appendChild(item)
-        })
-        target.appendChild(list)
-      } else {
-        const details = document.createElement('details')
-        details.className = 'mt-1'
-        const summary = document.createElement('summary')
-        summary.className = 'cursor-pointer'
-        summary.textContent = 'Show files'
-        details.appendChild(summary)
-        const list = document.createElement('ul')
-        list.className = 'mb-0 mt-1 ps-3'
-        files.forEach(file => {
-          const item = document.createElement('li')
-          appendInlineCodeText(item, file, { wrapPlainInCode: true })
-          list.appendChild(item)
-        })
-        details.appendChild(list)
-        target.appendChild(details)
-      }
-    }
-    return
-  }
-
-  const text = String(message || '').trim()
-  if (!text) return
-
-  if (text === overlayRepoDependencyMessage) {
-    target.append('Overlay file repo entries require Custom Repo to be configured and saved first within the ')
-    appendMetadataSettingsLink(target)
-    target.append(' page.')
-    return
-  }
-
-  appendInlineCodeText(target, text)
-}
-
-function setOverlayFileStatus (row, kind, message) {
-  if (!row) return
-  const target = row.querySelector('[data-overlay-file-status]')
-  if (!target) return
-  row.dataset.overlayFileState = kind || ''
-  target.className = 'mt-2 small'
-  if (!message) {
-    target.classList.add('d-none')
-    target.textContent = ''
-    if (applyOverlayFileDependencyState(row, { skipStatus: true })) {
-      setOverlayFileButtonState(row, 'blocked')
-    } else {
-      setOverlayFileButtonState(row, 'idle')
-    }
-    const editor = row.closest('[data-overlay-files-editor]')
-    if (editor) updateOverlayFilesAccordionState(editor)
-    return
-  }
-  target.classList.remove('d-none')
-  if (kind === 'success') {
-    target.classList.add('text-success')
-  } else if (kind === 'error') {
-    target.classList.add('text-danger')
-  } else {
-    target.classList.add('text-warning')
-  }
-  renderOverlayFileStatusMessage(target, message)
-  if (kind === 'success') {
-    setOverlayFileButtonState(row, 'success')
-  } else if (row.dataset.overlayFileDependency === 'repo-missing') {
-    setOverlayFileButtonState(row, 'blocked')
-  } else {
-    setOverlayFileButtonState(row, 'idle')
-  }
-  const editor = row.closest('[data-overlay-files-editor]')
-  if (editor) updateOverlayFilesAccordionState(editor)
-}
-
-function updateOverlayFilesAccordionState (editor) {
-  if (!editor) return
-  const accordionItem = editor.closest('.accordion-item')
-  const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
-  if (!accordionHeader) return
-
-  const rows = Array.from(editor.querySelectorAll('[data-overlay-file-row]'))
-  const hasEntries = rows.some(row => normalizeMetadataFileEntry({
-    type: row.querySelector('[data-overlay-file-type]')?.value || '',
-    location: row.querySelector('[data-overlay-file-location]')?.value || ''
-  }))
-  const hasInvalid = rows.some(row => {
-    const state = String(row.dataset.overlayFileState || '').trim().toLowerCase()
-    return state === 'error' || state === 'warning'
-  })
-
-  accordionHeader.classList.remove('warning')
-  accordionHeader.classList.toggle('invalid', hasInvalid)
-  if (!hasInvalid && hasEntries) {
-    accordionHeader.classList.add('selected')
-  } else {
-    accordionHeader.classList.remove('selected')
-    if (!hasEntries && !hasInvalid) {
-      updateAccordionHighlights()
-    }
-  }
-}
-
-function applyOverlayFileServerErrors (editor, errors) {
-  if (!editor || !Array.isArray(errors) || !errors.length) return false
-  const rows = Array.from(editor.querySelectorAll('[data-overlay-file-row]'))
-  rows.forEach(row => setOverlayFileStatus(row, '', ''))
-  let applied = false
-  errors.forEach(error => {
-    const text = String(error || '').trim()
-    const match = text.match(/overlay_files\[(\d+)\]:\s*(.+)$/i)
-    if (!match) return
-    const index = Number(match[1]) - 1
-    const message = match[2] || 'Validation failed.'
-    if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
-    setOverlayFileStatus(rows[index], 'error', message)
-    applied = true
-  })
-  return applied
-}
-
-function syncOverlayFilesEditor (editor, emitEvents = true) {
-  if (!editor) return []
-  const hidden = editor.querySelector('input[type="hidden"][name$="-overlay_files"]')
-  if (!hidden) return []
-  const rows = Array.from(editor.querySelectorAll('[data-overlay-file-row]'))
-  const entries = rows.map(row => {
-    const type = row.querySelector('[data-overlay-file-type]')?.value
-    const location = row.querySelector('[data-overlay-file-location]')?.value
-    const validated = String(row.dataset.overlayFileState || '').trim().toLowerCase() === 'success'
-    return normalizeMetadataFileEntry({ type, location, validated })
-  }).filter(Boolean)
-  hidden.value = JSON.stringify(entries)
-  if (emitEvents) {
-    hidden.dispatchEvent(new Event('input', { bubbles: true }))
-    hidden.dispatchEvent(new Event('change', { bubbles: true }))
-  }
-  updateOverlayFilesAccordionState(editor)
-  return entries
-}
-
-function renderOverlayFilesEditor (editor) {
-  if (!editor) return
-  const hidden = editor.querySelector('input[type="hidden"][name$="-overlay_files"]')
-  const list = editor.querySelector('[data-overlay-files-list]')
-  if (!hidden || !list) return
-  updateOverlayCustomRepoStatus(editor)
-  const entries = parseMetadataFilesValue(hidden.value)
-  list.replaceChildren()
-  entries.forEach(entry => list.appendChild(buildOverlayFileRow(entry)))
-  list.querySelectorAll('[data-overlay-file-row]').forEach(row => {
-    if (applyOverlayFileDependencyState(row)) return
-    if (String(row.dataset.overlayFileState || '').trim().toLowerCase() === 'success') {
-      setOverlayFileButtonState(row, 'success')
-    } else {
-      setOverlayFileButtonState(row, 'idle')
-    }
-  })
-  syncOverlayFilesEditor(editor, false)
-  updateOverlayFilesAccordionState(editor)
-}
-
-function initOverlayFilesEditors (scope) {
-  const root = scope || document
-  root.querySelectorAll('[data-overlay-files-editor]').forEach(editor => {
-    if (editor.dataset.overlayFilesReady === 'true') return
-    renderOverlayFilesEditor(editor)
-    editor.dataset.overlayFilesReady = 'true'
-  })
-}
-
 document.addEventListener('click', async function (event) {
   const addButton = event.target.closest('[data-add-overlay-file]')
   if (addButton) {
@@ -1813,259 +914,150 @@ function parsePlaylistFilesValue (rawValue) {
   }
 }
 
+// ============================================================
+// Shared library-files-editor subsystem wiring.
+//
+// Prior to the #1334 Step 9 dedupe pass, this file carried 43
+// near-duplicate helper functions -- 11 helper families x 4 kinds
+// (metadata / collection / overlay / playlist) -- for editing the four
+// kinds of library file lists. All 43 now live in one parameterised
+// implementation under modules/libraryFilesEditor.js; here we call the
+// factory four times with per-kind config and re-expose each returned
+// method under its historical name so the ~184 in-file call sites
+// don't have to change.
+//
+// The per-kind configs capture every behavioural knob that used to be
+// baked into each duplicate: hidden-input selector (metadata/collection/
+// overlay use a name-suffix, playlist uses an exact name),
+// truncate-long-file-lists (only the first three), custom-repo-saved-
+// value-diff (ditto), accordion-state style (three variants), and
+// playlist's re-entrancy guard on syncEditor.
+// ============================================================
 
-function updatePlaylistFileValidateButton (row, isValidated) {
-  if (!row) return
-  const button = row.querySelector('[data-validate-playlist-file]')
-  if (!button) return
-  const state = String(row.dataset.playlistFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
-  button.classList.remove('btn-success', 'btn-secondary')
-  if (state === 'success') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validated'
-    return
-  }
-  if (state === 'blocked') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Needs Repo'
-    return
-  }
-  if (state === 'loading') {
-    button.disabled = true
-    button.classList.add('btn-secondary')
-    button.textContent = 'Validating...'
-    return
-  }
-  button.disabled = false
-  button.classList.add('btn-success')
-  button.textContent = 'Validate'
+const sharedLibraryFilesEditorDeps = {
+  getCustomRepoBase: () => metadataCustomRepoBase,
+  getCustomRepoRaw: () => metadataCustomRepoRaw,
+  appendMetadataSettingsLink: (target, className) => appendMetadataSettingsLink(target, className),
+  appendInlineCodeText: (target, text, options) => appendInlineCodeText(target, text, options),
+  updateAccordionHighlights: () => updateAccordionHighlights()
 }
 
-function setPlaylistFileButtonState (row, state) {
-  if (!row) return
-  row.dataset.playlistFileButtonState = state || 'idle'
-  updatePlaylistFileValidateButton(row, state === 'success')
-}
+const metadataFilesEditor = createLibraryFilesEditor({
+  kind: 'metadata_files',
+  domPrefix: 'metadata-file',
+  editorSelector: '[data-metadata-files-editor]',
+  listSelector: '[data-metadata-files-list]',
+  hiddenInputSelector: 'input[type="hidden"][name$="-metadata_files"]',
+  customRepoStatusSelector: '[data-metadata-custom-repo-status]',
+  repoDependencyMessage: metadataRepoDependencyMessage,
+  kindWord: 'metadata',
+  entryLabel: 'metadata files',
+  normalizeEntry: normalizeMetadataFileEntry,
+  parseFilesValue: parseMetadataFilesValue,
+  buildRow: buildMetadataFileRow,
+  truncateLongFileLists: true,
+  showCustomRepoSavedValueDiff: true,
+  accordionStateStyle: 'early-return',
+  accordionStateClearWarningUpFront: false
+}, sharedLibraryFilesEditorDeps)
 
-function updatePlaylistCustomRepoStatus (editor) {
-  if (!editor) return
-  const target = editor.querySelector('[data-playlist-custom-repo-status]')
-  if (!target) return
+const collectionFilesEditor = createLibraryFilesEditor({
+  kind: 'collection_files',
+  domPrefix: 'collection-file',
+  editorSelector: '[data-collection-files-editor]',
+  listSelector: '[data-collection-files-list]',
+  hiddenInputSelector: 'input[type="hidden"][name$="-collection_files"]',
+  customRepoStatusSelector: '[data-collection-custom-repo-status]',
+  repoDependencyMessage: collectionRepoDependencyMessage,
+  kindWord: 'collection',
+  entryLabel: 'collection files',
+  normalizeEntry: normalizeMetadataFileEntry,  // metadata/collection/overlay share this normalizer historically
+  parseFilesValue: parseMetadataFilesValue,
+  buildRow: buildCollectionFileRow,
+  truncateLongFileLists: true,
+  showCustomRepoSavedValueDiff: true,
+  accordionStateStyle: 'toggle'
+}, sharedLibraryFilesEditorDeps)
 
-  target.replaceChildren()
-  target.className = 'alert small mb-3'
-  if (!metadataCustomRepoBase) {
-    target.classList.add('alert-warning')
-    target.append('Custom Repo is not configured. ')
-    target.append('Use ')
-    appendMetadataSettingsLink(target, 'alert-link fw-semibold')
-    target.append(' to configure and save it before using ')
-    const code = document.createElement('code')
-    code.textContent = 'repo'
-    target.appendChild(code)
-    target.append(' playlist files.')
-    return
-  }
+const overlayFilesEditor = createLibraryFilesEditor({
+  kind: 'overlay_files',
+  domPrefix: 'overlay-file',
+  editorSelector: '[data-overlay-files-editor]',
+  listSelector: '[data-overlay-files-list]',
+  hiddenInputSelector: 'input[type="hidden"][name$="-overlay_files"]',
+  customRepoStatusSelector: '[data-overlay-custom-repo-status]',
+  repoDependencyMessage: overlayRepoDependencyMessage,
+  kindWord: 'overlay',
+  entryLabel: 'overlay files',
+  normalizeEntry: normalizeMetadataFileEntry,
+  parseFilesValue: parseMetadataFilesValue,
+  buildRow: buildOverlayFileRow,
+  truncateLongFileLists: true,
+  showCustomRepoSavedValueDiff: true,
+  accordionStateStyle: 'toggle'
+}, sharedLibraryFilesEditorDeps)
 
-  target.classList.add('alert-secondary')
-  const label = document.createElement('div')
-  label.className = 'fw-semibold mb-1'
-  label.textContent = 'Custom Repo base used for repo entries'
-  target.appendChild(label)
+const playlistFilesEditor = createLibraryFilesEditor({
+  kind: 'playlist_files',
+  domPrefix: 'playlist-file',
+  editorSelector: '[data-playlist-files-editor]',
+  listSelector: '[data-playlist-files-list]',
+  hiddenInputSelector: 'input[type="hidden"][name="playlist_files_entries"]',
+  customRepoStatusSelector: '[data-playlist-custom-repo-status]',
+  repoDependencyMessage: playlistRepoDependencyMessage,
+  kindWord: 'playlist',
+  entryLabel: 'playlist files',
+  normalizeEntry: normalizePlaylistFileEntry,
+  parseFilesValue: parsePlaylistFilesValue,
+  buildRow: buildPlaylistFileRow,
+  truncateLongFileLists: false,
+  showCustomRepoSavedValueDiff: false,
+  accordionStateStyle: 'early-return',
+  accordionStateClearWarningUpFront: true,
+  syncingGuardKey: 'playlistFilesSyncing'
+}, sharedLibraryFilesEditorDeps)
 
-  const baseValue = document.createElement('code')
-  baseValue.textContent = metadataCustomRepoBase
-  target.appendChild(baseValue)
-}
+// Historical per-kind names -- kept so the ~184 in-file call sites keep working.
+const updateMetadataFileValidateButton = metadataFilesEditor.updateValidateButton
+const setMetadataFileButtonState = metadataFilesEditor.setButtonState
+const applyMetadataFileDependencyState = metadataFilesEditor.applyDependencyState
+const setMetadataFileStatus = metadataFilesEditor.setStatus
+const applyMetadataFileServerErrors = metadataFilesEditor.applyServerErrors
+const syncMetadataFilesEditor = metadataFilesEditor.syncEditor
+const renderMetadataFilesEditor = metadataFilesEditor.renderEditor
+const initMetadataFilesEditors = metadataFilesEditor.initEditors
 
-function applyPlaylistFileDependencyState (row, opts = {}) {
-  if (!row) return false
-  const skipStatus = Boolean(opts.skipStatus)
-  const type = row.querySelector('[data-playlist-file-type]')?.value || ''
-  if (type !== 'repo') {
-    if (row.dataset.playlistFileDependency === 'repo-missing') {
-      row.dataset.playlistFileDependency = ''
-    }
-    return false
-  }
+const updateCollectionFileValidateButton = collectionFilesEditor.updateValidateButton
+const setCollectionFileButtonState = collectionFilesEditor.setButtonState
+const applyCollectionFileDependencyState = collectionFilesEditor.applyDependencyState
+const setCollectionFileStatus = collectionFilesEditor.setStatus
+const applyCollectionFileServerErrors = collectionFilesEditor.applyServerErrors
+const syncCollectionFilesEditor = collectionFilesEditor.syncEditor
+const renderCollectionFilesEditor = collectionFilesEditor.renderEditor
+const initCollectionFilesEditors = collectionFilesEditor.initEditors
 
-  if (metadataCustomRepoBase) {
-    if (row.dataset.playlistFileDependency === 'repo-missing') {
-      row.dataset.playlistFileDependency = ''
-    }
-    return false
-  }
+const updateOverlayFileValidateButton = overlayFilesEditor.updateValidateButton
+const setOverlayFileButtonState = overlayFilesEditor.setButtonState
+const applyOverlayFileDependencyState = overlayFilesEditor.applyDependencyState
+const setOverlayFileStatus = overlayFilesEditor.setStatus
+const applyOverlayFileServerErrors = overlayFilesEditor.applyServerErrors
+const syncOverlayFilesEditor = overlayFilesEditor.syncEditor
+const renderOverlayFilesEditor = overlayFilesEditor.renderEditor
+const initOverlayFilesEditors = overlayFilesEditor.initEditors
 
-  row.dataset.playlistFileDependency = 'repo-missing'
-  setPlaylistFileButtonState(row, 'blocked')
-  if (!skipStatus) {
-    setPlaylistFileStatus(row, 'error', playlistRepoDependencyMessage)
-  }
-  return true
-}
+const updatePlaylistFileValidateButton = playlistFilesEditor.updateValidateButton
+const setPlaylistFileButtonState = playlistFilesEditor.setButtonState
+const applyPlaylistFileDependencyState = playlistFilesEditor.applyDependencyState
+const setPlaylistFileStatus = playlistFilesEditor.setStatus
+const syncPlaylistFilesEditor = playlistFilesEditor.syncEditor
+const renderPlaylistFilesEditor = playlistFilesEditor.renderEditor
+const initPlaylistFilesEditors = playlistFilesEditor.initEditors
+// Note: no `applyPlaylistFileServerErrors` shim -- there were zero call
+// sites in the original code, so exposing the (now free) subsystem method
+// under that name would just be dead code. Available via
+// playlistFilesEditor.applyServerErrors if a future caller needs it.
 
-function renderPlaylistFileStatusMessage (target, message) {
-  target.replaceChildren()
-  if (!message) return
 
-  if (typeof message === 'object' && message !== null) {
-    const text = String(message.text || message.message || '').trim()
-    const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
-    if (text) {
-      const summary = document.createElement('div')
-      appendInlineCodeText(summary, text)
-      target.appendChild(summary)
-    }
-    if (files.length) {
-      const list = document.createElement('ul')
-      list.className = 'mb-0 mt-1 ps-3'
-      files.forEach(file => {
-        const item = document.createElement('li')
-        appendInlineCodeText(item, file, { wrapPlainInCode: true })
-        list.appendChild(item)
-      })
-      target.appendChild(list)
-    }
-    return
-  }
-
-  const text = String(message || '').trim()
-  if (!text) return
-
-  if (text === playlistRepoDependencyMessage) {
-    target.append('Playlist file repo entries require Custom Repo to be configured and saved first within the ')
-    appendMetadataSettingsLink(target)
-    target.append(' page.')
-    return
-  }
-
-  appendInlineCodeText(target, text)
-}
-
-function setPlaylistFileStatus (row, kind, message) {
-  if (!row) return
-  const target = row.querySelector('[data-playlist-file-status]')
-  if (!target) return
-  row.dataset.playlistFileState = kind || ''
-  target.className = 'mt-2 small'
-  if (!message) {
-    target.classList.add('d-none')
-    target.textContent = ''
-    if (applyPlaylistFileDependencyState(row, { skipStatus: true })) {
-      setPlaylistFileButtonState(row, 'blocked')
-    } else {
-      setPlaylistFileButtonState(row, 'idle')
-    }
-    const editor = row.closest('[data-playlist-files-editor]')
-    if (editor) updatePlaylistFilesAccordionState(editor)
-    return
-  }
-  target.classList.remove('d-none')
-  if (kind === 'success') {
-    target.classList.add('text-success')
-  } else if (kind === 'error') {
-    target.classList.add('text-danger')
-  } else {
-    target.classList.add('text-warning')
-  }
-  renderPlaylistFileStatusMessage(target, message)
-  if (kind === 'success') {
-    setPlaylistFileButtonState(row, 'success')
-  } else if (row.dataset.playlistFileDependency === 'repo-missing') {
-    setPlaylistFileButtonState(row, 'blocked')
-  } else {
-    setPlaylistFileButtonState(row, 'idle')
-  }
-  const editor = row.closest('[data-playlist-files-editor]')
-  if (editor) updatePlaylistFilesAccordionState(editor)
-}
-
-function updatePlaylistFilesAccordionState (editor) {
-  if (!editor) return
-  const accordionItem = editor.closest('.accordion-item')
-  const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
-  if (!accordionHeader) return
-
-  const rows = Array.from(editor.querySelectorAll('[data-playlist-file-row]'))
-  const hasEntries = rows.some(row => {
-    const type = row.querySelector('[data-playlist-file-type]')?.value || ''
-    const location = row.querySelector('[data-playlist-file-location]')?.value || ''
-    return Boolean(normalizePlaylistFileEntry({ type, location }))
-  })
-  const hasInvalid = rows.some(row => {
-    const state = String(row.dataset.playlistFileState || '').trim().toLowerCase()
-    return state === 'error' || state === 'warning'
-  })
-
-  accordionHeader.classList.remove('invalid', 'warning')
-  if (hasInvalid) {
-    accordionHeader.classList.add('invalid')
-    return
-  }
-  if (hasEntries) {
-    accordionHeader.classList.add('selected')
-  } else {
-    accordionHeader.classList.remove('selected')
-  }
-}
-
-function syncPlaylistFilesEditor (editor, emitEvents = true) {
-  if (!editor) return []
-  const hidden = editor.querySelector('input[type="hidden"][name="playlist_files_entries"]')
-  if (!hidden) return []
-  const alreadySyncing = editor.dataset.playlistFilesSyncing === 'true'
-  if (emitEvents && alreadySyncing) {
-    emitEvents = false
-  }
-  editor.dataset.playlistFilesSyncing = 'true'
-  const rows = Array.from(editor.querySelectorAll('[data-playlist-file-row]'))
-  const entries = rows.map(row => {
-    const type = row.querySelector('[data-playlist-file-type]')?.value
-    const location = row.querySelector('[data-playlist-file-location]')?.value
-    const validated = String(row.dataset.playlistFileState || '').trim().toLowerCase() === 'success'
-    return normalizePlaylistFileEntry({ type, location, validated })
-  }).filter(Boolean)
-  hidden.value = JSON.stringify(entries)
-  if (emitEvents) {
-    hidden.dispatchEvent(new Event('input', { bubbles: true }))
-    hidden.dispatchEvent(new Event('change', { bubbles: true }))
-  }
-  delete editor.dataset.playlistFilesSyncing
-  updatePlaylistFilesAccordionState(editor)
-  return entries
-}
-
-function renderPlaylistFilesEditor (editor) {
-  if (!editor) return
-  const hidden = editor.querySelector('input[type="hidden"][name="playlist_files_entries"]')
-  const list = editor.querySelector('[data-playlist-files-list]')
-  if (!hidden || !list) return
-  updatePlaylistCustomRepoStatus(editor)
-  const entries = parsePlaylistFilesValue(hidden.value)
-  list.replaceChildren()
-  entries.forEach(entry => list.appendChild(buildPlaylistFileRow(entry)))
-  list.querySelectorAll('[data-playlist-file-row]').forEach(row => {
-    if (applyPlaylistFileDependencyState(row)) return
-    if (String(row.dataset.playlistFileState || '').trim().toLowerCase() === 'success') {
-      setPlaylistFileButtonState(row, 'success')
-    } else {
-      setPlaylistFileButtonState(row, 'idle')
-    }
-  })
-  syncPlaylistFilesEditor(editor, false)
-  updatePlaylistFilesAccordionState(editor)
-}
-
-function initPlaylistFilesEditors (scope) {
-  const root = scope || document
-  root.querySelectorAll('[data-playlist-files-editor]').forEach(editor => {
-    if (editor.dataset.playlistFilesReady === 'true') return
-    renderPlaylistFilesEditor(editor)
-    editor.dataset.playlistFilesReady = 'true'
-  })
-}
 
 function renderLibraryFileEditorForHiddenInput (input) {
   if (!input || input.type !== 'hidden') return false

--- a/static/local-js/modules/libraryFilesEditor.js
+++ b/static/local-js/modules/libraryFilesEditor.js
@@ -1,0 +1,490 @@
+// Shared library-files-editor subsystem.
+//
+// Extracted from static/local-js/025-libraries.js as part of the #1334
+// Step 9 direction. Previously the "editor for the four kinds of
+// library file lists" (metadata_files / collection_files /
+// overlay_files / playlist_files) was implemented as 44 near-duplicate
+// functions -- 11 helper families x 4 kinds -- with the same shape
+// copy-pasted across ~1100 lines. This module collapses that into ONE
+// implementation parameterised by a per-kind config object.
+//
+// Public API: createLibraryFilesEditor(config) returns a bundle of the
+// 11 methods sharing a closure over `config`. 025-libraries.js calls
+// this factory four times (once per kind) and re-exposes each returned
+// method under its historical name (setMetadataFileStatus,
+// syncPlaylistFilesEditor, etc.) so the ~184 in-file call sites don't
+// change.
+//
+// Config shape (all fields required unless marked optional):
+//
+//   {
+//     kind: 'metadata_files' | 'collection_files' | 'overlay_files' | 'playlist_files'
+//                                              -- used in the error-parser regex
+//     domPrefix: 'metadata-file' | 'collection-file' | 'overlay-file' | 'playlist-file'
+//                                              -- powers every data-* attribute lookup
+//     editorSelector: e.g. '[data-metadata-files-editor]'
+//     listSelector:   e.g. '[data-metadata-files-list]'
+//     hiddenInputSelector: CSS selector that finds the JSON hidden input
+//                                              -- differs meaningfully: metadata/collection/overlay use
+//                                              -- name-suffix, playlist uses exact name
+//     customRepoStatusSelector: e.g. '[data-metadata-custom-repo-status]'
+//     repoDependencyMessage: 'Metadata file repo entries require...' -- pinned string
+//     kindWord: 'metadata' | 'collection' | 'overlay' | 'playlist'
+//                                              -- for the "... to be configured and saved first" prose
+//                                              -- and the "... files." suffix in the custom-repo alert
+//     entryLabel: 'metadata files' | 'collection files' | 'overlay files' | 'playlist files'
+//                                              -- optional; if omitted, derived as kindWord + ' files'
+//     normalizeEntry: (entry) => normalized-entry-or-null
+//     parseFilesValue: (rawJson) => entry[]
+//     buildRow: (entry) => HTMLElement
+//     truncateLongFileLists: boolean
+//                                              -- metadata/collection/overlay: true; playlist: false
+//     showCustomRepoSavedValueDiff: boolean
+//                                              -- metadata/collection/overlay: true; playlist: false
+//     accordionStateStyle: 'toggle' | 'early-return'
+//                                              -- collection/overlay use 'toggle' (with an
+//                                              -- updateAccordionHighlights callback when the editor
+//                                              -- drains to empty); metadata/playlist use
+//                                              -- 'early-return' (add-invalid-and-return if any row
+//                                              -- is bad, no highlight callback).
+//     accordionStateClearWarningUpFront: boolean
+//                                              -- only consulted when accordionStateStyle is 'early-return'.
+//                                              -- playlist clears 'invalid' AND 'warning' up-front;
+//                                              -- metadata only clears 'invalid' up-front and clears
+//                                              -- 'warning' after the early return.
+//     syncingGuardKey: optional dataset key; if set, the sync method
+//                                              -- flips it to 'true' during work and drops it after,
+//                                              -- suppressing re-entrant event dispatches. Only
+//                                              -- playlist needed this in the original code.
+//
+// Injected shared helpers (all required):
+//
+//   {
+//     getCustomRepoBase: () => string
+//     getCustomRepoRaw:  () => string
+//     appendMetadataSettingsLink: (target, className?) => void
+//     appendInlineCodeText: (target, text, options?) => void
+//     updateAccordionHighlights: () => void
+//   }
+//
+// The factory is pure -- no module-level state, no listeners attached
+// at import time. It is safe to call once per kind on page init.
+
+export function createLibraryFilesEditor (config, shared) {
+  const {
+    kind,
+    domPrefix,
+    editorSelector,
+    listSelector,
+    hiddenInputSelector,
+    customRepoStatusSelector,
+    repoDependencyMessage,
+    kindWord,
+    entryLabel = `${kindWord} files`,
+    normalizeEntry,
+    parseFilesValue,
+    buildRow,
+    truncateLongFileLists,
+    showCustomRepoSavedValueDiff,
+    accordionStateStyle,
+    accordionStateClearWarningUpFront = false,
+    syncingGuardKey
+  } = config
+
+  const {
+    getCustomRepoBase,
+    getCustomRepoRaw,
+    appendMetadataSettingsLink,
+    appendInlineCodeText,
+    updateAccordionHighlights
+  } = shared
+
+  // Dataset key derived from the DOM prefix. All the original functions
+  // referenced dataset properties like row.dataset.metadataFileState;
+  // the browser converts data-metadata-file-state to metadataFileState.
+  const stateKey = camelCase(`${domPrefix}-state`)              // e.g. metadataFileState
+  const buttonStateKey = camelCase(`${domPrefix}-button-state`) // e.g. metadataFileButtonState
+  const dependencyKey = camelCase(`${domPrefix}-dependency`)    // e.g. metadataFileDependency
+  const readyKey = camelCase(`${domPrefix.replace(/-file$/, '')}-files-ready`)
+  const syncingKey = syncingGuardKey || null
+
+  // Precompiled selectors for the row-level bits.
+  const rowSelector = `[data-${domPrefix}-row]`
+  const typeSelector = `[data-${domPrefix}-type]`
+  const locationSelector = `[data-${domPrefix}-location]`
+  const statusSelector = `[data-${domPrefix}-status]`
+  const validateButtonSelector = `[data-validate-${domPrefix}]`
+
+  function updateValidateButton (row, isValidated) {
+    if (!row) return
+    const button = row.querySelector(validateButtonSelector)
+    if (!button) return
+    const state = String(row.dataset[buttonStateKey] || '').trim() || (isValidated ? 'success' : 'idle')
+    button.classList.remove('btn-success', 'btn-secondary')
+    if (state === 'success') {
+      button.disabled = true
+      button.classList.add('btn-secondary')
+      button.textContent = 'Validated'
+      return
+    }
+    if (state === 'blocked') {
+      button.disabled = true
+      button.classList.add('btn-secondary')
+      button.textContent = 'Needs Repo'
+      return
+    }
+    if (state === 'loading') {
+      button.disabled = true
+      button.classList.add('btn-secondary')
+      button.textContent = 'Validating...'
+      return
+    }
+    button.disabled = false
+    button.classList.add('btn-success')
+    button.textContent = 'Validate'
+  }
+
+  function setButtonState (row, state) {
+    if (!row) return
+    row.dataset[buttonStateKey] = state || 'idle'
+    updateValidateButton(row, state === 'success')
+  }
+
+  function applyDependencyState (row, opts = {}) {
+    if (!row) return false
+    const skipStatus = Boolean(opts.skipStatus)
+    const type = row.querySelector(typeSelector)?.value || ''
+    if (type !== 'repo') {
+      if (row.dataset[dependencyKey] === 'repo-missing') {
+        row.dataset[dependencyKey] = ''
+      }
+      return false
+    }
+
+    if (getCustomRepoBase()) {
+      if (row.dataset[dependencyKey] === 'repo-missing') {
+        row.dataset[dependencyKey] = ''
+      }
+      return false
+    }
+
+    row.dataset[dependencyKey] = 'repo-missing'
+    setButtonState(row, 'blocked')
+    if (!skipStatus) {
+      setStatus(row, 'error', repoDependencyMessage)
+    }
+    return true
+  }
+
+  function renderStatusMessage (target, message) {
+    target.replaceChildren()
+    if (!message) return
+
+    if (typeof message === 'object' && message !== null) {
+      const text = String(message.text || message.message || '').trim()
+      const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
+      if (text) {
+        const summary = document.createElement('div')
+        appendInlineCodeText(summary, text)
+        target.appendChild(summary)
+      }
+      if (files.length) {
+        // metadata/collection/overlay use a <details> disclosure when
+        // the file list is long (>5); playlist always shows all files
+        // inline.
+        if (truncateLongFileLists && files.length > 5) {
+          const details = document.createElement('details')
+          details.className = 'mt-1'
+          const summary = document.createElement('summary')
+          summary.className = 'cursor-pointer'
+          summary.textContent = 'Show files'
+          details.appendChild(summary)
+          const list = document.createElement('ul')
+          list.className = 'mb-0 mt-1 ps-3'
+          files.forEach(file => {
+            const item = document.createElement('li')
+            appendInlineCodeText(item, file, { wrapPlainInCode: true })
+            list.appendChild(item)
+          })
+          details.appendChild(list)
+          target.appendChild(details)
+        } else {
+          const list = document.createElement('ul')
+          list.className = 'mb-0 mt-1 ps-3'
+          files.forEach(file => {
+            const item = document.createElement('li')
+            appendInlineCodeText(item, file, { wrapPlainInCode: true })
+            list.appendChild(item)
+          })
+          target.appendChild(list)
+        }
+      }
+      return
+    }
+
+    const text = String(message || '').trim()
+    if (!text) return
+
+    if (text === repoDependencyMessage) {
+      target.append(`${capitalize(kindWord)} file repo entries require Custom Repo to be configured and saved first within the `)
+      appendMetadataSettingsLink(target)
+      target.append(' page.')
+      return
+    }
+
+    appendInlineCodeText(target, text)
+  }
+
+  function setStatus (row, statusKind, message) {
+    if (!row) return
+    const target = row.querySelector(statusSelector)
+    if (!target) return
+    row.dataset[stateKey] = statusKind || ''
+    target.className = 'mt-2 small'
+    if (!message) {
+      target.classList.add('d-none')
+      target.textContent = ''
+      if (applyDependencyState(row, { skipStatus: true })) {
+        setButtonState(row, 'blocked')
+      } else {
+        setButtonState(row, 'idle')
+      }
+      const editor = row.closest(editorSelector)
+      if (editor) updateAccordionState(editor)
+      return
+    }
+    target.classList.remove('d-none')
+    if (statusKind === 'success') {
+      target.classList.add('text-success')
+    } else if (statusKind === 'error') {
+      target.classList.add('text-danger')
+    } else {
+      target.classList.add('text-warning')
+    }
+    renderStatusMessage(target, message)
+    if (statusKind === 'success') {
+      setButtonState(row, 'success')
+    } else if (row.dataset[dependencyKey] === 'repo-missing') {
+      setButtonState(row, 'blocked')
+    } else {
+      setButtonState(row, 'idle')
+    }
+    const editor = row.closest(editorSelector)
+    if (editor) updateAccordionState(editor)
+  }
+
+  function updateCustomRepoStatus (editor) {
+    if (!editor) return
+    const target = editor.querySelector(customRepoStatusSelector)
+    if (!target) return
+
+    target.replaceChildren()
+    target.className = 'alert small mb-3'
+    const base = getCustomRepoBase()
+    if (!base) {
+      target.classList.add('alert-warning')
+      target.append('Custom Repo is not configured. ')
+      target.append('Use ')
+      appendMetadataSettingsLink(target, 'alert-link fw-semibold')
+      target.append(' to configure and save it before using ')
+      const code = document.createElement('code')
+      code.textContent = 'repo'
+      target.appendChild(code)
+      target.append(` ${entryLabel}.`)
+      return
+    }
+
+    target.classList.add('alert-secondary')
+    const label = document.createElement('div')
+    label.className = 'fw-semibold mb-1'
+    label.textContent = 'Custom Repo base used for repo entries'
+    target.appendChild(label)
+
+    const baseValue = document.createElement('code')
+    baseValue.textContent = base
+    target.appendChild(baseValue)
+
+    // metadata/collection/overlay: if the saved value differs from
+    // the normalized base, also show the saved value and a "change it"
+    // hint. Playlist historically didn't include either -- gated by
+    // showCustomRepoSavedValueDiff.
+    if (!showCustomRepoSavedValueDiff) return
+
+    const raw = getCustomRepoRaw()
+    if (raw && raw !== base) {
+      const savedValue = document.createElement('div')
+      savedValue.className = 'mt-2'
+      savedValue.append('Saved Custom Repo value: ')
+      const savedCode = document.createElement('code')
+      savedCode.textContent = raw
+      savedValue.appendChild(savedCode)
+      target.appendChild(savedValue)
+    }
+
+    const hint = document.createElement('div')
+    hint.className = 'mt-2'
+    hint.append('Change it in ')
+    appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
+    hint.append('.')
+    target.appendChild(hint)
+  }
+
+  function updateAccordionState (editor) {
+    if (!editor) return
+    const accordionItem = editor.closest('.accordion-item')
+    const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
+    if (!accordionHeader) return
+
+    const rows = Array.from(editor.querySelectorAll(rowSelector))
+    const hasEntries = rows.some(row => {
+      const type = row.querySelector(typeSelector)?.value || ''
+      const location = row.querySelector(locationSelector)?.value || ''
+      return Boolean(normalizeEntry({ type, location }))
+    })
+    const hasInvalid = rows.some(row => {
+      const state = String(row.dataset[stateKey] || '').trim().toLowerCase()
+      return state === 'error' || state === 'warning'
+    })
+
+    if (accordionStateStyle === 'early-return') {
+      // metadata / playlist. Clear 'invalid' (and, for playlist, also
+      // 'warning') up-front; short-circuit on hasInvalid.
+      if (accordionStateClearWarningUpFront) {
+        accordionHeader.classList.remove('invalid', 'warning')
+      } else {
+        accordionHeader.classList.remove('invalid')
+      }
+      if (hasInvalid) {
+        accordionHeader.classList.add('invalid')
+        return
+      }
+      if (!accordionStateClearWarningUpFront) {
+        accordionHeader.classList.remove('warning')
+      }
+      if (hasEntries) {
+        accordionHeader.classList.add('selected')
+      } else {
+        accordionHeader.classList.remove('selected')
+      }
+      return
+    }
+
+    // 'toggle' style -- collection / overlay. Refreshes accordion
+    // highlights globally when the editor drains to empty.
+    accordionHeader.classList.remove('warning')
+    accordionHeader.classList.toggle('invalid', hasInvalid)
+    if (!hasInvalid && hasEntries) {
+      accordionHeader.classList.add('selected')
+    } else {
+      accordionHeader.classList.remove('selected')
+      if (!hasEntries && !hasInvalid) {
+        updateAccordionHighlights()
+      }
+    }
+  }
+
+  function applyServerErrors (editor, errors) {
+    if (!editor || !Array.isArray(errors) || !errors.length) return false
+    const rows = Array.from(editor.querySelectorAll(rowSelector))
+    rows.forEach(row => setStatus(row, '', ''))
+    let applied = false
+    const pattern = new RegExp(`${kind}\\[(\\d+)\\]:\\s*(.+)$`, 'i')
+    errors.forEach(error => {
+      const text = String(error || '').trim()
+      const match = text.match(pattern)
+      if (!match) return
+      const index = Number(match[1]) - 1
+      const message = match[2] || 'Validation failed.'
+      if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
+      setStatus(rows[index], 'error', message)
+      applied = true
+    })
+    return applied
+  }
+
+  function syncEditor (editor, emitEvents = true) {
+    if (!editor) return []
+    const hidden = editor.querySelector(hiddenInputSelector)
+    if (!hidden) return []
+
+    // playlist historically had a re-entrancy guard because its own
+    // change-listener could re-invoke sync mid-flight. Gated on
+    // syncingKey so metadata/collection/overlay stay guard-free.
+    let requestedEmit = emitEvents
+    if (syncingKey) {
+      const alreadySyncing = editor.dataset[syncingKey] === 'true'
+      if (requestedEmit && alreadySyncing) requestedEmit = false
+      editor.dataset[syncingKey] = 'true'
+    }
+
+    const rows = Array.from(editor.querySelectorAll(rowSelector))
+    const entries = rows.map(row => {
+      const type = row.querySelector(typeSelector)?.value
+      const location = row.querySelector(locationSelector)?.value
+      const validated = String(row.dataset[stateKey] || '').trim().toLowerCase() === 'success'
+      return normalizeEntry({ type, location, validated })
+    }).filter(Boolean)
+    hidden.value = JSON.stringify(entries)
+    if (requestedEmit) {
+      hidden.dispatchEvent(new Event('input', { bubbles: true }))
+      hidden.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+    if (syncingKey) {
+      delete editor.dataset[syncingKey]
+    }
+    updateAccordionState(editor)
+    return entries
+  }
+
+  function renderEditor (editor) {
+    if (!editor) return
+    const hidden = editor.querySelector(hiddenInputSelector)
+    const list = editor.querySelector(listSelector)
+    if (!hidden || !list) return
+    updateCustomRepoStatus(editor)
+    const entries = parseFilesValue(hidden.value)
+    list.replaceChildren()
+    entries.forEach(entry => list.appendChild(buildRow(entry)))
+    list.querySelectorAll(rowSelector).forEach(row => {
+      if (applyDependencyState(row)) return
+      if (String(row.dataset[stateKey] || '').trim().toLowerCase() === 'success') {
+        setButtonState(row, 'success')
+      } else {
+        setButtonState(row, 'idle')
+      }
+    })
+    syncEditor(editor, false)
+    updateAccordionState(editor)
+  }
+
+  function initEditors (scope) {
+    const root = scope || document
+    root.querySelectorAll(editorSelector).forEach(editor => {
+      if (editor.dataset[readyKey] === 'true') return
+      renderEditor(editor)
+      editor.dataset[readyKey] = 'true'
+    })
+  }
+
+  return {
+    updateValidateButton,
+    setButtonState,
+    applyDependencyState,
+    renderStatusMessage,
+    setStatus,
+    updateCustomRepoStatus,
+    updateAccordionState,
+    applyServerErrors,
+    syncEditor,
+    renderEditor,
+    initEditors
+  }
+}
+
+function camelCase (kebab) {
+  return kebab.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+}
+
+function capitalize (str) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}

--- a/tests/js/modules/libraryFilesEditor.test.js
+++ b/tests/js/modules/libraryFilesEditor.test.js
@@ -1,0 +1,383 @@
+// Behavioural tests for the shared library-files-editor subsystem
+// (#1334 Step 9 dedupe).
+//
+// This module replaces 43 near-duplicate per-kind functions that used
+// to live in static/local-js/025-libraries.js. The unit tests below
+// exercise the shared implementation directly with a synthetic per-kind
+// config, so a regression in any of the 11 helper families would fail
+// here regardless of which kind (metadata / collection / overlay /
+// playlist) triggered it.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createLibraryFilesEditor } from '../../../static/local-js/modules/libraryFilesEditor.js'
+
+// A minimal but realistic normalizer: keep entries that have both a
+// type and a location, otherwise reject.
+const stubNormalize = ({ type, location, validated } = {}) => {
+  const t = String(type || '').trim()
+  const l = String(location || '').trim()
+  if (!t || !l) return null
+  return { type: t, location: l, validated: Boolean(validated) }
+}
+
+const stubParse = (raw) => {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.map(stubNormalize).filter(Boolean) : []
+  } catch { return [] }
+}
+
+// A minimal row builder that produces the same DOM shape the real
+// buildLibraryFileRow does: the row wrapper, a type <select>, a
+// location <input>, a status <div>, and a validate <button>.
+const makeStubBuildRow = (domPrefix) => (entry = {}) => {
+  const row = document.createElement('div')
+  row.setAttribute(`data-${domPrefix}-row`, '')
+  row.innerHTML = `
+    <select data-${domPrefix}-type>
+      <option value="">--</option>
+      <option value="file">file</option>
+      <option value="repo">repo</option>
+      <option value="url">url</option>
+    </select>
+    <input data-${domPrefix}-location value="${entry.location || ''}">
+    <div data-${domPrefix}-status></div>
+    <button data-validate-${domPrefix}>Validate</button>
+  `
+  row.querySelector(`[data-${domPrefix}-type]`).value = entry.type || ''
+  if (entry.validated) row.dataset[camel(`${domPrefix}-state`)] = 'success'
+  return row
+}
+
+const camel = (kebab) => kebab.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+
+const makeSharedDeps = (overrides = {}) => ({
+  getCustomRepoBase: () => '',
+  getCustomRepoRaw: () => '',
+  appendMetadataSettingsLink: (target) => target.append('[settings]'),
+  appendInlineCodeText: (target, text) => target.append(text),
+  updateAccordionHighlights: vi.fn(),
+  ...overrides
+})
+
+const makeConfig = (overrides = {}) => ({
+  kind: 'test_files',
+  domPrefix: 'test-file',
+  editorSelector: '[data-test-files-editor]',
+  listSelector: '[data-test-files-list]',
+  hiddenInputSelector: 'input[type="hidden"][name="test_files_entries"]',
+  customRepoStatusSelector: '[data-test-custom-repo-status]',
+  repoDependencyMessage: 'Test file repo entries require Custom Repo...',
+  kindWord: 'test',
+  entryLabel: 'test files',
+  normalizeEntry: stubNormalize,
+  parseFilesValue: stubParse,
+  buildRow: makeStubBuildRow('test-file'),
+  truncateLongFileLists: true,
+  showCustomRepoSavedValueDiff: true,
+  accordionStateStyle: 'toggle',
+  ...overrides
+})
+
+const makeEditor = () => {
+  const editor = document.createElement('div')
+  editor.setAttribute('data-test-files-editor', '')
+  editor.innerHTML = `
+    <div data-test-custom-repo-status></div>
+    <div data-test-files-list></div>
+    <input type="hidden" name="test_files_entries" value="">
+  `
+  // Wrap in an accordion-item so updateAccordionState finds a header
+  const accordionItem = document.createElement('div')
+  accordionItem.className = 'accordion-item'
+  const header = document.createElement('div')
+  header.className = 'accordion-header'
+  accordionItem.appendChild(header)
+  accordionItem.appendChild(editor)
+  document.body.appendChild(accordionItem)
+  return { editor, header, accordionItem }
+}
+
+describe('createLibraryFilesEditor', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  it('exposes all 11 helper methods', () => {
+    const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+    for (const name of [
+      'updateValidateButton', 'setButtonState', 'applyDependencyState',
+      'renderStatusMessage', 'setStatus', 'updateCustomRepoStatus',
+      'updateAccordionState', 'applyServerErrors', 'syncEditor',
+      'renderEditor', 'initEditors'
+    ]) {
+      expect(typeof ed[name]).toBe('function')
+    }
+  })
+
+  describe('updateValidateButton', () => {
+    const setup = () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const row = makeStubBuildRow('test-file')({ type: 'file', location: 'x.yml' })
+      return { ed, row, btn: row.querySelector('[data-validate-test-file]') }
+    }
+
+    it('renders "Validate" when idle', () => {
+      const { ed, row, btn } = setup()
+      ed.updateValidateButton(row, false)
+      expect(btn.textContent).toBe('Validate')
+      expect(btn.disabled).toBe(false)
+      expect(btn.classList.contains('btn-success')).toBe(true)
+    })
+
+    it('renders "Validated" when isValidated', () => {
+      const { ed, row, btn } = setup()
+      ed.updateValidateButton(row, true)
+      expect(btn.textContent).toBe('Validated')
+      expect(btn.disabled).toBe(true)
+      expect(btn.classList.contains('btn-secondary')).toBe(true)
+    })
+
+    it('renders "Needs Repo" when blocked', () => {
+      const { ed, row, btn } = setup()
+      row.dataset.testFileButtonState = 'blocked'
+      ed.updateValidateButton(row, false)
+      expect(btn.textContent).toBe('Needs Repo')
+      expect(btn.disabled).toBe(true)
+    })
+
+    it('renders "Validating..." when loading', () => {
+      const { ed, row, btn } = setup()
+      row.dataset.testFileButtonState = 'loading'
+      ed.updateValidateButton(row, false)
+      expect(btn.textContent).toBe('Validating...')
+    })
+
+    it('is a safe no-op for a null row', () => {
+      const { ed } = setup()
+      expect(() => ed.updateValidateButton(null, false)).not.toThrow()
+    })
+  })
+
+  describe('applyDependencyState', () => {
+    it('flags a repo-typed row when Custom Repo base is missing', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const row = makeStubBuildRow('test-file')({ type: 'repo', location: 'x' })
+      const target = document.createElement('div'); row.appendChild(target)
+      row.querySelector('[data-test-file-status]').replaceWith(target)
+      target.setAttribute('data-test-file-status', '')
+      expect(ed.applyDependencyState(row, { skipStatus: true })).toBe(true)
+      expect(row.dataset.testFileDependency).toBe('repo-missing')
+    })
+
+    it('clears the flag once Custom Repo base is configured', () => {
+      const deps = makeSharedDeps({ getCustomRepoBase: () => 'https://x' })
+      const ed = createLibraryFilesEditor(makeConfig(), deps)
+      const row = makeStubBuildRow('test-file')({ type: 'repo', location: 'x' })
+      row.dataset.testFileDependency = 'repo-missing'
+      ed.applyDependencyState(row)
+      expect(row.dataset.testFileDependency).toBe('')
+    })
+
+    it('returns false for non-repo types', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const row = makeStubBuildRow('test-file')({ type: 'file', location: 'x' })
+      expect(ed.applyDependencyState(row)).toBe(false)
+    })
+  })
+
+  describe('renderStatusMessage', () => {
+    it('truncates >5 file lists into a <details> when truncateLongFileLists is on', () => {
+      const ed = createLibraryFilesEditor(makeConfig({ truncateLongFileLists: true }), makeSharedDeps())
+      const target = document.createElement('div')
+      ed.renderStatusMessage(target, { text: 'boom', files: ['a', 'b', 'c', 'd', 'e', 'f'] })
+      expect(target.querySelector('details')).not.toBeNull()
+    })
+
+    it('always inlines file lists when truncateLongFileLists is off', () => {
+      const ed = createLibraryFilesEditor(makeConfig({ truncateLongFileLists: false }), makeSharedDeps())
+      const target = document.createElement('div')
+      ed.renderStatusMessage(target, { text: 'boom', files: Array.from({ length: 20 }, (_, i) => `f${i}`) })
+      expect(target.querySelector('details')).toBeNull()
+      expect(target.querySelectorAll('li').length).toBe(20)
+    })
+
+    it('rewrites the repo-dependency message into humane prose with a settings link', () => {
+      const cfg = makeConfig({ repoDependencyMessage: 'MAGIC_DEPS', kindWord: 'metadata' })
+      const ed = createLibraryFilesEditor(cfg, makeSharedDeps())
+      const target = document.createElement('div')
+      ed.renderStatusMessage(target, 'MAGIC_DEPS')
+      expect(target.textContent).toContain('Metadata file repo entries require Custom Repo')
+      expect(target.textContent).toContain('[settings]')
+    })
+  })
+
+  describe('updateCustomRepoStatus', () => {
+    it('renders the "not configured" warning when Custom Repo base is empty', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      ed.updateCustomRepoStatus(editor)
+      const target = editor.querySelector('[data-test-custom-repo-status]')
+      expect(target.classList.contains('alert-warning')).toBe(true)
+      expect(target.textContent).toContain('Custom Repo is not configured')
+      expect(target.textContent).toContain('test files.')
+    })
+
+    it('renders the "base used" summary when Custom Repo base is set', () => {
+      const deps = makeSharedDeps({
+        getCustomRepoBase: () => 'https://repo/base',
+        getCustomRepoRaw: () => 'https://repo/base'
+      })
+      const ed = createLibraryFilesEditor(makeConfig(), deps)
+      const { editor } = makeEditor()
+      ed.updateCustomRepoStatus(editor)
+      const target = editor.querySelector('[data-test-custom-repo-status]')
+      expect(target.classList.contains('alert-secondary')).toBe(true)
+      expect(target.textContent).toContain('https://repo/base')
+    })
+
+    it('shows the saved-value drift only when showCustomRepoSavedValueDiff is on', () => {
+      const deps = makeSharedDeps({
+        getCustomRepoBase: () => 'https://repo/base',
+        getCustomRepoRaw: () => 'https://repo/base/trailing'
+      })
+
+      const withDiff = createLibraryFilesEditor(makeConfig({ showCustomRepoSavedValueDiff: true }), deps)
+      const { editor: e1 } = makeEditor()
+      withDiff.updateCustomRepoStatus(e1)
+      expect(e1.querySelector('[data-test-custom-repo-status]').textContent).toContain('https://repo/base/trailing')
+
+      const withoutDiff = createLibraryFilesEditor(makeConfig({ showCustomRepoSavedValueDiff: false }), deps)
+      const { editor: e2 } = makeEditor()
+      withoutDiff.updateCustomRepoStatus(e2)
+      expect(e2.querySelector('[data-test-custom-repo-status]').textContent).not.toContain('trailing')
+    })
+  })
+
+  describe('updateAccordionState', () => {
+    it('toggles .invalid and .selected under the "toggle" style', () => {
+      const ed = createLibraryFilesEditor(makeConfig({ accordionStateStyle: 'toggle' }), makeSharedDeps())
+      const { editor, header } = makeEditor()
+      // Empty editor -> no .selected
+      ed.updateAccordionState(editor)
+      expect(header.classList.contains('selected')).toBe(false)
+      // Add a real row
+      editor.querySelector('[data-test-files-list]').appendChild(
+        makeStubBuildRow('test-file')({ type: 'file', location: 'x.yml' })
+      )
+      ed.updateAccordionState(editor)
+      expect(header.classList.contains('selected')).toBe(true)
+      expect(header.classList.contains('invalid')).toBe(false)
+    })
+
+    it('flips to .invalid when any row is in an error/warning state', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor, header } = makeEditor()
+      const row = makeStubBuildRow('test-file')({ type: 'file', location: 'x.yml' })
+      row.dataset.testFileState = 'error'
+      editor.querySelector('[data-test-files-list]').appendChild(row)
+      ed.updateAccordionState(editor)
+      expect(header.classList.contains('invalid')).toBe(true)
+    })
+
+    it('calls updateAccordionHighlights when the editor drains empty (toggle style)', () => {
+      const deps = makeSharedDeps()
+      const ed = createLibraryFilesEditor(makeConfig({ accordionStateStyle: 'toggle' }), deps)
+      const { editor } = makeEditor()
+      ed.updateAccordionState(editor)
+      expect(deps.updateAccordionHighlights).toHaveBeenCalled()
+    })
+
+    it('does NOT call updateAccordionHighlights under "early-return" style', () => {
+      const deps = makeSharedDeps()
+      const ed = createLibraryFilesEditor(makeConfig({ accordionStateStyle: 'early-return' }), deps)
+      const { editor } = makeEditor()
+      ed.updateAccordionState(editor)
+      expect(deps.updateAccordionHighlights).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('applyServerErrors', () => {
+    it('routes indexed errors to the correct row', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      const list = editor.querySelector('[data-test-files-list]')
+      list.appendChild(makeStubBuildRow('test-file')({ type: 'file', location: 'a.yml' }))
+      list.appendChild(makeStubBuildRow('test-file')({ type: 'file', location: 'b.yml' }))
+      const applied = ed.applyServerErrors(editor, ['test_files[2]: nope'])
+      expect(applied).toBe(true)
+      const rows = list.querySelectorAll('[data-test-file-row]')
+      expect(rows[1].dataset.testFileState).toBe('error')
+      expect(rows[0].dataset.testFileState).toBe('')
+    })
+
+    it('is a no-op for an empty error list', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      expect(ed.applyServerErrors(editor, [])).toBe(false)
+    })
+  })
+
+  describe('syncEditor', () => {
+    it('writes the filtered entry list into the hidden input', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      const list = editor.querySelector('[data-test-files-list]')
+      list.appendChild(makeStubBuildRow('test-file')({ type: 'file', location: 'a.yml' }))
+      list.appendChild(makeStubBuildRow('test-file')({ type: '', location: '' })) // gets normalized away
+      const entries = ed.syncEditor(editor, false)
+      expect(entries).toEqual([{ type: 'file', location: 'a.yml', validated: false }])
+      const hidden = editor.querySelector('input[type="hidden"]')
+      expect(JSON.parse(hidden.value)).toEqual([{ type: 'file', location: 'a.yml', validated: false }])
+    })
+
+    it('emits input/change events when emitEvents is true', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      const hidden = editor.querySelector('input[type="hidden"]')
+      let inputs = 0, changes = 0
+      hidden.addEventListener('input', () => inputs++)
+      hidden.addEventListener('change', () => changes++)
+      ed.syncEditor(editor, true)
+      expect(inputs).toBe(1); expect(changes).toBe(1)
+    })
+
+    it('suppresses re-entrant emits when syncingGuardKey is set', () => {
+      const ed = createLibraryFilesEditor(makeConfig({ syncingGuardKey: 'testSyncing' }), makeSharedDeps())
+      const { editor } = makeEditor()
+      const hidden = editor.querySelector('input[type="hidden"]')
+      let emits = 0
+      // A listener that recursively triggers a sync during the first emit.
+      hidden.addEventListener('input', () => {
+        emits++
+        if (emits === 1) ed.syncEditor(editor, true)  // should NOT re-emit
+      })
+      ed.syncEditor(editor, true)
+      expect(emits).toBe(1)
+    })
+  })
+
+  describe('renderEditor + initEditors', () => {
+    it('renders rows from the hidden input value on first init', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      editor.querySelector('input[type="hidden"]').value = JSON.stringify([
+        { type: 'file', location: 'a.yml' },
+        { type: 'file', location: 'b.yml' }
+      ])
+      ed.initEditors(document)
+      const rows = editor.querySelectorAll('[data-test-file-row]')
+      expect(rows.length).toBe(2)
+      expect(editor.dataset.testFilesReady).toBe('true')
+    })
+
+    it('is idempotent -- initEditors() re-run leaves the editor untouched', () => {
+      const ed = createLibraryFilesEditor(makeConfig(), makeSharedDeps())
+      const { editor } = makeEditor()
+      editor.querySelector('input[type="hidden"]').value = JSON.stringify([{ type: 'file', location: 'a.yml' }])
+      ed.initEditors(document)
+      const firstRow = editor.querySelector('[data-test-file-row]')
+      ed.initEditors(document)
+      expect(editor.querySelector('[data-test-file-row]')).toBe(firstRow)
+    })
+  })
+})


### PR DESCRIPTION
Refs #1334 (Step 9 direction). Follow-up to #1673 (externalYamlEditor extraction) and #1674 (row-builder dedupe).

## What was there

`static/local-js/025-libraries.js` carried **43 near-duplicate helper functions** — 11 helper families × 4 kinds (metadata / collection / overlay / playlist) — for editing the four kinds of library file lists. That was **1,110 lines of copy-paste**, containing at least three different accordion-state variants and two versions of the custom-repo-status alert.

## What's there now

All 43 functions collapse into ONE parameterised implementation under `static/local-js/modules/libraryFilesEditor.js` exposing a single factory:

```js
createLibraryFilesEditor(config, sharedDeps)
```

`025-libraries.js` calls it four times and re-exposes each returned method under its historical name (`setMetadataFileStatus`, `syncPlaylistFilesEditor`, etc.), so the **~184 in-file call sites don't change**. Zero external references had to be touched.

The per-kind configs capture every behavioural knob that used to be baked into each duplicate:

- **hidden-input selector** — metadata/collection/overlay use a name *suffix*, playlist uses an *exact* name
- **truncateLongFileLists** — metadata/collection/overlay collapse file lists > 5 into a `<details>`; playlist inlines them all
- **showCustomRepoSavedValueDiff** — metadata/collection/overlay show the saved-vs-normalized drift + a "change it in [settings]" hint; playlist doesn't
- **accordionStateStyle** — `'toggle'` (collection/overlay, with an `updateAccordionHighlights` callback on drain) vs `'early-return'` (metadata/playlist), plus a further sub-flag for whether the early-return path clears `warning` up-front (playlist) or after the return (metadata)
- **syncingGuardKey** — optional dataset key that guards `syncEditor` against re-entrant emits. Only playlist historically needed this.

## Side benefits (not counted as behaviour changes)

- `applyPlaylistFileServerErrors` now *exists* (via `playlistFilesEditor.applyServerErrors`) even though the original code had no equivalent. Not wired to a caller — available if a future playlist-validation flow wants it.
- 12 dead per-kind shims (`render*StatusMessage`, `update*CustomRepoStatus`, `update*FilesAccordionState`) were pruned because they had no external callers — only the shared implementation calls them internally.

## Net

`static/local-js/025-libraries.js`: **8,781 → 7,773 lines** (**−1,008 lines**). Vite chunk: **224.35 kB → 211.20 kB** (−5.9%).

## Verification

- `npx eslint` — clean
- `npm run build` — clean
- **26 new vitest cases** in `tests/js/modules/libraryFilesEditor.test.js` covering every helper family and each per-kind config knob (truncateLongFileLists, showCustomRepoSavedValueDiff, both accordion styles, syncingGuardKey re-entrancy)
- **1,577** total vitest pass (+26 vs pre-PR)
- **48** pytest route tests pass (`test_external_yaml_editor` + `test_config_and_library_routes`)

## Roadmap position

With #1673 + #1674 + this PR, the three biggest deduplication opportunities in `025-libraries.js` from the Step 9 direction are done. Remaining work in that file is mostly the metadata-settings + collection/playlist-page pieces, which aren't obvious dedupe candidates — they're different features that happen to share the file.
