### PR TITLE
Validate shared playlist_files on /autosave_library

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -971,6 +971,14 @@ def autosave_library(library_id):
         collection_errors = _qs._validate_library_collection_files(merged_libraries, selected_library_ids)
         metadata_errors = _qs._validate_library_metadata_files(merged_libraries, selected_library_ids)
         overlay_errors = _qs._validate_library_overlay_files(merged_libraries, selected_library_ids)
+        # Playlists live in a shared-across-libraries hidden field
+        # (`playlist_files_entries`) that the current library card
+        # happens to render, so autosave receives the latest edits
+        # even though there is no per-library selection. Validate them
+        # the same way the full-form POST does -- otherwise invalid
+        # playlist entries silently save on card switch and the user
+        # only sees the error much later when they hit full Save.
+        playlist_errors = _qs._validate_shared_playlist_files(merged_libraries)
         auto_sort_hubs_errors = _qs._validate_library_auto_sort_hubs(merged_libraries, selected_library_ids)
         if collection_errors:
             return jsonify({"success": False, "error": "Invalid collection files.", "errors": collection_errors}), 400
@@ -978,6 +986,8 @@ def autosave_library(library_id):
             return jsonify({"success": False, "error": "Invalid metadata files.", "errors": metadata_errors}), 400
         if overlay_errors:
             return jsonify({"success": False, "error": "Invalid overlay files.", "errors": overlay_errors}), 400
+        if playlist_errors:
+            return jsonify({"success": False, "error": "Invalid playlist files.", "errors": playlist_errors}), 400
         if auto_sort_hubs_errors:
             return jsonify({"success": False, "error": "Invalid library settings.", "errors": auto_sort_hubs_errors}), 400
         normalized_libraries, normalization_errors, changed = _qs._normalize_library_file_entries_payload(

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -235,6 +235,33 @@ def test_autosave_library_returns_400_on_overlay_file_errors(client, isolated_co
     assert resp.get_json()["success"] is False
 
 
+def test_autosave_library_returns_400_on_playlist_file_errors(client, isolated_config_dir, qs_module, monkeypatch):
+    # Playlists live in a shared-across-libraries hidden field on the
+    # library card. Prior to this fix, autosave validated collection /
+    # metadata / overlay files but silently accepted invalid playlist
+    # entries, so a user only saw the error much later on full Save.
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: set())
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_validate_shared_playlist_files",
+        lambda libs: ["playlist_files playlist_files[1]: Repo location must be non-empty."],
+    )
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={"config_name": "pytest_lib", "playlist_files_entries": '[{"type":"repo","location":""}]'},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert body["error"] == "Invalid playlist files."
+    assert any("playlist_files[1]" in e for e in body["errors"])
+
+
 def test_autosave_library_returns_400_on_normalization_errors(client, isolated_config_dir, qs_module, monkeypatch):
     monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: set())
     monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])


### PR DESCRIPTION
Companion to #1677 (independent — this one branches from `develop`, not from the dedupe stack).

## Audit context

Following up on the playlist server-error gap that #1676's refactor made visible: I audited whether the other three kinds (metadata / collection / overlay) had *any* other silently-dropped error shapes. **They're clean.** Every error string produced by `build_validation_summary()` in `quickstart.py` gets routed to a row via the client-side `applyXFileServerErrors` handlers.

**But the playlist audit surfaced a second, deeper bug** that #1677's client-side fix alone doesn't close: `/autosave_library` never validates playlist entries in the first place.

## The bug

The `/025_libraries` full-form POST calls `_validate_shared_playlist_files()`, but the `/autosave_library` blueprint route silently skipped it. Metadata / collection / overlay all get validated on both endpoints; playlist only on the full submit.

Consequence: on library card switch, an invalid playlist entry saves silently to disk. The user only finds out much later when they hit the full "Save" button and get a validation error page for input they'd already forgotten editing.

## The fix

Call `_qs._validate_shared_playlist_files(merged_libraries)` in the autosave route, alongside the three existing per-kind validators. On error, return `400` with `{ error: "Invalid playlist files.", errors: [...] }`. Combined with #1677, the offending row now gets the red status treatment the other three kinds have always had.

## Test

Added `test_autosave_library_returns_400_on_playlist_file_errors` mirroring the shape of the three existing per-kind tests. Monkeypatches `_validate_shared_playlist_files` to return a synthetic error, submits a payload with `playlist_files_entries`, asserts 400 + `Invalid playlist files.` + the error string flows through in the response body.

## Verification

- `pre-commit` — passed (ruff, black)
- 15 autosave route tests pass (was 14, +1 new)
- Broader run: 289 tests across `test_config_and_library_routes`, `test_core_backend`, `test_external_yaml_editor` all pass — every existing test needed **zero** monkeypatch changes, because payloads without `playlist_files_entries` short-circuit to `[]`.

## Net

+37 / −0 across two files. Two-line route change, one small test.
