### PR TITLE
cleanup validate all

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -2556,7 +2556,7 @@ def step(name):
         elif final_gate.get("stage") == "freshness":
             validation_rollup_state = "warn"
             if not validation_bulk_rollup:
-                validation_bulk_rollup = f"Validation is stale. Bulk validation has not run in the last {QS_FINAL_VALIDATION_TTL_HOURS} hours."
+                validation_bulk_rollup = f"Validation is stale. Validate All has not completed in the last {QS_FINAL_VALIDATION_TTL_HOURS} hours."
         page_info["saved_filename"] = saved_filename
         page_info["yaml_valid"] = validated
         page_info["quickstart_root"] = helpers.get_app_root()
@@ -3196,7 +3196,7 @@ def validate_all_services():
         details=kometa_details,
     )
 
-    # Bulk validation for libraries
+    # Validate All checks for libraries
     plex_settings = persistence.retrieve_settings("010-plex") or {}
     plex_is_valid = helpers.booler(plex_settings.get("validated", False)) if isinstance(plex_settings, dict) else False
     if not plex_is_valid:
@@ -3318,7 +3318,7 @@ def validate_all_services():
                 ),
             )
 
-    # Bulk validation for settings
+    # Validate All checks for settings
     settings_settings = persistence.retrieve_settings("150-settings") or {}
     settings_section = settings_settings.get("settings", {}) if isinstance(settings_settings, dict) else {}
     if not isinstance(settings_section, dict) or not settings_section:
@@ -3381,7 +3381,7 @@ def validate_all_services():
         else:
             update_section_validation("150-settings", "settings", True)
 
-    # Bulk validation for AniDB
+    # Validate All checks for AniDB
     anidb_settings = persistence.retrieve_settings("100-anidb") or {}
     anidb_data = anidb_settings.get("anidb", {}) if isinstance(anidb_settings, dict) else {}
     anidb_enabled = helpers.booler(anidb_data.get("enable")) if isinstance(anidb_data, dict) else False
@@ -3390,7 +3390,7 @@ def validate_all_services():
     else:
         skip_section_validation("100-anidb", "anidb", reason="disabled")
 
-    # Bulk validation for Webhooks
+    # Validate All checks for Webhooks
     webhooks_settings = persistence.retrieve_settings("090-webhooks") or {}
     webhooks_data = webhooks_settings.get("webhooks", {}) if isinstance(webhooks_settings, dict) else {}
     configured_webhooks = False
@@ -3405,7 +3405,7 @@ def validate_all_services():
     else:
         skip_section_validation("090-webhooks", "webhooks", reason="no_webhooks")
 
-    # Bulk validation for Trakt (token check if present)
+    # Validate All checks for Trakt (token check if present)
     trakt_settings = persistence.retrieve_settings("130-trakt") or {}
     trakt_data = trakt_settings.get("trakt", {}) if isinstance(trakt_settings, dict) else {}
     trakt_auth = trakt_data.get("authorization", {}) if isinstance(trakt_data, dict) else {}
@@ -3436,7 +3436,7 @@ def validate_all_services():
         except requests.exceptions.RequestException:
             update_section_validation("130-trakt", "trakt", False, reason="validation_error")
 
-    # Bulk validation for MAL (token check if present)
+    # Validate All checks for MAL (token check if present)
     mal_settings = persistence.retrieve_settings("140-mal") or {}
     mal_data = mal_settings.get("mal", {}) if isinstance(mal_settings, dict) else {}
     mal_auth = mal_data.get("authorization", {}) if isinstance(mal_data, dict) else {}
@@ -3513,7 +3513,7 @@ def validate_all_services():
     failed = summary.get("failed", 0)
     skipped = summary.get("skipped", 0)
     separator = "\u2022"
-    summary_text = f"Completed. Validated: {ok} {separator} Failed: {failed} {separator} Skipped: {skipped}."
+    summary_text = f"Validated: {ok} {separator} Failed: {failed} {separator} Skipped: {skipped}."
     summary_updated_at = utc_now_iso()
     summary_payload = {
         "summary_text": summary_text,

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -802,10 +802,8 @@ document.querySelectorAll('[data-validation-iso-age]').forEach(el => {
 
 const validateAllBtn = document.getElementById('validate-all-services')
 const validateAllStatus = document.getElementById('validate-all-status')
-const validateAllStatusTime = document.getElementById('validate-all-status-time')
 const validateAllStatusBulk = document.getElementById('validate-all-status-bulk')
 const validateAllStatusBulkTime = document.getElementById('validate-all-status-bulk-time')
-const validationStatusLastRun = document.getElementById('validation-status-last-run')
 let previouslyBlocked = false
 let previousStatuses = {}
 
@@ -824,7 +822,7 @@ if (validateAllBtn) {
     if (validateAllStatus) {
       validateAllStatus.classList.add('d-none')
       validateAllStatus.classList.remove('text-danger', 'text-success', 'text-warning')
-      validateAllStatus.textContent = 'Validating configured services...'
+      validateAllStatus.textContent = 'Validating all services...'
       validateAllStatus.classList.remove('d-none')
     }
   })
@@ -858,34 +856,13 @@ if (validateAllBtn) {
     const skipped = summary.skipped || 0
     const summaryUpdatedAt = data.summary_updated_at || new Date().toISOString()
     if (validateAllStatus) {
-      validateAllStatus.classList.remove('d-none', 'text-danger', 'text-success', 'text-warning')
-      if (failed > 0) {
-        validateAllStatus.classList.add('text-danger')
-      } else if (skipped > 0) {
-        validateAllStatus.classList.add('text-warning')
-      } else {
-        validateAllStatus.classList.add('text-success')
-      }
-      const currentSummaryText = `Current. Validated: ${ok} • Failed: ${failed} • Pending: ${skipped}.`
-      validateAllStatus.textContent = currentSummaryText
-      if (validateAllStatusTime) {
-        validateAllStatusTime.dataset.validationIso = summaryUpdatedAt
-        const parsed = new Date(summaryUpdatedAt)
-        if (!Number.isNaN(parsed.getTime())) {
-          validateAllStatusTime.textContent = formatLocalTimestamp(parsed)
-        }
-      }
-      if (validationStatusLastRun) {
-        validationStatusLastRun.dataset.validationIso = summaryUpdatedAt
-        const parsed = new Date(summaryUpdatedAt)
-        if (!Number.isNaN(parsed.getTime())) {
-          validationStatusLastRun.textContent = formatLocalTimestamp(parsed)
-        }
-      }
+      validateAllStatus.classList.add('d-none')
+      validateAllStatus.classList.remove('text-danger', 'text-success', 'text-warning')
+      validateAllStatus.textContent = ''
     }
     if (validateAllStatusBulk) {
       validateAllStatusBulk.classList.remove('d-none')
-      validateAllStatusBulk.textContent = data.summary_text || `Completed. Validated: ${ok} • Failed: ${failed} • Skipped: ${skipped}.`
+      validateAllStatusBulk.textContent = data.summary_text || `Validated: ${ok} • Failed: ${failed} • Skipped: ${skipped}.`
     }
     if (validateAllStatusBulkTime) {
       validateAllStatusBulkTime.dataset.validationIso = summaryUpdatedAt

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -99,7 +99,7 @@
   {% elif final_gate.stage == 'freshness' %}
   <div class="fw-semibold mb-1">Validation is stale</div>
   <div>
-    Bulk validation is missing or older than {{ final_gate.validation_ttl_hours }} hours. Quickstart is running Validate All now and will refresh this page when it finishes.
+    Validate All is missing or older than {{ final_gate.validation_ttl_hours }} hours. Quickstart is running Validate All now and will refresh this page when it finishes.
     <span class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
   </div>
   {% elif final_gate.stage == 'config' %}
@@ -136,10 +136,6 @@
           data-skipped="{{ rollup_skipped }}">
           {{ rollup_label }}
         </span>
-        <span class="small text-muted ms-2">
-          Last updated:
-          <span id="validation-status-last-run" data-validation-iso="{{ validation_rollup_at | default('', true) }}">Never</span>
-        </span>
       </button>
     </h2>
     <div id="validation-status-collapse" class="accordion-collapse collapse{% if final_gate and final_gate.stage == 'freshness' %} show{% endif %}" aria-labelledby="validation-status-heading"
@@ -150,39 +146,25 @@
             Status
             <span class="rating-mapping-option-via rating-mapping-option-via--header rating-mapping-option-via--neutral">Pill</span>
             shows the page name and is clickable; colors reflect validation status. Gray means not applicable.
-            <div class="mt-1 d-flex flex-wrap align-items-center gap-2">
-              Bulk legend:
-              <span class="rating-mapping-option-via rating-mapping-option-via--validated">Bulk</span>
-              <span class="rating-mapping-option-via rating-mapping-option-via--interactive">Interactive</span>
-              <span class="rating-mapping-option-via rating-mapping-option-via--neutral">N/A</span>
-            </div>
           </div>
           <button id="validate-all-services" type="button" class="btn btn-outline-info btn-sm" data-qs-validate-all>
-            <i class="bi bi-check2-circle me-1"></i> Validate Configured Services
+            <i class="bi bi-check2-circle me-1"></i> Validate All
             <span id="validate-all-spinner" class="spinner-border spinner-border-sm ms-1 d-none qs-validate-all-spinner" role="status" aria-hidden="true"></span>
           </button>
         </div>
-        <div class="small text-muted text-uppercase">Current validation summary</div>
-        <div id="validate-all-status" class="small text-muted">{{ validation_rollup if validation_rollup else 'Current status unavailable.' }}</div>
+        <div id="validate-all-status" class="small text-muted d-none"></div>
+        <div class="small text-muted text-uppercase">Validate All run summary</div>
+        {% set validate_all_summary = validation_bulk_rollup | replace('Completed. ', '') | replace('Completed ', '') if validation_bulk_rollup else '' %}
+        <div id="validate-all-status-bulk" class="small text-muted">{{ validate_all_summary if validate_all_summary else 'No Validate All run has completed yet.' }}</div>
         <div class="small text-muted mb-2">
-          Last updated:
-          <span id="validate-all-status-time" data-validation-iso="{{ validation_rollup_at | default('', true) }}">—</span>
-        </div>
-        <div class="small text-muted text-uppercase">Last bulk validation run</div>
-        <div id="validate-all-status-bulk" class="small text-muted">{{ validation_bulk_rollup if validation_bulk_rollup else 'No bulk validation run yet.' }}</div>
-        <div class="small text-muted mb-2">
-          Bulk updated:
+          Run completed:
           <span id="validate-all-status-bulk-time" data-validation-iso="{{ validation_bulk_rollup_at | default('', true) }}">—</span>
         </div>
-        {% set bulk_pages = ['010-plex','020-tmdb','025-libraries','030-tautulli','040-github','050-omdb','060-mdblist','070-notifiarr','080-gotify','085-ntfy','087-apprise','088-yamtrack','090-webhooks','100-anidb','110-radarr','120-sonarr','150-settings','130-trakt','140-mal'] %}
-        {% set interactive_pages = [] %}
-        {% set nonservice_pages = ['001-start','900-kometa','910-sponsor','905-analytics'] %}
         <div class="table-responsive" data-qs-sticky-first="true">
           <table class="table table-sm table-dark table-striped align-middle mb-0">
             <thead>
               <tr>
                 <th>Status</th>
-                <th>Bulk</th>
                 <th>Last validated</th>
                 <th>Time since</th>
                 <th>Validation Results</th>
@@ -190,35 +172,17 @@
             </thead>
             <tbody>
               {% for entry in validation_meta %}
+              {% if entry.has_validation %}
               <tr data-validation-key="{{ entry.key }}">
                 <td>
                   <div class="d-flex flex-column gap-1">
-                    {% if entry.has_validation %}
                     <a class="rating-mapping-option-via rating-mapping-option-link validation-status-pill rating-mapping-option-via--{{ 'validated' if entry.validated else 'unvalidated' }}"
                       href="javascript:void(0);" data-jumpto-page="{{ entry.page }}">
                       {{ entry.label }}
                     </a>
-                    {% else %}
-                    <a class="rating-mapping-option-via rating-mapping-option-link validation-status-pill rating-mapping-option-via--neutral"
-                      href="javascript:void(0);" data-jumpto-page="{{ entry.page }}">
-                      {{ entry.label }}
-                    </a>
-                    {% endif %}
                   </div>
                 </td>
                 <td>
-                  {% if entry.page in bulk_pages %}
-                  <span class="rating-mapping-option-via rating-mapping-option-via--validated">Bulk</span>
-                  {% elif entry.page in interactive_pages %}
-                  <span class="rating-mapping-option-via rating-mapping-option-via--interactive">Interactive</span>
-                  {% elif entry.page in nonservice_pages or not entry.has_validation %}
-                  <span class="rating-mapping-option-via rating-mapping-option-via--neutral">N/A</span>
-                  {% else %}
-                  <span class="rating-mapping-option-via rating-mapping-option-via--neutral">N/A</span>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if entry.has_validation %}
                   <span class="validation-timestamp small text-muted"
                     data-validation-iso="{{ entry.validated_at | default('', true) }}">
                     {% if entry.validated_at %}
@@ -229,34 +193,24 @@
                     Never
                     {% endif %}
                   </span>
-                  {% else %}
-                  <span class="validation-timestamp small text-muted">N/A</span>
-                  {% endif %}
                 </td>
                 <td>
-                  {% if entry.has_validation %}
                   {% if entry.validated_at %}
                   <span class="validation-age small text-muted"
                     data-validation-iso-age="{{ entry.validated_at | default('', true) }}">—</span>
                   {% else %}
                   <span class="validation-age small text-muted">—</span>
                   {% endif %}
-                  {% else %}
-                  <span class="validation-age small text-muted">N/A</span>
-                  {% endif %}
                 </td>
                 <td>
-                  {% if entry.has_validation %}
                   {% if entry.validation_result %}
                   <span class="validation-result small text-muted">{{ entry.validation_result }}</span>
                   {% else %}
                   <span class="validation-result small text-muted">—</span>
                   {% endif %}
-                  {% else %}
-                  <span class="validation-result small text-muted">N/A</span>
-                  {% endif %}
                 </td>
               </tr>
+              {% endif %}
               {% endfor %}
             </tbody>
           </table>


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR simplifies the Kometa validation status panel so it is easier to read, especially on mobile.

## Changes

- Renamed the validation action button from `Validate Configured Services` to `Validate All`.
- Removed the Bulk legend row and the `BULK`, `INTERACTIVE`, and `N/A` pills.
- Removed the Current Validation Summary block.
- Removed the validation timestamp from the accordion header.
- Renamed the remaining summary section to `Validate All run summary`.
- Changed the summary timestamp label to `Run completed`.
- Removed noisy non-validation rows from the per-page validation table.
- Removed the `Bulk` column from the validation table.
- Normalized persisted/displayed summary text so it shows counts directly, without the old `Completed.` prefix.
- Updated stale-validation copy to use `Validate All` terminology instead of bulk-validation language.

## Validation

- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k "final_page or bulk"`
- `npx eslint static/local-js/900-kometa.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
