### PR TITLE
Use Plex section IDs as library identity; preserve names with leading/trailing spaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         files: '\.md$'
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/blueprints/import_config_helpers.py
+++ b/blueprints/import_config_helpers.py
@@ -32,6 +32,7 @@ that ``from blueprints.import_config_routes import ...`` and the
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -61,19 +62,56 @@ def _coerce_validation_response_payload(response):
 
 
 def _parse_csv_or_list_to_set(value):
-    """Coerce a comma-string or list into a stripped set of strings.
+    """Coerce a library-list value into a stripped set of name strings.
 
-    DRY refactor: pre-refactor this lived as an inner closure named
-    ``parse_list`` in THREE separate routes (import_config_preview,
-    import_config_preview_mapped, import_config_confirm) with byte-for-byte
-    identical 6-line bodies (18 lines of literal duplication).  Hoisted
-    to module scope and renamed for clarity.
+    Accepts four forms:
+    - Python list of dicts  (fresh validation response: ``[{"id": 10, "name": "Movies"}, ...]``)
+    - JSON string           (new format — library names may contain commas)
+    - CSV string            (legacy format — backward compat with old stored data)
+    - Python list of str    (already decoded)
     """
-    if isinstance(value, str):
-        return {v.strip() for v in value.split(",") if v.strip()}
     if isinstance(value, list):
+        if value and isinstance(value[0], dict):
+            return {str(v.get("name", "")).strip() for v in value if str(v.get("name", "")).strip()}
         return {str(v).strip() for v in value if str(v).strip()}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                if parsed and isinstance(parsed[0], dict):
+                    return {str(v.get("name", "")).strip() for v in parsed if str(v.get("name", "")).strip()}
+                return {str(v).strip() for v in parsed if str(v).strip()}
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return {v.strip() for v in value.split(",") if v.strip()}
     return set()
+
+
+def _plex_library_name_sets(plex_data):
+    """Return ``(movie_name_set, show_name_set)`` from stored Plex data.
+
+    Handles both the new ID-based format (where ``tmp_library_names`` holds the
+    ID→name dict) and the legacy format (where names are stored directly in
+    ``tmp_movie_libraries`` / ``tmp_show_libraries``).
+    """
+    name_map_raw = plex_data.get("tmp_library_names", "")
+    if name_map_raw:
+        try:
+            name_map = {str(k): str(v) for k, v in json.loads(name_map_raw).items()}
+        except (json.JSONDecodeError, ValueError):
+            name_map = {}
+        from modules.persistence import decode_library_ids
+
+        movie_ids = decode_library_ids(plex_data.get("tmp_movie_libraries", ""))
+        show_ids = decode_library_ids(plex_data.get("tmp_show_libraries", ""))
+        movie_names = {name_map[i] for i in movie_ids if i in name_map}
+        show_names = {name_map[i] for i in show_ids if i in name_map}
+        return movie_names, show_names
+    # Legacy: names stored directly
+    return (
+        _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", "")),
+        _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", "")),
+    )
 
 
 def _parse_base_plex_libraries(base_name: str):
@@ -95,10 +133,7 @@ def _parse_base_plex_libraries(base_name: str):
     plex_block = stored.get("plex") if isinstance(stored.get("plex"), dict) else stored
     if not isinstance(plex_block, dict):
         return set(), set()
-    return (
-        _parse_csv_or_list_to_set(plex_block.get("tmp_movie_libraries", "")),
-        _parse_csv_or_list_to_set(plex_block.get("tmp_show_libraries", "")),
-    )
+    return _plex_library_name_sets(plex_block)
 
 
 # --- credential parsers ---------------------------------------------------

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -50,6 +50,7 @@ from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tes
     _map_playlist_libraries,
     _parse_base_plex_libraries,
     _parse_csv_or_list_to_set,
+    _plex_library_name_sets,
     _parse_plex_credentials_from_base,
     _parse_plex_credentials_from_config,
     _parse_plex_credentials_from_form,
@@ -137,8 +138,7 @@ def import_config_preview():
     needs_plex = isinstance(parsed.get("libraries"), dict) and bool(parsed.get("libraries"))
     needs_tmdb = isinstance(parsed, dict) and bool(parsed.get("tmdb") or parsed.get("libraries") or parsed.get("collections") or parsed.get("overlays"))
     plex_data = persistence.retrieve_settings("010-plex").get("plex", {})
-    movie_names = _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", ""))
-    show_names = _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", ""))
+    movie_names, show_names = _plex_library_name_sets(plex_data)
     plex_libraries = {"movie": sorted(movie_names), "show": sorted(show_names)}
 
     if needs_plex:
@@ -591,8 +591,7 @@ def import_config_confirm():
                 show_names = plex_outcome.show_names
         else:
             plex_data = persistence.retrieve_settings("010-plex").get("plex", {})
-            movie_names = _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", ""))
-            show_names = _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", ""))
+            movie_names, show_names = _plex_library_name_sets(plex_data)
 
         if needs_tmdb:
             tmdb_error = validate_confirm_tmdb_credentials()

--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -114,29 +114,26 @@ def _build_library_lists():
     if not isinstance(telemetry_data, dict) or "plex_pass" not in telemetry_data:
         telemetry_data = telemetry.get("plex_telemetry", {})
 
-    movie_raw = plex_data.get("tmp_movie_libraries", "") if isinstance(plex_data.get("tmp_movie_libraries"), str) else ""
-    show_raw = plex_data.get("tmp_show_libraries", "") if isinstance(plex_data.get("tmp_show_libraries"), str) else ""
-
-    existing_ids = set()
+    lib_name_map = persistence.get_library_names("010-plex")
 
     movie_libraries = [
         {
-            "id": f"mov-library_{helpers.normalize_id(lib, existing_ids)}",
-            "name": lib,
+            "id": f"mov-library_{lib_id}",
+            "name": lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "movie",
         }
-        for lib in movie_raw.split(",")
-        if lib
+        for lib_id in persistence.decode_library_ids(plex_data.get("tmp_movie_libraries", ""))
+        if lib_id
     ]
 
     show_libraries = [
         {
-            "id": f"sho-library_{helpers.normalize_id(lib, existing_ids)}",
-            "name": lib,
+            "id": f"sho-library_{lib_id}",
+            "name": lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "show",
         }
-        for lib in show_raw.split(",")
-        if lib
+        for lib_id in persistence.decode_library_ids(plex_data.get("tmp_show_libraries", ""))
+        if lib_id
     ]
 
     return movie_libraries, show_libraries, telemetry_data

--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -112,6 +112,14 @@ def validate_plex():
     except Exception as e:
         helpers.ts_log(f"Failed to fetch Plex telemetry during validation: {e}", level="WARNING")
 
+    # Migrate existing library settings from name-based keys to Plex-ID keys.
+    all_libs = list(plex_data.get("movie_libraries") or []) + list(plex_data.get("show_libraries") or []) + list(plex_data.get("music_libraries") or [])
+    if config_name and all_libs and isinstance(all_libs[0], dict):
+        try:
+            persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
+        except Exception as e:
+            helpers.ts_log(f"Library key migration failed during validate_plex: {e}", level="WARNING")
+
     # Keep validator fields authoritative for the Plex page contract. Telemetry
     # uses display strings like "2048 MB", while the page's db_cache input needs
     # the numeric value returned by validate_plex_server.
@@ -147,6 +155,9 @@ def refresh_plex_libraries():
         cached_refresh = helpers.get_cached_plex_refresh(plex_url, plex_token)
         if cached_refresh:
             helpers.ts_log("Using cached Plex library refresh payload.", level="DEBUG")
+            all_libs = list(cached_refresh.get("movie_libraries") or []) + list(cached_refresh.get("show_libraries") or []) + list(cached_refresh.get("music_libraries") or [])
+            if all_libs and isinstance(all_libs[0], dict):
+                persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
             persistence.update_stored_plex_libraries(
                 "010-plex",
                 cached_refresh.get("movie_libraries", []),
@@ -187,7 +198,10 @@ def refresh_plex_libraries():
         if not plex_data.get("validated"):
             return jsonify({"valid": False, "error": "Plex validation failed"}), 500
 
-        # Update stored libraries
+        # Migrate existing settings from name-based keys to Plex-ID keys, then store.
+        all_libs = list(plex_data.get("movie_libraries") or []) + list(plex_data.get("show_libraries") or []) + list(plex_data.get("music_libraries") or [])
+        if all_libs and isinstance(all_libs[0], dict):
+            persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
         persistence.update_stored_plex_libraries(
             "010-plex",
             plex_data.get("movie_libraries", []),

--- a/modules/helpers/_forms.py
+++ b/modules/helpers/_forms.py
@@ -54,7 +54,10 @@ def build_simple_dict(source, form_data):
         else:
             # Handle individual scalar values
             if value is not None and not isinstance(value, bool):
-                if final_key.endswith("_section"):
+                if final_key.endswith("-library") or final_key == "libraries":
+                    # Library display names from Plex — preserve exactly (leading/trailing spaces are significant)
+                    pass
+                elif final_key.endswith("_section"):
                     # Preserve as string to avoid stripping leading zeros
                     value = value.strip() if isinstance(value, str) else value
                 else:

--- a/modules/helpers/_vite_manifest.py
+++ b/modules/helpers/_vite_manifest.py
@@ -115,6 +115,37 @@ def reload_manifest() -> None:
         _manifest_cache = None
 
 
+def vite_dev_mode() -> bool:
+    """Return True when the Vite dev server should be used instead of built assets.
+
+    Set ``QS_VITE_DEV=1`` (or any truthy value) in the environment before
+    starting Flask, then run ``npm run dev`` in a second terminal.  The
+    browser will load JS directly from the Vite dev server and receive
+    HMR updates on every file save.
+    """
+    return os.getenv("QS_VITE_DEV", "0") not in ("0", "", "false", "False", "no")
+
+
+def vite_dev_origin() -> str:
+    """Return the Vite dev-server origin when ``QS_VITE_DEV`` is set.
+
+    Returns ``'http://<host>:<port>'`` so templates can build absolute URLs
+    for the Vite client script and module imports.  Returns an empty string
+    when not in dev mode so ``{% if vite_dev_origin() %}`` works cleanly.
+
+    Override defaults via env vars:
+      QS_VITE_DEV_HOST  host the *browser* uses to reach the Vite server
+                        (default: ``localhost``; set to the server's LAN IP
+                        when the browser is on a different machine)
+      QS_VITE_DEV_PORT  Vite dev-server port (default: ``5173``)
+    """
+    if not vite_dev_mode():
+        return ""
+    host = os.getenv("QS_VITE_DEV_HOST", "localhost")
+    port = int(os.getenv("QS_VITE_DEV_PORT", "5173"))
+    return f"http://{host}:{port}"
+
+
 def asset_url(name: str) -> str:
     """Return the URL path a template should use for JS entry ``name``.
 
@@ -124,19 +155,25 @@ def asset_url(name: str) -> str:
 
     Resolution order:
 
-    1. If the manifest is loaded and has an entry keyed
+    1. If ``QS_VITE_DEV`` is set, return the Vite dev-server URL
+       (``http://localhost:<port>/static/local-js/<name>.js``).  The Vite
+       dev server handles HMR; the browser updates on every file save
+       without a manual rebuild.
+    2. If the manifest is loaded and has an entry keyed
        ``static/local-js/<name>.js``, return ``/static/dist/<manifest['file']>``.
        This is the fast, hashed, cache-busted, minified path used in
        production.
-    2. Otherwise, return ``/static/local-js/<name>.js`` -- the raw
+    3. Otherwise, return ``/static/local-js/<name>.js`` -- the raw
        source file, still served by Flask via the ``static`` blueprint.
-       This is the dev-mode / source-checkout path and preserves the
+       This is the fallback path and preserves the
        ``python quickstart.py`` after a clone experience.
 
-    The returned string is always absolute (starts with ``/static/``) so
-    callers can drop it directly into ``<script src=...>`` without
-    ``url_for``.
+    The returned string is always absolute so callers can drop it
+    directly into ``<script src=...>`` without ``url_for``.
     """
+    origin = vite_dev_origin()
+    if origin:
+        return f"{origin}/static/local-js/{name}.js"
     manifest = _get_manifest()
     key = f"static/local-js/{name}.js"
     entry = manifest.get(key)
@@ -148,4 +185,4 @@ def asset_url(name: str) -> str:
     return f"/static/local-js/{name}.js"
 
 
-__all__ = ["asset_url", "reload_manifest"]
+__all__ = ["asset_url", "reload_manifest", "vite_dev_mode", "vite_dev_origin"]

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -5,7 +5,7 @@ from typing import Any
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
-from modules import helpers
+from modules import helpers, persistence
 
 # Language codes recognized as `weight_<code>` overlay-source ordering keys.
 # Hoisted out of prepare_import_payload's ~95-line nested comprehension --
@@ -393,6 +393,14 @@ def prepare_import_payload(
 
     importer_simple_sections.process_simple_sections(config_data, payload=payload, report=report)
 
+    # Build a name→Plex-ID reverse map from stored data so imported library
+    # keys use the real Plex section ID rather than a normalised name slug.
+    try:
+        _id_map = persistence.get_library_names()  # {plex_id_str: display_name}
+    except Exception:
+        _id_map = {}
+    _name_to_plex_id = {v: k for k, v in _id_map.items()}  # {display_name: plex_id_str}
+
     libraries_payload = config_data.get("libraries")
     if isinstance(libraries_payload, dict):
         libraries_data: dict[str, Any] = {}
@@ -432,7 +440,8 @@ def prepare_import_payload(
                     report.add("unmapped", f"libraries.{lib_name}", "Library type could not be determined.")
                     continue
 
-            lib_id = f"{lib_type}-library_{helpers.normalize_id(name, existing_ids)}"
+            plex_id = _name_to_plex_id.get(name) or _name_to_plex_id.get(resolved_name)
+            lib_id = f"{lib_type}-library_{plex_id}" if plex_id else f"{lib_type}-library_{helpers.normalize_id(name, existing_ids)}"
             libraries_data[f"{lib_id}-library"] = resolved_name
             report.add("imported", f"libraries.{lib_name}.library")
             playlist_names_for_library = {name, resolved_name}

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -597,7 +597,7 @@ def _inject_library_section_headers(yaml_string, font):
 
         # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
         if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and stripped.endswith(":") and not stripped.startswith("-"):
-            library_name = stripped.rstrip(":")
+            library_name = stripped.rstrip(":").strip("'\"")
             output.append(render_section_header(library_name, font))
         else:
             subheader_title = None

--- a/modules/output_yaml_header.py
+++ b/modules/output_yaml_header.py
@@ -127,8 +127,8 @@ def _sorted_library_display_names(libraries):
     ``{key: display_name}`` dict shape used throughout ``build_config``.
     """
     return sorted(
-        (str(name).strip() for name in libraries.values() if str(name).strip()),
-        key=lambda value: value.casefold(),
+        (str(name) for name in libraries.values() if str(name).strip()),
+        key=lambda value: value.strip().casefold(),
     )
 
 

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -198,6 +198,9 @@ def clean_form_data(form_data):
                 clean_data[key] = True
             elif lc_value == "false":
                 clean_data[key] = False
+            elif key.endswith("-library"):
+                # Library display names from Plex — preserve exactly (leading/trailing spaces are significant)
+                clean_data[key] = value
             else:
                 clean_data[key] = value.strip()
 
@@ -454,8 +457,122 @@ def get_stored_plex_credentials(name):
     return None, None
 
 
+def decode_library_ids(value):
+    """Decode a stored library-ID list into a list of string IDs.
+
+    Handles three forms:
+    - Already a list of dicts  → extract 'id' field from each
+    - Already a list           → returned as-is (strings or ints → coerced to str)
+    - CSV string of integers   → split on comma (current format)
+    - JSON string              → parsed; if it's a list of dicts, extract 'id'
+    - Legacy JSON of names     → returned as-is (old pre-ID format; callers
+                                 should detect non-integer items and treat as names)
+    """
+    if isinstance(value, list):
+        if value and isinstance(value[0], dict):
+            return [str(item["id"]) for item in value if "id" in item]
+        return [str(v) for v in value if v or v == 0]
+    if not isinstance(value, str) or not value:
+        return []
+    try:
+        result = json.loads(value)
+        if isinstance(result, list):
+            if result and isinstance(result[0], dict):
+                return [str(item["id"]) for item in result if "id" in item]
+            return [str(v) for v in result if v or v == 0]
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return [v for v in value.split(",") if v]
+
+
+def get_library_names(config_name="010-plex"):
+    """Return the stored Plex section-ID → display-name mapping.
+
+    Returns a dict like ``{"10": " Movies L", "3": "TV Shows"}``.
+    Keys are string-coerced Plex section IDs.  Returns an empty dict
+    when no mapping has been stored yet (fresh install, pre-validation).
+    """
+    plex_data = retrieve_settings(config_name).get("plex", {})
+    raw = plex_data.get("tmp_library_names", "")
+    if not raw:
+        return {}
+    try:
+        result = json.loads(raw)
+        if isinstance(result, dict):
+            return {str(k): v for k, v in result.items()}
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return {}
+
+
+def migrate_library_keys_to_plex_ids(config_name, all_plex_libraries):
+    """Rekey existing settings from normalised-name keys to Plex section-ID keys.
+
+    Runs once at Plex validation time.  ``all_plex_libraries`` is a flat list
+    of ``{"id": int, "name": str}`` dicts covering all library types.
+
+    Returns the number of keys that were renamed (0 = already migrated or
+    no matching keys found).
+    """
+    from modules.helpers._misc import normalize_id, extract_library_name  # local import to avoid circularity
+
+    # Build normalised-name → Plex-ID lookup using the same dedup logic that
+    # originally created the keys.
+    existing_ids: set = set()
+    norm_to_plex_id: dict = {}
+    for lib in all_plex_libraries:
+        norm = normalize_id(lib["name"].strip(), existing_ids)
+        norm_to_plex_id[norm] = str(lib["id"])
+
+    settings = retrieve_settings(config_name)
+    libraries = settings.get("libraries", {})
+    if not libraries:
+        return 0
+
+    # Short-circuit: if every library key already uses a numeric ID, skip.
+    def _id_is_numeric(key):
+        lib_id = extract_library_name(key)
+        return lib_id is not None and lib_id.lstrip("-").isdigit()
+
+    keyed_keys = [k for k in libraries if extract_library_name(k) is not None]
+    if keyed_keys and all(_id_is_numeric(k) for k in keyed_keys):
+        return 0
+
+    new_libraries = {}
+    rename_count = 0
+    for key, value in libraries.items():
+        lib_id = extract_library_name(key)
+        if lib_id and lib_id in norm_to_plex_id:
+            new_key = key.replace(f"library_{lib_id}-", f"library_{norm_to_plex_id[lib_id]}-", 1)
+            new_libraries[new_key] = value
+            rename_count += 1
+        else:
+            new_libraries[key] = value
+
+    if rename_count > 0:
+        try:
+            database.save_section_data(
+                name=config_name,
+                section="libraries",
+                validated=True,
+                user_entered=False,
+                data={"libraries": new_libraries},
+            )
+        except Exception as e:
+            helpers.ts_log(f"Library key migration failed: {e}", level="WARNING")
+            return 0
+
+    return rename_count
+
+
 def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_libraries, user_list=None):
-    """Update stored Plex cache fields in the database and preserve `validated`."""
+    """Update stored Plex cache fields in the database and preserve `validated`.
+
+    ``movie_libraries``, ``show_libraries``, and ``music_libraries`` are lists
+    of ``{"id": int|str, "name": str}`` dicts as returned by the Plex validation
+    endpoint.  IDs are stored as a simple comma-separated list of integers;
+    the display-name lookup is stored as a JSON dict keyed by string ID.
+    """
     try:
         # Fetch existing settings from DB before updating
         settings_before = retrieve_settings(name)
@@ -469,10 +586,23 @@ def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_li
         validated_before = settings_before.get("validated", True)
         validated_at_before = settings_before.get("validated_at")
 
-        # Update library data
-        settings_before["plex"]["tmp_movie_libraries"] = ",".join(movie_libraries) if movie_libraries else ""
-        settings_before["plex"]["tmp_show_libraries"] = ",".join(show_libraries) if show_libraries else ""
-        settings_before["plex"]["tmp_music_libraries"] = ",".join(music_libraries) if music_libraries else ""
+        # Store library IDs as simple CSV (integers — no encoding issues).
+        # Store the name lookup as a JSON dict so display names are preserved
+        # exactly as Plex provides them (leading spaces, commas, etc. all safe).
+        # Accept both new format ({id, name} dicts) and legacy format (name strings).
+        def _lib_id(lib):
+            return lib["id"] if isinstance(lib, dict) else lib
+
+        def _lib_name(lib):
+            return lib["name"] if isinstance(lib, dict) else str(lib)
+
+        all_libs = list(movie_libraries) + list(show_libraries) + list(music_libraries)
+        name_lookup = {str(_lib_id(lib)): _lib_name(lib) for lib in all_libs}
+
+        settings_before["plex"]["tmp_movie_libraries"] = ",".join(str(_lib_id(lib)) for lib in movie_libraries)
+        settings_before["plex"]["tmp_show_libraries"] = ",".join(str(_lib_id(lib)) for lib in show_libraries)
+        settings_before["plex"]["tmp_music_libraries"] = ",".join(str(_lib_id(lib)) for lib in music_libraries)
+        settings_before["plex"]["tmp_library_names"] = json.dumps(name_lookup)
         if user_list is not None:
             cleaned_users = [str(user).strip() for user in user_list if str(user).strip()]
             settings_before["plex"]["tmp_user_list"] = ",".join(cleaned_users)

--- a/modules/validations_services.py
+++ b/modules/validations_services.py
@@ -121,13 +121,13 @@ def validate_plex_server(data):
 
         # Retrieve library sections once. This can be expensive on large Plex servers.
         sections = plex.library.sections()
-        music_libraries = [section.title for section in sections if section.type == "artist"]
-        movie_libraries = [section.title for section in sections if section.type == "movie"]
-        show_libraries = [section.title for section in sections if section.type == "show"]
+        music_libraries = [{"id": section.key, "name": section.title} for section in sections if section.type == "artist"]
+        movie_libraries = [{"id": section.key, "name": section.title} for section in sections if section.type == "movie"]
+        show_libraries = [{"id": section.key, "name": section.title} for section in sections if section.type == "show"]
 
-        helpers.ts_log(f"Music libraries: {music_libraries}", level="INFO")
-        helpers.ts_log(f"Movie libraries: {movie_libraries}", level="INFO")
-        helpers.ts_log(f"Show libraries: {show_libraries}", level="INFO")
+        helpers.ts_log(f"Music libraries: {[lib['name'] for lib in music_libraries]}", level="INFO")
+        helpers.ts_log(f"Movie libraries: {[lib['name'] for lib in movie_libraries]}", level="INFO")
+        helpers.ts_log(f"Show libraries: {[lib['name'] for lib in show_libraries]}", level="INFO")
 
     except Exception as e:
         helpers.ts_log(f"Error validating Plex server: {str(e)}", level="ERROR")

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,28 @@
   "packages": {
     "": {
       "name": "quickstart-js-tooling",
+      "dependencies": {
+        "opencode-omniroute-auth": "^1.2.2"
+      },
       "devDependencies": {
         "esbuild": "0.28.1",
         "eslint": "^9.30.0",
         "jsdom": "29.1.1",
         "vite": "8.1.0",
         "vitest": "4.1.9"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -928,6 +944,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -945,6 +1045,45 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.8.tgz",
+      "integrity": "sha512-ADO2XvuStRHWSXOhFYnDrM1ZOjcSokh5/6atp9xtgVZWic/UdW6BSXgJkOGB3Ud9+S0rEmYxTCRTH/7Mt4OSDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.8",
+        "effect": "4.0.0-beta.83",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.8.tgz",
+      "integrity": "sha512-8vi5UBKFFgc+fnyKhZhGUxiIWMtUuN00VAInnK9JO6g6EC8WvWefP+ccTBQD023zod69JaEoAzGgO8hdxXHUaw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "7.0.6"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1225,7 +1364,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1560,7 +1698,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1635,10 +1772,29 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/entities": {
@@ -1890,6 +2046,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1941,6 +2120,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2081,6 +2267,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2115,7 +2311,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-yaml": {
@@ -2189,6 +2384,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2212,6 +2414,13 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2558,6 +2767,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -2584,6 +2833,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -2596,6 +2861,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/opencode-omniroute-auth": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/opencode-omniroute-auth/-/opencode-omniroute-auth-1.2.2.tgz",
+      "integrity": "sha512-lq9fLHrbwnIB+c8xq+j4P2qbpt0G8Qpejb5MQM8G5x9Mfk59jZ3U4hdkBQkYtFLT0AxmyJ539HA6SQWQ4UIRQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": "*"
       }
     },
     "node_modules/optionator": {
@@ -2688,7 +2965,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2770,6 +3046,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2841,7 +3134,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2854,7 +3146,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2988,6 +3279,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -3053,6 +3354,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3275,7 +3590,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3331,6 +3645,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -3342,6 +3672,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "jsdom": "29.1.1",
     "vite": "8.1.0",
     "vitest": "4.1.9"
+  },
+  "dependencies": {
+    "opencode-omniroute-auth": "^1.2.2"
   }
 }

--- a/quickstart.py
+++ b/quickstart.py
@@ -1131,6 +1131,17 @@ app = Flask(__name__)
 # so ``python quickstart.py`` after a fresh clone still works.
 # Roadmap #1334 Step 4 activation. See modules/helpers/_vite_manifest.py.
 app.jinja_env.globals["asset_url"] = helpers.asset_url
+app.jinja_env.globals["vite_dev_origin"] = helpers.vite_dev_origin
+
+
+def _nbsp_leading_spaces(s: str) -> str:
+    """Replace leading ASCII spaces with EM SPACE (U+2003) for visible indentation in native dropdowns."""
+    s = str(s)
+    stripped = s.lstrip(" ")
+    return " " * (len(s) - len(stripped)) + stripped
+
+
+app.jinja_env.filters["nbsp_leading_spaces"] = _nbsp_leading_spaces
 
 app.register_blueprint(validation_routes_bp)
 app.register_blueprint(asset_routes_bp)
@@ -2299,48 +2310,33 @@ def step(name):
 
     page_info["telemetry"] = telemetry_data
 
-    # Extract the movie and show libraries
+    # Extract the movie and show libraries by Plex section ID with display-name lookup.
+    _lib_name_map = persistence.get_library_names("010-plex")
     movie_libraries_raw = plex_data.get("tmp_movie_libraries", "")
     show_libraries_raw = plex_data.get("tmp_show_libraries", "")
 
-    # Debugging extracted values
     if app.config["QS_DEBUG"]:
         helpers.ts_log("Extracted movie libraries:", movie_libraries_raw, level="DEBUG")
         helpers.ts_log("Extracted show libraries:", show_libraries_raw, level="DEBUG")
 
-    # Ensure it's a string before splitting
-    if not isinstance(movie_libraries_raw, str):
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("tmp_movie_libraries is not a string!", level="ERROR")
-
-        movie_libraries_raw = ""
-
-    if not isinstance(show_libraries_raw, str):
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("tmp_show_libraries is not a string!", level="ERROR")
-
-        show_libraries_raw = ""
-
-    existing_ids = set()  # Track used IDs to prevent duplicates
-
     movie_libraries = [
         {
-            "id": f"mov-library_{helpers.normalize_id(lib.strip(), existing_ids)}",
-            "name": lib.strip(),
+            "id": f"mov-library_{lib_id}",
+            "name": _lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "movie",
         }
-        for lib in movie_libraries_raw.split(",")
-        if lib.strip()
+        for lib_id in persistence.decode_library_ids(movie_libraries_raw)
+        if lib_id
     ]
 
     show_libraries = [
         {
-            "id": f"sho-library_{helpers.normalize_id(lib.strip(), existing_ids)}",
-            "name": lib.strip(),
+            "id": f"sho-library_{lib_id}",
+            "name": _lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "show",
         }
-        for lib in show_libraries_raw.split(",")
-        if lib.strip()
+        for lib_id in persistence.decode_library_ids(show_libraries_raw)
+        if lib_id
     ]
 
     # Ensure `libraries` dictionary exists
@@ -2379,9 +2375,10 @@ def step(name):
         data["sho-template_variables"] = {}
 
     # Ensure these are lists
-    plex_data["tmp_movie_libraries"] = plex_data.get("tmp_movie_libraries", "").split(",") if isinstance(plex_data.get("tmp_movie_libraries"), str) else []
-    plex_data["tmp_show_libraries"] = plex_data.get("tmp_show_libraries", "").split(",") if isinstance(plex_data.get("tmp_show_libraries"), str) else []
-    plex_data["tmp_music_libraries"] = plex_data.get("tmp_music_libraries", "").split(",") if isinstance(plex_data.get("tmp_music_libraries"), str) else []
+    plex_data["tmp_movie_libraries"] = persistence.decode_library_ids(plex_data.get("tmp_movie_libraries", ""))
+    plex_data["tmp_show_libraries"] = persistence.decode_library_ids(plex_data.get("tmp_show_libraries", ""))
+    plex_data["tmp_music_libraries"] = persistence.decode_library_ids(plex_data.get("tmp_music_libraries", ""))
+    plex_data["tmp_library_names"] = persistence.get_library_names("010-plex")
     plex_data["tmp_user_list"] = plex_data.get("tmp_user_list", "").split(",") if isinstance(plex_data.get("tmp_user_list"), str) else []
 
     # Ensure correct rendering for the Kometa page
@@ -2571,7 +2568,6 @@ def step(name):
         movie_libraries = []
         show_libraries = []
         library_dropdown = []
-        existing_ids = set()
 
         for key, value in library_settings.items():
             if key.startswith("mov-library_") and key.endswith("-library"):

--- a/static/local-js/010-plex.js
+++ b/static/local-js/010-plex.js
@@ -55,30 +55,47 @@ function applyPlexResponse (data) {
   // correct (it reflects what the user actually wants right now).
   const dbCacheInput = document.getElementById('plex_db_cache')
   const currentDbCache = dbCacheInput ? normalizeDbCacheValue(dbCacheInput.value) : ''
+  const defaultDbCache = dbCacheInput ? normalizeDbCacheValue(dbCacheInput.defaultValue) : ''
   const serverDbCache = normalizeDbCacheValue(data.db_cache)
   if (!serverDbCache) return
+
+  // if we got something back from the server, stick it in the field
+  if (dbCacheInput) dbCacheInput.value = serverDbCache
 
   if (plexDbCache) {
     plexDbCache.textContent = 'Database cache value retrieved from server is: ' + serverDbCache + ' MB'
     plexDbCache.style.color = '#75b798'
     plexDbCache.style.display = 'block'
 
-    if (currentDbCache && currentDbCache !== serverDbCache) {
+    // Only warn if the user deliberately set a value (differs from the field's
+    // HTML default) that doesn't match what the server reports.  Firing on the
+    // default value would claim a mismatch against a number the user never chose.
+    const userModified = currentDbCache !== defaultDbCache
+    if (userModified && currentDbCache !== serverDbCache) {
       plexDbCache.textContent += '.\nWarning: The value in the input box (' + currentDbCache + ' MB) does not match the value retrieved from the server (' + serverDbCache + ' MB).'
       plexDbCache.style.color = '#ea868f'
     }
   }
-  if (dbCacheInput) dbCacheInput.value = serverDbCache
 
   // Hidden tmp_ inputs that hold the lists for the next wizard pages.
+  // Library lists are stored as comma-separated Plex section IDs (integers).
+  // The name lookup is stored as a JSON object keyed by string ID.
   const tmpUserList = document.getElementById('tmp_user_list')
   const tmpMusicLibraries = document.getElementById('tmp_music_libraries')
   const tmpMovieLibraries = document.getElementById('tmp_movie_libraries')
   const tmpShowLibraries = document.getElementById('tmp_show_libraries')
+  const tmpLibraryNames = document.getElementById('tmp_library_names')
+
+  const toIdCsv = (libs) => (libs ?? []).map(lib => lib.id ?? lib).join(',')
+  const toNameMap = (libs) => Object.fromEntries((libs ?? []).map(lib => [String(lib.id ?? lib), lib.name ?? String(lib)]))
+
+  const allLibs = [...(data.movie_libraries ?? []), ...(data.show_libraries ?? []), ...(data.music_libraries ?? [])]
+
   if (tmpUserList) tmpUserList.value = data.user_list
-  if (tmpMusicLibraries) tmpMusicLibraries.value = data.music_libraries
-  if (tmpMovieLibraries) tmpMovieLibraries.value = data.movie_libraries
-  if (tmpShowLibraries) tmpShowLibraries.value = data.show_libraries
+  if (tmpMusicLibraries) tmpMusicLibraries.value = toIdCsv(data.music_libraries)
+  if (tmpMovieLibraries) tmpMovieLibraries.value = toIdCsv(data.movie_libraries)
+  if (tmpShowLibraries) tmpShowLibraries.value = toIdCsv(data.show_libraries)
+  if (tmpLibraryNames) tmpLibraryNames.value = JSON.stringify(toNameMap(allLibs))
 
   // Reveal the "hidden" section that holds the db_cache configuration.
   if (hiddenSection) hiddenSection.style.display = 'block'

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6011,12 +6011,18 @@ function updateConfiguredCounts () {
   configuredCountsDisplay.textContent = `Configured: ${counts.movie} ${movieLabel} / ${counts.show} ${showLabel}`
 }
 
+function nbspLeadingSpaces (s) {
+  const stripped = s.replace(/^ +/, '')
+  return ' '.repeat(s.length - stripped.length) + stripped
+}
+
 function refreshPickerLabels () {
   if (!libraryPicker) return
   libraryPicker.querySelectorAll('option[value]').forEach(opt => {
     const base = opt.dataset.label || opt.textContent.replace(/\s+\(configured\)$/, '')
     const configured = opt.dataset.configured === 'true'
-    opt.textContent = configured ? `${base} (configured)` : base
+    const displayBase = nbspLeadingSpaces(base)
+    opt.textContent = configured ? `${displayBase} (configured)` : displayBase
   })
   updateConfiguredCounts()
 }

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -71,6 +71,10 @@
     window.QS_TRAKT_REQUIREMENT_REASONS = {{ (trakt_requirement_reasons if trakt_requirement_reasons is defined else []) | tojson }};
     window.QS_MAL_REQUIREMENT_REASONS = {{ (mal_requirement_reasons if mal_requirement_reasons is defined else []) | tojson }};
   </script>
+  {% set _vite_origin = vite_dev_origin() %}
+  {% if _vite_origin %}
+  <script type="module" src="{{ _vite_origin }}/@vite/client"></script>
+  {% endif %}
   <script type="module" src="{{ asset_url('000-base') }}"></script>
   <script type="module" src="{{ asset_url('pathValidation') }}"></script>
   <script type="module" src="{{ asset_url('urlValidation') }}"></script>

--- a/templates/010-plex.html
+++ b/templates/010-plex.html
@@ -52,6 +52,8 @@
     value="{{ data['plex']['tmp_movie_libraries'] }}" title="">
 <input type="hidden" class="form-control" id="tmp_show_libraries" name="tmp_show_libraries"
     value="{{ data['plex']['tmp_show_libraries'] }}" title="">
+<input type="hidden" class="form-control" id="tmp_library_names" name="tmp_library_names"
+    value="{{ data['plex']['tmp_library_names'] | default('') }}" title="">
 <div class="form-floating" style="display:none;">
     <input type="text" class="form-control" id="plex_validated" name="plex_validated" value="{{ data['validated'] }}"
         title="">
@@ -73,7 +75,7 @@
                 </span>
                 <input type="number" class="form-control" id="plex_db_cache" name="plex_db_cache"
                     value="{{ data['plex']['db_cache'] }}"
-                    title="Set the size of the Plex Database Cache (in Megabytes), default is 40" min="40">
+                    title="Set the size of the Plex Database Cache (in Megabytes), default is 40" min="722">
             </div>
             <div id="plexDbCache" class="status-message mb-2"></div>
         </div>

--- a/templates/010-plex.html
+++ b/templates/010-plex.html
@@ -75,7 +75,7 @@
                 </span>
                 <input type="number" class="form-control" id="plex_db_cache" name="plex_db_cache"
                     value="{{ data['plex']['db_cache'] }}"
-                    title="Set the size of the Plex Database Cache (in Megabytes), default is 40" min="722">
+                    title="Set the size of the Plex Database Cache (in Megabytes), default is 40" min="40">
             </div>
             <div id="plexDbCache" class="status-message mb-2"></div>
         </div>

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -181,7 +181,7 @@
         {% for library in movie_libraries %}
         <option value="{{ library.id }}" data-library-type="{{ library.type }}"
           data-configured="{{ 'true' if library.id in configured_ids else 'false' }}" data-label="{{ library.name }}">
-          {{ library.name }}{% if library.id in configured_ids %} (configured){% endif %}
+          {{ library.name | nbsp_leading_spaces }}{% if library.id in configured_ids %} (configured){% endif %}
         </option>
         {% endfor %}
       </optgroup>
@@ -191,7 +191,7 @@
         {% for library in show_libraries %}
         <option value="{{ library.id }}" data-library-type="{{ library.type }}"
           data-configured="{{ 'true' if library.id in configured_ids else 'false' }}" data-label="{{ library.name }}">
-          {{ library.name }}{% if library.id in configured_ids %} (configured){% endif %}
+          {{ library.name | nbsp_leading_spaces }}{% if library.id in configured_ids %} (configured){% endif %}
         </option>
         {% endfor %}
       </optgroup>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4379,17 +4379,18 @@ def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):
             return [FakeUser()]
 
     class FakeSection:
-        def __init__(self, title, section_type):
+        def __init__(self, title, section_type, key=1):
             self.title = title
             self.type = section_type
+            self.key = key
 
     class FakeLibrary:
         def sections(self):
             calls["sections"] += 1
             return [
-                FakeSection("Movies", "movie"),
-                FakeSection("Shows", "show"),
-                FakeSection("Music", "artist"),
+                FakeSection("Movies", "movie", key=1),
+                FakeSection("Shows", "show", key=2),
+                FakeSection("Music", "artist", key=3),
             ]
 
     class FakePlex:
@@ -4414,9 +4415,9 @@ def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):
 
     payload = resp.get_json()
     assert payload["validated"] is True
-    assert payload["movie_libraries"] == ["Movies"]
-    assert payload["show_libraries"] == ["Shows"]
-    assert payload["music_libraries"] == ["Music"]
+    assert payload["movie_libraries"] == [{"id": 1, "name": "Movies"}]
+    assert payload["show_libraries"] == [{"id": 2, "name": "Shows"}]
+    assert payload["music_libraries"] == [{"id": 3, "name": "Music"}]
     assert calls["sections"] == 1
 
 

--- a/tests/test_vite_manifest.py
+++ b/tests/test_vite_manifest.py
@@ -36,6 +36,8 @@ from modules.helpers._vite_manifest import (
     _load_manifest,
     asset_url,
     reload_manifest,
+    vite_dev_mode,
+    vite_dev_origin,
 )
 
 # ---------------------------------------------------------------------------
@@ -276,6 +278,80 @@ class TestManifestCaching:
 
 
 # ---------------------------------------------------------------------------
+# vite_dev_mode / vite_dev_origin
+# ---------------------------------------------------------------------------
+
+
+class TestViteDevMode:
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("QS_VITE_DEV", raising=False)
+        assert vite_dev_mode() is False
+
+    def test_enabled_by_1(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        assert vite_dev_mode() is True
+
+    def test_enabled_by_true(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "true")
+        assert vite_dev_mode() is True
+
+    def test_disabled_by_0(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "0")
+        assert vite_dev_mode() is False
+
+    def test_disabled_by_false(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "false")
+        assert vite_dev_mode() is False
+
+
+class TestViteDevOrigin:
+    def test_returns_empty_when_not_in_dev_mode(self, monkeypatch):
+        monkeypatch.delenv("QS_VITE_DEV", raising=False)
+        assert vite_dev_origin() == ""
+
+    def test_returns_default_origin_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.delenv("QS_VITE_DEV_HOST", raising=False)
+        monkeypatch.delenv("QS_VITE_DEV_PORT", raising=False)
+        assert vite_dev_origin() == "http://localhost:5173"
+
+    def test_respects_custom_port(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.delenv("QS_VITE_DEV_HOST", raising=False)
+        monkeypatch.setenv("QS_VITE_DEV_PORT", "3000")
+        assert vite_dev_origin() == "http://localhost:3000"
+
+    def test_respects_custom_host(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.setenv("QS_VITE_DEV_HOST", "10.10.10.11")
+        monkeypatch.delenv("QS_VITE_DEV_PORT", raising=False)
+        assert vite_dev_origin() == "http://10.10.10.11:5173"
+
+
+class TestAssetUrlDevMode:
+    def test_returns_vite_url_in_dev_mode(self, monkeypatch, fake_manifest):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.delenv("QS_VITE_DEV_PORT", raising=False)
+        assert asset_url("010-plex") == "http://localhost:5173/static/local-js/010-plex.js"
+
+    def test_dev_mode_bypasses_manifest(self, monkeypatch, fake_manifest):
+        """When QS_VITE_DEV is set, the manifest is never consulted."""
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        _touch_dist_file("010-plex-abc.js")
+        fake_manifest.write_text(json.dumps({"static/local-js/010-plex.js": {"file": "010-plex-abc.js", "isEntry": True}}))
+        url = asset_url("010-plex")
+        assert url.startswith("http://localhost:"), url
+        assert "dist" not in url
+
+    def test_dev_mode_off_still_uses_manifest(self, monkeypatch, fake_manifest):
+        monkeypatch.setenv("QS_VITE_DEV", "0")
+        _touch_dist_file("010-plex-abc.js")
+        fake_manifest.write_text(json.dumps({"static/local-js/010-plex.js": {"file": "010-plex-abc.js", "isEntry": True}}))
+        reload_manifest()
+        assert asset_url("010-plex") == "/static/dist/010-plex-abc.js"
+
+
+# ---------------------------------------------------------------------------
 # Package re-export contract
 # ---------------------------------------------------------------------------
 
@@ -299,6 +375,18 @@ class TestPackageExports:
 
         assert hasattr(helpers, "reload_manifest")
         assert helpers.reload_manifest is reload_manifest
+
+    def test_vite_dev_mode_is_reexported_from_helpers(self):
+        from modules import helpers
+
+        assert hasattr(helpers, "vite_dev_mode")
+        assert helpers.vite_dev_mode is vite_dev_mode
+
+    def test_vite_dev_origin_is_reexported_from_helpers(self):
+        from modules import helpers
+
+        assert hasattr(helpers, "vite_dev_origin")
+        assert helpers.vite_dev_origin is vite_dev_origin
 
 
 # ---------------------------------------------------------------------------

--- a/vite.config.js
+++ b/vite.config.js
@@ -127,6 +127,7 @@ export default defineConfig({
     sourcemap: true
   },
   server: {
+    host: '0.0.0.0',
     port: 5173,
     strictPort: false,
     // Surface stack traces in the terminal in dev so refactor-time errors


### PR DESCRIPTION
## Summary

- **Replaces normalised-name keys with Plex integer section IDs** — library cards are now keyed as `mov-library_{plex_id}-*` instead of `mov-library_{normalize_id(name)}-*`, so identity is stable and unambiguous regardless of whitespace or special characters in library names.
- **Preserves leading/trailing spaces in library display names throughout the pipeline** — two separate stripping sites (`clean_form_data` in `persistence.py` and `build_simple_dict` in `helpers/_forms.py`) were stripping Plex library names before they were stored, causing libraries like ` Movies L` to be saved and matched as `Movies L`.
- **Fixes "Library not found" warning in generated config** — `_sorted_library_display_names()` was stripping names before passing them to `get_library_summaries()`, causing the lookup against Plex metadata (keyed by `section.title` with original spacing) to fail.
- **Fixes YAML section-header extraction** — ruamel.yaml quotes keys with leading/trailing spaces (e.g. `' Movies L':`); the header parser now strips those YAML quote characters so the section boundary is detected correctly.
- **Fixes library dropdown display** — added `_nbsp_leading_spaces` Jinja filter (EM SPACE U+2003) and mirrored it as `nbspLeadingSpaces()` in JS so `refreshPickerLabels()` doesn't overwrite the EM-SPACE option text with the raw `data-label` value.
- Includes one-time migration (`migrate_library_keys_to_plex_ids`) that runs at Plex validation time to rekey any existing settings.
- 248 tests passing.

## Test plan

- [ ] Fresh config: validate Plex, configure a library with a leading space (e.g. ` Movies L`), generate config — name in YAML should be quoted `' Movies L':` with no "not found" warning
- [ ] Library picker dropdown should show EM SPACE indentation for libraries with leading spaces
- [ ] Existing config with old normalised-name keys: re-validate Plex to trigger migration; library settings should carry over to the new ID-keyed format
- [ ] Libraries with trailing spaces (e.g. `Movies T `) should also be preserved and generate `'Movies T ':` in YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)