### PR TITLE
Extract Commonsense content-rating preview helpers (POC for Step 9)

### DIFF
--- a/static/local-js/modules/commonsenseContentRatingPreview.js
+++ b/static/local-js/modules/commonsenseContentRatingPreview.js
@@ -1,0 +1,121 @@
+// Commonsense content-rating overlay preview helpers.
+//
+// Extracted from static/local-js/overlayHandler.js as a proof-of-concept
+// for the Step 9 direction. That file is 8500+ lines with a single
+// initializeOverlayBoards closure holding 200+ nested helpers -- this
+// module carves out the smallest self-contained cluster (7 pure
+// cfg->value functions with zero closure dependencies beyond `cfg`)
+// so we have a proven pattern for the larger extractions to come.
+//
+// Every function here takes a `cfg` object shaped like:
+//
+//   { id: 'overlay_content_rating_commonsense', container: HTMLElement }
+//
+// and does nothing but query/mutate `cfg.container`. No listeners, no
+// module-level state, no callbacks to the outer closure.
+
+/**
+ * True when `cfg` describes the Commonsense content-rating overlay.
+ * The overlay id is a stable server-rendered token so we identify it
+ * by exact string match rather than any structural DOM cue.
+ */
+export function isCommonsenseContentRatingOverlay (cfg) {
+  return String(cfg?.id || '').trim() === 'overlay_content_rating_commonsense'
+}
+
+/**
+ * The `[name="<template>[text]"]` input inside `cfg.container` that
+ * holds the currently-selected commonsense preview value.
+ * Returns null when the container is missing or has no overlay
+ * template attached.
+ */
+export function getCommonsensePreviewTextInput (cfg) {
+  if (!cfg?.container) return null
+  const templateName = cfg.container.dataset.overlayTemplate
+  if (!templateName) return null
+  return cfg.container.querySelector(`[name="${templateName}[text]"]`)
+}
+
+/**
+ * Enumerate the `<template>[use_<age>]` checkboxes into a sortable
+ * option list of { value, label, enabled, sortValue }.
+ *
+ * Options are sorted numerically by `<age>` (with NaN pushed to the
+ * end via MAX_SAFE_INTEGER) then alphabetically as a tiebreak.
+ * Labels are stripped of a leading "Use " prefix so the preview UI
+ * shows "13+" instead of "Use 13+".
+ */
+export function getCommonsensePreviewOptions (cfg) {
+  if (!cfg?.container) return []
+  const templateName = cfg.container.dataset.overlayTemplate
+  if (!templateName) return []
+  const options = []
+  cfg.container.querySelectorAll(`input[type="checkbox"][name^="${templateName}[use_"]`).forEach((input) => {
+    const rawName = String(input.name || '')
+    const match = new RegExp(`^${templateName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\[use_(.+)\\]$`).exec(rawName)
+    const value = String(match?.[1] || '').trim()
+    if (!value) return
+    const numericValue = Number(value)
+    const labelEl = input.closest('.form-check')?.querySelector('.form-check-label')
+    let label = String(labelEl?.textContent || `${value}+`).replace(/\s+/g, ' ').trim()
+    if (label.toLowerCase().startsWith('use ')) {
+      label = label.slice(4).trim()
+    }
+    options.push({
+      value,
+      label,
+      enabled: input.checked,
+      sortValue: Number.isFinite(numericValue) ? numericValue : Number.MAX_SAFE_INTEGER
+    })
+  })
+  options.sort((a, b) => {
+    if (a.sortValue !== b.sortValue) return a.sortValue - b.sortValue
+    return a.label.localeCompare(b.label)
+  })
+  return options
+}
+
+/**
+ * The first enabled option's value, falling back to the first option
+ * overall, falling back to ''. Called when the current preview value
+ * is missing or no longer valid.
+ */
+export function pickDefaultCommonsensePreviewValue (cfg) {
+  const options = getCommonsensePreviewOptions(cfg)
+  return options.find(option => option.enabled)?.value || options[0]?.value || ''
+}
+
+/**
+ * The current preview value, self-healing: if the text input holds a
+ * value that no option matches, it's rewritten to the default and the
+ * default is returned. Callers may therefore assume the input is
+ * always consistent with the option list after this call.
+ */
+export function getCommonsensePreviewValue (cfg) {
+  const input = getCommonsensePreviewTextInput(cfg)
+  const current = String(input?.value || '').trim()
+  const options = getCommonsensePreviewOptions(cfg)
+  const values = new Set(options.map(option => option.value))
+  if (current && values.has(current)) return current
+  const fallback = pickDefaultCommonsensePreviewValue(cfg)
+  if (input && fallback) input.value = fallback
+  return fallback
+}
+
+export function setCommonsensePreviewValue (cfg, value) {
+  const input = getCommonsensePreviewTextInput(cfg)
+  if (input) {
+    input.value = String(value || '').trim()
+  }
+}
+
+/**
+ * Display normalisation for text pulled off the input: trim, and
+ * upper-case the special-cased 'nr' sentinel. Everything else passes
+ * through unchanged.
+ */
+export function normalizeCommonsensePreviewText (value) {
+  const normalized = String(value || '').trim()
+  if (!normalized) return ''
+  return normalized.toLowerCase() === 'nr' ? 'NR' : normalized
+}

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -10,6 +10,15 @@ import {
   initializeOverlays,
   syncSeparatorPlaceholderFields
 } from './modules/separatorPreview.js'
+import {
+  isCommonsenseContentRatingOverlay,
+  getCommonsensePreviewTextInput,
+  getCommonsensePreviewOptions,
+  pickDefaultCommonsensePreviewValue,
+  getCommonsensePreviewValue,
+  setCommonsensePreviewValue,
+  normalizeCommonsensePreviewText
+} from './modules/commonsenseContentRatingPreview.js'
 
 const OverlayHandler = {
   baseDimensions: {
@@ -1060,76 +1069,6 @@ const OverlayHandler = {
 
     const isRegionalContentRatingOverlay = (cfg) => {
       return REGIONAL_CONTENT_RATING_OVERLAY_IDS.has(String(cfg?.id || '').trim())
-    }
-
-    const isCommonsenseContentRatingOverlay = (cfg) => {
-      return String(cfg?.id || '').trim() === 'overlay_content_rating_commonsense'
-    }
-
-    const getCommonsensePreviewTextInput = (cfg) => {
-      if (!cfg?.container) return null
-      const templateName = cfg.container.dataset.overlayTemplate
-      if (!templateName) return null
-      return cfg.container.querySelector(`[name="${templateName}[text]"]`)
-    }
-
-    const getCommonsensePreviewOptions = (cfg) => {
-      if (!cfg?.container) return []
-      const templateName = cfg.container.dataset.overlayTemplate
-      if (!templateName) return []
-      const options = []
-      cfg.container.querySelectorAll(`input[type="checkbox"][name^="${templateName}[use_"]`).forEach((input) => {
-        const rawName = String(input.name || '')
-        const match = new RegExp(`^${templateName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\[use_(.+)\\]$`).exec(rawName)
-        const value = String(match?.[1] || '').trim()
-        if (!value) return
-        const numericValue = Number(value)
-        const labelEl = input.closest('.form-check')?.querySelector('.form-check-label')
-        let label = String(labelEl?.textContent || `${value}+`).replace(/\s+/g, ' ').trim()
-        if (label.toLowerCase().startsWith('use ')) {
-          label = label.slice(4).trim()
-        }
-        options.push({
-          value,
-          label,
-          enabled: input.checked,
-          sortValue: Number.isFinite(numericValue) ? numericValue : Number.MAX_SAFE_INTEGER
-        })
-      })
-      options.sort((a, b) => {
-        if (a.sortValue !== b.sortValue) return a.sortValue - b.sortValue
-        return a.label.localeCompare(b.label)
-      })
-      return options
-    }
-
-    const pickDefaultCommonsensePreviewValue = (cfg) => {
-      const options = getCommonsensePreviewOptions(cfg)
-      return options.find(option => option.enabled)?.value || options[0]?.value || ''
-    }
-
-    const getCommonsensePreviewValue = (cfg) => {
-      const input = getCommonsensePreviewTextInput(cfg)
-      const current = String(input?.value || '').trim()
-      const options = getCommonsensePreviewOptions(cfg)
-      const values = new Set(options.map(option => option.value))
-      if (current && values.has(current)) return current
-      const fallback = pickDefaultCommonsensePreviewValue(cfg)
-      if (input && fallback) input.value = fallback
-      return fallback
-    }
-
-    const setCommonsensePreviewValue = (cfg, value) => {
-      const input = getCommonsensePreviewTextInput(cfg)
-      if (input) {
-        input.value = String(value || '').trim()
-      }
-    }
-
-    const normalizeCommonsensePreviewText = (value) => {
-      const normalized = String(value || '').trim()
-      if (!normalized) return ''
-      return normalized.toLowerCase() === 'nr' ? 'NR' : normalized
     }
 
     const getContentRatingPreviewOptions = (cfg) => {

--- a/tests/js/modules/commonsenseContentRatingPreview.test.js
+++ b/tests/js/modules/commonsenseContentRatingPreview.test.js
@@ -1,0 +1,174 @@
+// Unit tests for the Commonsense content-rating overlay preview
+// helpers extracted from static/local-js/overlayHandler.js.
+//
+// These are pure cfg-in / value-out functions: they read from
+// cfg.container (an HTMLElement) and either return a derived value or
+// mutate a single input. No listeners, no module state.
+
+import { describe, it, expect } from 'vitest'
+import {
+  isCommonsenseContentRatingOverlay,
+  getCommonsensePreviewTextInput,
+  getCommonsensePreviewOptions,
+  pickDefaultCommonsensePreviewValue,
+  getCommonsensePreviewValue,
+  setCommonsensePreviewValue,
+  normalizeCommonsensePreviewText
+} from '../../../static/local-js/modules/commonsenseContentRatingPreview.js'
+
+// A container shaped like the real thing: `data-overlay-template` on the
+// wrapper, a hidden `[name="<template>[text]"]` input, and one or more
+// `[name="<template>[use_<age>]"]` checkboxes wrapped in .form-check
+// with a .form-check-label sibling.
+const makeContainer = ({ template = 'ov_commonsense', text = '', ages = [] } = {}) => {
+  const container = document.createElement('div')
+  container.dataset.overlayTemplate = template
+  const textInput = document.createElement('input')
+  textInput.type = 'text'
+  textInput.name = `${template}[text]`
+  textInput.value = text
+  container.appendChild(textInput)
+  ages.forEach(({ age, enabled = false, label }) => {
+    const wrap = document.createElement('div')
+    wrap.className = 'form-check'
+    const cb = document.createElement('input')
+    cb.type = 'checkbox'
+    cb.name = `${template}[use_${age}]`
+    cb.checked = enabled
+    const lab = document.createElement('label')
+    lab.className = 'form-check-label'
+    lab.textContent = label ?? `Use ${age}+`
+    wrap.appendChild(cb)
+    wrap.appendChild(lab)
+    container.appendChild(wrap)
+  })
+  return container
+}
+
+const cfgFor = (opts) => ({
+  id: 'overlay_content_rating_commonsense',
+  container: makeContainer(opts)
+})
+
+describe('isCommonsenseContentRatingOverlay', () => {
+  it('matches the exact server-rendered id', () => {
+    expect(isCommonsenseContentRatingOverlay({ id: 'overlay_content_rating_commonsense' })).toBe(true)
+  })
+  it('is false for other overlay ids', () => {
+    expect(isCommonsenseContentRatingOverlay({ id: 'overlay_content_rating_us' })).toBe(false)
+  })
+  it('is false for null/undefined/missing id', () => {
+    expect(isCommonsenseContentRatingOverlay(null)).toBe(false)
+    expect(isCommonsenseContentRatingOverlay({})).toBe(false)
+    expect(isCommonsenseContentRatingOverlay({ id: '  ' })).toBe(false)
+  })
+})
+
+describe('getCommonsensePreviewTextInput', () => {
+  it('returns the [name="<template>[text]"] input', () => {
+    const cfg = cfgFor({ template: 'ov1', text: 'PG' })
+    const input = getCommonsensePreviewTextInput(cfg)
+    expect(input?.name).toBe('ov1[text]')
+    expect(input?.value).toBe('PG')
+  })
+  it('returns null when container is missing or has no template dataset', () => {
+    expect(getCommonsensePreviewTextInput(null)).toBeNull()
+    const bareContainer = document.createElement('div')
+    expect(getCommonsensePreviewTextInput({ container: bareContainer })).toBeNull()
+  })
+})
+
+describe('getCommonsensePreviewOptions', () => {
+  it('sorts numerically then alphabetically and strips "Use " from labels', () => {
+    const cfg = cfgFor({ ages: [
+      { age: '13', label: 'Use 13+' },
+      { age: '3', label: 'Use 3+', enabled: true },
+      { age: '18', label: 'Use 18+' },
+      { age: '7', label: 'Use 7+' }
+    ]})
+    const opts = getCommonsensePreviewOptions(cfg)
+    expect(opts.map(o => o.value)).toEqual(['3', '7', '13', '18'])
+    expect(opts.map(o => o.label)).toEqual(['3+', '7+', '13+', '18+'])
+    expect(opts.find(o => o.value === '3').enabled).toBe(true)
+  })
+  it('pushes NaN sort values to the end', () => {
+    const cfg = cfgFor({ ages: [
+      { age: 'nr', label: 'Use NR' },
+      { age: '10', label: 'Use 10+' }
+    ]})
+    const opts = getCommonsensePreviewOptions(cfg)
+    expect(opts[0].value).toBe('10')
+    expect(opts[1].value).toBe('nr')
+  })
+  it('returns [] when container / template is missing', () => {
+    expect(getCommonsensePreviewOptions({})).toEqual([])
+    const bare = document.createElement('div')
+    expect(getCommonsensePreviewOptions({ container: bare })).toEqual([])
+  })
+})
+
+describe('pickDefaultCommonsensePreviewValue', () => {
+  it('prefers the first enabled option', () => {
+    const cfg = cfgFor({ ages: [
+      { age: '13' },
+      { age: '18', enabled: true },
+      { age: '7' }
+    ]})
+    expect(pickDefaultCommonsensePreviewValue(cfg)).toBe('18')
+  })
+  it('falls back to the first option when nothing is enabled', () => {
+    const cfg = cfgFor({ ages: [{ age: '13' }, { age: '18' }] })
+    expect(pickDefaultCommonsensePreviewValue(cfg)).toBe('13')
+  })
+  it('returns "" when there are no options at all', () => {
+    expect(pickDefaultCommonsensePreviewValue(cfgFor({ ages: [] }))).toBe('')
+  })
+})
+
+describe('getCommonsensePreviewValue', () => {
+  it('returns the current text when it matches an option', () => {
+    const cfg = cfgFor({ text: '13', ages: [{ age: '7' }, { age: '13' }] })
+    expect(getCommonsensePreviewValue(cfg)).toBe('13')
+  })
+  it('self-heals: rewrites the input to the default when current value is invalid', () => {
+    const cfg = cfgFor({ text: 'garbage', ages: [{ age: '10', enabled: true }, { age: '18' }] })
+    expect(getCommonsensePreviewValue(cfg)).toBe('10')
+    expect(getCommonsensePreviewTextInput(cfg).value).toBe('10')
+  })
+  it('does not blow up when the input is missing entirely', () => {
+    const container = document.createElement('div')
+    container.dataset.overlayTemplate = 'ov'
+    expect(getCommonsensePreviewValue({ container })).toBe('')
+  })
+})
+
+describe('setCommonsensePreviewValue', () => {
+  it('writes a trimmed value to the input', () => {
+    const cfg = cfgFor({ ages: [{ age: '7' }] })
+    setCommonsensePreviewValue(cfg, '  7  ')
+    expect(getCommonsensePreviewTextInput(cfg).value).toBe('7')
+  })
+  it('is a no-op when the input is missing', () => {
+    expect(() => setCommonsensePreviewValue({}, 'anything')).not.toThrow()
+  })
+})
+
+describe('normalizeCommonsensePreviewText', () => {
+  it('trims whitespace', () => {
+    expect(normalizeCommonsensePreviewText('  13  ')).toBe('13')
+  })
+  it('upper-cases the "nr" sentinel (case-insensitively)', () => {
+    expect(normalizeCommonsensePreviewText('nr')).toBe('NR')
+    expect(normalizeCommonsensePreviewText('Nr')).toBe('NR')
+    expect(normalizeCommonsensePreviewText('NR')).toBe('NR')
+  })
+  it('passes through other values unchanged', () => {
+    expect(normalizeCommonsensePreviewText('13')).toBe('13')
+    expect(normalizeCommonsensePreviewText('PG-13')).toBe('PG-13')
+  })
+  it('returns "" for empty / null / undefined', () => {
+    expect(normalizeCommonsensePreviewText('')).toBe('')
+    expect(normalizeCommonsensePreviewText(null)).toBe('')
+    expect(normalizeCommonsensePreviewText(undefined)).toBe('')
+  })
+})


### PR DESCRIPTION
Refs #1334 (Step 9 direction). Proof-of-concept for chipping away at `overlayHandler.js`.

## Context

`overlayHandler.js` is 8543 lines. Nearly all of that is inside a single `initializeOverlayBoards` closure holding 200+ nested helpers that share per-board state. That's a fundamentally different shape than the copy-paste dedupes we did in `025-libraries.js` (#1673 / #1676) — this file needs *carving up*, not *deduplicating*.

Rather than commit to a multi-week epic without evidence the pattern works here, this PR extracts the smallest self-contained cluster in the file as a proof-of-concept.

## What moved

New module: `static/local-js/modules/commonsenseContentRatingPreview.js`

- `isCommonsenseContentRatingOverlay`
- `getCommonsensePreviewTextInput`
- `getCommonsensePreviewOptions`
- `pickDefaultCommonsensePreviewValue`
- `getCommonsensePreviewValue`
- `setCommonsensePreviewValue`
- `normalizeCommonsensePreviewText`

All 7 are pure functions of `cfg` — they read `cfg.container` and either return a derived value or mutate a single input. **No** listeners, **no** module state, **no** callback into the outer closure. `overlayHandler.js` imports them at the top; the 17 existing intra-closure call sites (all through `isCommonsenseContentRatingOverlay` from the content-rating cluster) continue to work unchanged.

## Net

- `overlayHandler.js`: **8543 → 8483 lines** (−60)
- new module: 117 lines with JSDoc
- **20 vitest cases** pinning behaviour of every helper — including several edge cases the closure form never had covered:
  - NaN sort values pushed to the end of the option list
  - self-heal path in `getCommonsensePreviewValue` (rewrites the input when the current value has no matching option)
  - `NR` sentinel case-insensitive normalization
  - no-op safety on null / missing container / missing input

## What this proves

The extraction pattern from #1673 / #1676 works on `overlayHandler.js` too, on cohesive clusters that don't share meaningful closure state.

## What it doesn't prove

Not every cluster in this file will be this clean. The `refresh<Type>OverlayPreview` × 11 and `bind<Type>PreviewInputs` × 9 families almost certainly capture per-type input widgets and the per-board `getRuntimeVars` closure — those extractions may need dependency injection (`sharedDeps`, like #1676) or may resist cleanly and be better left in place. This PR is the "confirm the pattern works and set up the module home" step; the follow-ups will need per-cluster judgment calls.

## Verification

- `npx eslint` — clean
- `npm run build` — clean
- 1571 total vitest pass (+20 vs pre-PR)
