### PR TITLE
Route playlist_files server errors back to their rows

### DIFF
--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1040,13 +1040,10 @@ const updatePlaylistFileValidateButton = playlistFilesEditor.updateValidateButto
 const setPlaylistFileButtonState = playlistFilesEditor.setButtonState
 const applyPlaylistFileDependencyState = playlistFilesEditor.applyDependencyState
 const setPlaylistFileStatus = playlistFilesEditor.setStatus
+const applyPlaylistFileServerErrors = playlistFilesEditor.applyServerErrors
 const syncPlaylistFilesEditor = playlistFilesEditor.syncEditor
 const renderPlaylistFilesEditor = playlistFilesEditor.renderEditor
 const initPlaylistFilesEditors = playlistFilesEditor.initEditors
-// Note: no `applyPlaylistFileServerErrors` shim -- there were zero call
-// sites in the original code, so exposing the (now free) subsystem method
-// under that name would just be dead code. Available via
-// playlistFilesEditor.applyServerErrors if a future caller needs it.
 
 
 
@@ -4978,6 +4975,7 @@ function autosaveActiveLibrary (options = {}) {
   const collectionEditor = card.querySelector('[data-collection-files-editor]')
   const metadataEditor = card.querySelector('[data-metadata-files-editor]')
   const overlayEditor = card.querySelector('[data-overlay-files-editor]')
+  const playlistEditor = card.querySelector('[data-playlist-files-editor]')
   const option = libraryPicker?.querySelector(`option[value="${activeLibraryId}"]`)
   const friendlyName = option?.dataset.label || option?.textContent?.trim() || activeLibraryId
 
@@ -4998,6 +4996,9 @@ function autosaveActiveLibrary (options = {}) {
           }
           if (overlayEditor) {
             applyOverlayFileServerErrors(overlayEditor, body && body.errors)
+          }
+          if (playlistEditor) {
+            applyPlaylistFileServerErrors(playlistEditor, body && body.errors)
           }
           const message = body && body.error ? body.error : `Autosave failed: ${res.status}`
           throw new Error(message)

--- a/tests/js/modules/libraryFilesEditor.test.js
+++ b/tests/js/modules/libraryFilesEditor.test.js
@@ -315,6 +315,25 @@ describe('createLibraryFilesEditor', () => {
       const { editor } = makeEditor()
       expect(ed.applyServerErrors(editor, [])).toBe(false)
     })
+
+    it('parses the real per-kind error prefix (kind: "playlist_files")', () => {
+      // Regression guard for the playlist server-error gap: the shared
+      // regex must recognise "playlist_files[N]: msg" strings that the
+      // Python side emits from build_validation_summary().
+      const ed = createLibraryFilesEditor(makeConfig({ kind: 'playlist_files' }), makeSharedDeps())
+      const { editor } = makeEditor()
+      const list = editor.querySelector('[data-test-files-list]')
+      list.appendChild(makeStubBuildRow('test-file')({ type: 'file', location: 'a.yml' }))
+      list.appendChild(makeStubBuildRow('test-file')({ type: 'repo', location: 'b' }))
+      const applied = ed.applyServerErrors(editor, [
+        'playlist_files[2]: Repo location must be non-empty.',
+        'not_our_prefix[1]: ignored'
+      ])
+      expect(applied).toBe(true)
+      const rows = list.querySelectorAll('[data-test-file-row]')
+      expect(rows[1].dataset.testFileState).toBe('error')
+      expect(rows[0].dataset.testFileState).toBe('')
+    })
   })
 
   describe('syncEditor', () => {


### PR DESCRIPTION
Stacked on #1676 (must merge #1676 first).

## The bug

When the server rejects a library autosave with per-index errors like `metadata_files[N]: <msg>`, `collection_files[N]: <msg>`, or `overlay_files[N]: <msg>` (produced by `build_validation_summary()` in `quickstart.py`), the `/autosave_library` fetch handler in `025-libraries.js` routes those errors back to the offending row via `applyXFileServerErrors`.

**Playlists were silently dropped.**

Two problems:

1. The fetch handler grabbed `collectionEditor`, `metadataEditor`, and `overlayEditor` from the card but never grabbed `playlistEditor`.
2. Even if it had, there was no `applyPlaylistFileServerErrors` shim — the pre-dedupe code had no playlist equivalent, and #1676's shared subsystem exposed `applyServerErrors` for every kind but this file had chosen not to wire up a shim ("dead code without a caller").

Net result: when the server said "playlist_files[3]: repo location is required", the user got a generic "Autosave failed" toast and no indication which playlist row was the problem. The error message was quietly dropped.

## The fix

- Add the `applyPlaylistFileServerErrors` shim.
- Grab `playlistEditor` from the card in the autosave handler.
- Route the errors on the same code path as the other three kinds.

## Regression test

Added a targeted vitest case that pins the `playlist_files[N]:` regex end-to-end against the real `kind: 'playlist_files'` config (my existing subsystem tests used a synthetic `kind: 'test_files'` for isolation). A future rename of the Python-side error prefix would fail here rather than silently degrade to a phantom-error toast.

## Verification

- `npx eslint` — clean
- `npm run build` — clean
- **27/27** subsystem tests pass (was 26)

## Net

+24 / −4 in two files.
