### PR TITLE
Use Plex section IDs as library identity; fix names with spaces throughout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         files: '\.md$'
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/blueprints/import_config_helpers.py
+++ b/blueprints/import_config_helpers.py
@@ -62,25 +62,31 @@ def _coerce_validation_response_payload(response):
 
 
 def _parse_csv_or_list_to_set(value):
-    """Coerce a library-list value into a stripped set of name strings.
+    """Coerce a library-list value into a set of name strings.
+
+    Leading/trailing whitespace is preserved in list and JSON-list forms
+    so that library names like " Movies " survive the round-trip.
+    Whitespace is used only as a filter (to skip blank values).
+    CSV values are still stripped because comma-delimited items typically
+    have spaces around the commas.
 
     Accepts four forms:
-    - Python list of dicts  (fresh validation response: ``[{"id": 10, "name": "Movies"}, ...]``)
+    - Python list of dicts  (fresh validation response: ``[{"id": 10, "name": " Movies "}, ...]``)
     - JSON string           (new format — library names may contain commas)
     - CSV string            (legacy format — backward compat with old stored data)
     - Python list of str    (already decoded)
     """
     if isinstance(value, list):
         if value and isinstance(value[0], dict):
-            return {str(v.get("name", "")).strip() for v in value if str(v.get("name", "")).strip()}
-        return {str(v).strip() for v in value if str(v).strip()}
+            return {str(v.get("name", "")) for v in value if str(v.get("name", "")).strip()}
+        return {str(v) for v in value if str(v).strip()}
     if isinstance(value, str):
         try:
             parsed = json.loads(value)
             if isinstance(parsed, list):
                 if parsed and isinstance(parsed[0], dict):
-                    return {str(v.get("name", "")).strip() for v in parsed if str(v.get("name", "")).strip()}
-                return {str(v).strip() for v in parsed if str(v).strip()}
+                    return {str(v.get("name", "")) for v in parsed if str(v.get("name", "")).strip()}
+                return {str(v) for v in parsed if str(v).strip()}
         except (json.JSONDecodeError, ValueError):
             pass
         return {v.strip() for v in value.split(",") if v.strip()}

--- a/blueprints/import_config_helpers.py
+++ b/blueprints/import_config_helpers.py
@@ -32,6 +32,7 @@ that ``from blueprints.import_config_routes import ...`` and the
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -61,19 +62,56 @@ def _coerce_validation_response_payload(response):
 
 
 def _parse_csv_or_list_to_set(value):
-    """Coerce a comma-string or list into a stripped set of strings.
+    """Coerce a library-list value into a stripped set of name strings.
 
-    DRY refactor: pre-refactor this lived as an inner closure named
-    ``parse_list`` in THREE separate routes (import_config_preview,
-    import_config_preview_mapped, import_config_confirm) with byte-for-byte
-    identical 6-line bodies (18 lines of literal duplication).  Hoisted
-    to module scope and renamed for clarity.
+    Accepts four forms:
+    - Python list of dicts  (fresh validation response: ``[{"id": 10, "name": "Movies"}, ...]``)
+    - JSON string           (new format — library names may contain commas)
+    - CSV string            (legacy format — backward compat with old stored data)
+    - Python list of str    (already decoded)
     """
-    if isinstance(value, str):
-        return {v.strip() for v in value.split(",") if v.strip()}
     if isinstance(value, list):
+        if value and isinstance(value[0], dict):
+            return {str(v.get("name", "")).strip() for v in value if str(v.get("name", "")).strip()}
         return {str(v).strip() for v in value if str(v).strip()}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                if parsed and isinstance(parsed[0], dict):
+                    return {str(v.get("name", "")).strip() for v in parsed if str(v.get("name", "")).strip()}
+                return {str(v).strip() for v in parsed if str(v).strip()}
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return {v.strip() for v in value.split(",") if v.strip()}
     return set()
+
+
+def _plex_library_name_sets(plex_data):
+    """Return ``(movie_name_set, show_name_set)`` from stored Plex data.
+
+    Handles both the new ID-based format (where ``tmp_library_names`` holds the
+    ID→name dict) and the legacy format (where names are stored directly in
+    ``tmp_movie_libraries`` / ``tmp_show_libraries``).
+    """
+    name_map_raw = plex_data.get("tmp_library_names", "")
+    if name_map_raw:
+        try:
+            name_map = {str(k): str(v) for k, v in json.loads(name_map_raw).items()}
+        except (json.JSONDecodeError, ValueError):
+            name_map = {}
+        from modules.persistence import decode_library_ids
+
+        movie_ids = decode_library_ids(plex_data.get("tmp_movie_libraries", ""))
+        show_ids = decode_library_ids(plex_data.get("tmp_show_libraries", ""))
+        movie_names = {name_map[i] for i in movie_ids if i in name_map}
+        show_names = {name_map[i] for i in show_ids if i in name_map}
+        return movie_names, show_names
+    # Legacy: names stored directly
+    return (
+        _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", "")),
+        _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", "")),
+    )
 
 
 def _parse_base_plex_libraries(base_name: str):
@@ -95,10 +133,7 @@ def _parse_base_plex_libraries(base_name: str):
     plex_block = stored.get("plex") if isinstance(stored.get("plex"), dict) else stored
     if not isinstance(plex_block, dict):
         return set(), set()
-    return (
-        _parse_csv_or_list_to_set(plex_block.get("tmp_movie_libraries", "")),
-        _parse_csv_or_list_to_set(plex_block.get("tmp_show_libraries", "")),
-    )
+    return _plex_library_name_sets(plex_block)
 
 
 # --- credential parsers ---------------------------------------------------

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -50,6 +50,7 @@ from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tes
     _map_playlist_libraries,
     _parse_base_plex_libraries,
     _parse_csv_or_list_to_set,
+    _plex_library_name_sets,
     _parse_plex_credentials_from_base,
     _parse_plex_credentials_from_config,
     _parse_plex_credentials_from_form,
@@ -137,8 +138,7 @@ def import_config_preview():
     needs_plex = isinstance(parsed.get("libraries"), dict) and bool(parsed.get("libraries"))
     needs_tmdb = isinstance(parsed, dict) and bool(parsed.get("tmdb") or parsed.get("libraries") or parsed.get("collections") or parsed.get("overlays"))
     plex_data = persistence.retrieve_settings("010-plex").get("plex", {})
-    movie_names = _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", ""))
-    show_names = _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", ""))
+    movie_names, show_names = _plex_library_name_sets(plex_data)
     plex_libraries = {"movie": sorted(movie_names), "show": sorted(show_names)}
 
     if needs_plex:
@@ -591,8 +591,7 @@ def import_config_confirm():
                 show_names = plex_outcome.show_names
         else:
             plex_data = persistence.retrieve_settings("010-plex").get("plex", {})
-            movie_names = _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", ""))
-            show_names = _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", ""))
+            movie_names, show_names = _plex_library_name_sets(plex_data)
 
         if needs_tmdb:
             tmdb_error = validate_confirm_tmdb_credentials()

--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -114,29 +114,26 @@ def _build_library_lists():
     if not isinstance(telemetry_data, dict) or "plex_pass" not in telemetry_data:
         telemetry_data = telemetry.get("plex_telemetry", {})
 
-    movie_raw = plex_data.get("tmp_movie_libraries", "") if isinstance(plex_data.get("tmp_movie_libraries"), str) else ""
-    show_raw = plex_data.get("tmp_show_libraries", "") if isinstance(plex_data.get("tmp_show_libraries"), str) else ""
-
-    existing_ids = set()
+    lib_name_map = persistence.get_library_names("010-plex")
 
     movie_libraries = [
         {
-            "id": f"mov-library_{helpers.normalize_id(lib, existing_ids)}",
-            "name": lib,
+            "id": f"mov-library_{lib_id}",
+            "name": lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "movie",
         }
-        for lib in movie_raw.split(",")
-        if lib
+        for lib_id in persistence.decode_library_ids(plex_data.get("tmp_movie_libraries", ""))
+        if lib_id
     ]
 
     show_libraries = [
         {
-            "id": f"sho-library_{helpers.normalize_id(lib, existing_ids)}",
-            "name": lib,
+            "id": f"sho-library_{lib_id}",
+            "name": lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "show",
         }
-        for lib in show_raw.split(",")
-        if lib
+        for lib_id in persistence.decode_library_ids(plex_data.get("tmp_show_libraries", ""))
+        if lib_id
     ]
 
     return movie_libraries, show_libraries, telemetry_data

--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -112,6 +112,14 @@ def validate_plex():
     except Exception as e:
         helpers.ts_log(f"Failed to fetch Plex telemetry during validation: {e}", level="WARNING")
 
+    # Migrate existing library settings from name-based keys to Plex-ID keys.
+    all_libs = list(plex_data.get("movie_libraries") or []) + list(plex_data.get("show_libraries") or []) + list(plex_data.get("music_libraries") or [])
+    if config_name and all_libs and isinstance(all_libs[0], dict):
+        try:
+            persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
+        except Exception as e:
+            helpers.ts_log(f"Library key migration failed during validate_plex: {e}", level="WARNING")
+
     # Keep validator fields authoritative for the Plex page contract. Telemetry
     # uses display strings like "2048 MB", while the page's db_cache input needs
     # the numeric value returned by validate_plex_server.
@@ -147,6 +155,9 @@ def refresh_plex_libraries():
         cached_refresh = helpers.get_cached_plex_refresh(plex_url, plex_token)
         if cached_refresh:
             helpers.ts_log("Using cached Plex library refresh payload.", level="DEBUG")
+            all_libs = list(cached_refresh.get("movie_libraries") or []) + list(cached_refresh.get("show_libraries") or []) + list(cached_refresh.get("music_libraries") or [])
+            if all_libs and isinstance(all_libs[0], dict):
+                persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
             persistence.update_stored_plex_libraries(
                 "010-plex",
                 cached_refresh.get("movie_libraries", []),
@@ -187,7 +198,10 @@ def refresh_plex_libraries():
         if not plex_data.get("validated"):
             return jsonify({"valid": False, "error": "Plex validation failed"}), 500
 
-        # Update stored libraries
+        # Migrate existing settings from name-based keys to Plex-ID keys, then store.
+        all_libs = list(plex_data.get("movie_libraries") or []) + list(plex_data.get("show_libraries") or []) + list(plex_data.get("music_libraries") or [])
+        if all_libs and isinstance(all_libs[0], dict):
+            persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
         persistence.update_stored_plex_libraries(
             "010-plex",
             plex_data.get("movie_libraries", []),

--- a/modules/helpers/_constants.py
+++ b/modules/helpers/_constants.py
@@ -27,7 +27,7 @@ IMAGEMAID_GITHUB_BASE_URL = "https://raw.githubusercontent.com/Kometa-Team/Image
 ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "webp", "gif", "bmp"}
 FONT_EXTENSIONS = {".ttf", ".otf"}
 
-BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
 WORKING_DIR = os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else BASE_DIR
 MEIPASS_DIR = sys._MEIPASS if getattr(sys, "frozen", False) else BASE_DIR  # noqa
 

--- a/modules/helpers/_forms.py
+++ b/modules/helpers/_forms.py
@@ -54,7 +54,10 @@ def build_simple_dict(source, form_data):
         else:
             # Handle individual scalar values
             if value is not None and not isinstance(value, bool):
-                if final_key.endswith("_section"):
+                if final_key.endswith("-library") or final_key == "libraries":
+                    # Library display names from Plex — preserve exactly (leading/trailing spaces are significant)
+                    pass
+                elif final_key.endswith("_section"):
                     # Preserve as string to avoid stripping leading zeros
                     value = value.strip() if isinstance(value, str) else value
                 else:

--- a/modules/helpers/_plex.py
+++ b/modules/helpers/_plex.py
@@ -236,18 +236,27 @@ def get_plex_maintenance_hours(plex_url, plex_token):
         return None, None
 
 
-def get_library_summaries(configured_library_names):
+def get_library_summaries(configured_library_id_map):
+    """Build the per-library comment block for the config header.
+
+    ``configured_library_id_map`` is a ``{section_id_str: display_name}``
+    dict for the selected libraries, sorted by display name.  Each entry
+    is looked up in the Plex metadata by section ID (the canonical key),
+    so the lookup is unambiguous even when display names contain spaces
+    or clash after stripping.
+    """
     try:
         metadata = get_plex_metadata()
         lib_metadata = metadata.get("libraries", {})
 
         output_lines = []
-        for lib_name in configured_library_names:
-            info = lib_metadata.get(lib_name)
+        for lib_id, display_name in configured_library_id_map.items():
+            info = lib_metadata.get(str(lib_id))
             if not info:
-                output_lines.append(f"Library '{lib_name}' not found on Plex server.")
+                output_lines.append(f"Library '{display_name}' (ID {lib_id}) not found on Plex server.")
                 continue
 
+            lib_name = info.get("name", display_name)
             output_lines.append(f"Information on library: {lib_name}")
             output_lines.append(f"Type: {info.get('type', 'Unknown').capitalize()}")
             output_lines.append(f"Agent: {info.get('agent', 'Unknown')}")
@@ -366,8 +375,10 @@ def get_library_metadata(plex=None, sections=None, plex_url=None, plex_token=Non
             sections = plex.library.sections()
 
         for section in sections:
+            section_id = str(section.key)
             try:
                 lib_info = {
+                    "name": section.title,
                     "agent": section.agent,
                     "scanner": section.scanner,
                     "type": section.type,
@@ -399,10 +410,11 @@ def get_library_metadata(plex=None, sections=None, plex_url=None, plex_token=Non
                 except Exception as e:
                     lib_info["error"] = str(e)
 
-                library_data[section.title] = lib_info
+                library_data[section_id] = lib_info
 
             except Exception as lib_err:
-                library_data[section.title] = {
+                library_data[section_id] = {
+                    "name": section.title,
                     "agent": "Unknown",
                     "scanner": "Unknown",
                     "type": "Unknown",

--- a/modules/helpers/_vite_manifest.py
+++ b/modules/helpers/_vite_manifest.py
@@ -115,6 +115,37 @@ def reload_manifest() -> None:
         _manifest_cache = None
 
 
+def vite_dev_mode() -> bool:
+    """Return True when the Vite dev server should be used instead of built assets.
+
+    Set ``QS_VITE_DEV=1`` (or any truthy value) in the environment before
+    starting Flask, then run ``npm run dev`` in a second terminal.  The
+    browser will load JS directly from the Vite dev server and receive
+    HMR updates on every file save.
+    """
+    return os.getenv("QS_VITE_DEV", "0") not in ("0", "", "false", "False", "no")
+
+
+def vite_dev_origin() -> str:
+    """Return the Vite dev-server origin when ``QS_VITE_DEV`` is set.
+
+    Returns ``'http://<host>:<port>'`` so templates can build absolute URLs
+    for the Vite client script and module imports.  Returns an empty string
+    when not in dev mode so ``{% if vite_dev_origin() %}`` works cleanly.
+
+    Override defaults via env vars:
+      QS_VITE_DEV_HOST  host the *browser* uses to reach the Vite server
+                        (default: ``localhost``; set to the server's LAN IP
+                        when the browser is on a different machine)
+      QS_VITE_DEV_PORT  Vite dev-server port (default: ``5173``)
+    """
+    if not vite_dev_mode():
+        return ""
+    host = os.getenv("QS_VITE_DEV_HOST", "localhost")
+    port = int(os.getenv("QS_VITE_DEV_PORT", "5173"))
+    return f"http://{host}:{port}"
+
+
 def asset_url(name: str) -> str:
     """Return the URL path a template should use for JS entry ``name``.
 
@@ -124,19 +155,25 @@ def asset_url(name: str) -> str:
 
     Resolution order:
 
-    1. If the manifest is loaded and has an entry keyed
+    1. If ``QS_VITE_DEV`` is set, return the Vite dev-server URL
+       (``http://localhost:<port>/static/local-js/<name>.js``).  The Vite
+       dev server handles HMR; the browser updates on every file save
+       without a manual rebuild.
+    2. If the manifest is loaded and has an entry keyed
        ``static/local-js/<name>.js``, return ``/static/dist/<manifest['file']>``.
        This is the fast, hashed, cache-busted, minified path used in
        production.
-    2. Otherwise, return ``/static/local-js/<name>.js`` -- the raw
+    3. Otherwise, return ``/static/local-js/<name>.js`` -- the raw
        source file, still served by Flask via the ``static`` blueprint.
-       This is the dev-mode / source-checkout path and preserves the
+       This is the fallback path and preserves the
        ``python quickstart.py`` after a clone experience.
 
-    The returned string is always absolute (starts with ``/static/``) so
-    callers can drop it directly into ``<script src=...>`` without
-    ``url_for``.
+    The returned string is always absolute so callers can drop it
+    directly into ``<script src=...>`` without ``url_for``.
     """
+    origin = vite_dev_origin()
+    if origin:
+        return f"{origin}/static/local-js/{name}.js"
     manifest = _get_manifest()
     key = f"static/local-js/{name}.js"
     entry = manifest.get(key)
@@ -148,4 +185,4 @@ def asset_url(name: str) -> str:
     return f"/static/local-js/{name}.js"
 
 
-__all__ = ["asset_url", "reload_manifest"]
+__all__ = ["asset_url", "reload_manifest", "vite_dev_mode", "vite_dev_origin"]

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -442,7 +442,7 @@ def prepare_import_payload(
 
             plex_id = _name_to_plex_id.get(name) or _name_to_plex_id.get(resolved_name)
             lib_id = f"{lib_type}-library_{plex_id}" if plex_id else f"{lib_type}-library_{helpers.normalize_id(name, existing_ids)}"
-            libraries_data[f"{lib_id}-library"] = resolved_name
+            libraries_data[f"{lib_id}-library"] = "true"
             report.add("imported", f"libraries.{lib_name}.library")
             playlist_names_for_library = {name, resolved_name}
             matched_names = playlist_libraries.intersection(playlist_names_for_library)

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -5,7 +5,7 @@ from typing import Any
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
-from modules import helpers
+from modules import helpers, persistence
 
 # Language codes recognized as `weight_<code>` overlay-source ordering keys.
 # Hoisted out of prepare_import_payload's ~95-line nested comprehension --
@@ -393,6 +393,14 @@ def prepare_import_payload(
 
     importer_simple_sections.process_simple_sections(config_data, payload=payload, report=report)
 
+    # Build a name→Plex-ID reverse map from stored data so imported library
+    # keys use the real Plex section ID rather than a normalised name slug.
+    try:
+        _id_map = persistence.get_library_names()  # {plex_id_str: display_name}
+    except Exception:
+        _id_map = {}
+    _name_to_plex_id = {v: k for k, v in _id_map.items()}  # {display_name: plex_id_str}
+
     libraries_payload = config_data.get("libraries")
     if isinstance(libraries_payload, dict):
         libraries_data: dict[str, Any] = {}
@@ -432,7 +440,8 @@ def prepare_import_payload(
                     report.add("unmapped", f"libraries.{lib_name}", "Library type could not be determined.")
                     continue
 
-            lib_id = f"{lib_type}-library_{helpers.normalize_id(name, existing_ids)}"
+            plex_id = _name_to_plex_id.get(name) or _name_to_plex_id.get(resolved_name)
+            lib_id = f"{lib_type}-library_{plex_id}" if plex_id else f"{lib_type}-library_{helpers.normalize_id(name, existing_ids)}"
             libraries_data[f"{lib_id}-library"] = resolved_name
             report.add("imported", f"libraries.{lib_name}.library")
             playlist_names_for_library = {name, resolved_name}

--- a/modules/logscan_library_stats.py
+++ b/modules/logscan_library_stats.py
@@ -228,13 +228,21 @@ def normalize_library_name(value: object) -> str:
 def match_library_name(raw_name: str, library_entries: list[dict]) -> Optional[str]:
     """Find the config library-entry name that best matches *raw_name*.
 
-    * Exact normalized match wins.
+    * Exact string match wins first (preserves meaningful leading/trailing whitespace).
+    * Exact normalized match wins next.
     * Otherwise, the LONGEST substring match wins (both directions:
       ``needle in candidate`` and ``candidate in needle``).
 
     Returns the entry's ``name`` field, or ``None`` when nothing
     matches.
     """
+    # Exact match first — libraries whose names differ only in whitespace
+    # (e.g. "Movies" vs " Movies ") must not be conflated by normalization.
+    for entry in library_entries:
+        name = entry.get("name")
+        if name is not None and raw_name == name:
+            return name
+
     needle = normalize_library_name(raw_name)
     if not needle:
         return None

--- a/modules/logscan_progress.py
+++ b/modules/logscan_progress.py
@@ -59,12 +59,15 @@ def get_progress_run_order(config_data=None):
 
 
 def get_progress_library_list(selected_libraries=None, config_path=None, config_data=None, config_name=None):
+    import json as _json
     import quickstart
 
     library_settings = {}
+    plex_name_map = {}
     if has_request_context():
         settings = persistence.retrieve_settings("025-libraries")
         library_settings = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+        plex_name_map = persistence.get_library_names()
     elif config_name:
         try:
             _validated, _user_entered, stored = database.retrieve_section_data(config_name, "libraries")
@@ -77,6 +80,12 @@ def get_progress_library_list(selected_libraries=None, config_path=None, config_
                     library_settings = stored
         except Exception:
             library_settings = {}
+        try:
+            plex_settings = persistence.retrieve_settings_for_config(config_name, "010-plex")
+            raw = plex_settings.get("plex", {}).get("tmp_library_names", "")
+            plex_name_map = _json.loads(raw) if raw else {}
+        except Exception:
+            plex_name_map = {}
     libraries = []
     type_by_name = {}
     if isinstance(library_settings, dict):
@@ -84,9 +93,15 @@ def get_progress_library_list(selected_libraries=None, config_path=None, config_
             if not value:
                 continue
             if key.startswith("mov-library_") and key.endswith("-library"):
-                type_by_name[value] = "movie"
+                lib_id = helpers.extract_library_name(key)
+                display_name = plex_name_map.get(lib_id, "") if lib_id else ""
+                if display_name:
+                    type_by_name[display_name] = "movie"
             elif key.startswith("sho-library_") and key.endswith("-library"):
-                type_by_name[value] = "show"
+                lib_id = helpers.extract_library_name(key)
+                display_name = plex_name_map.get(lib_id, "") if lib_id else ""
+                if display_name:
+                    type_by_name[display_name] = "show"
     parsed = config_data if isinstance(config_data, dict) else quickstart._load_progress_config(config_path)
     if isinstance(parsed, dict):
         lib_section = parsed.get("libraries")
@@ -106,7 +121,13 @@ def get_progress_library_list(selected_libraries=None, config_path=None, config_
     return libraries
 
 
-def build_incomplete_progress_snapshot(progress=None, last_log_at=None, config_data=None, original_command="", config_name=None):
+def build_incomplete_progress_snapshot(
+    progress=None,
+    last_log_at=None,
+    config_data=None,
+    original_command="",
+    config_name=None,
+):
     progress = progress if isinstance(progress, dict) else {}
     libraries = progress.get("libraries") if isinstance(progress.get("libraries"), list) else []
     if not libraries:
@@ -148,14 +169,16 @@ def build_incomplete_progress_snapshot(progress=None, last_log_at=None, config_d
     ):
         if not isinstance(entry, dict):
             continue
-        name = str(entry.get("name") or "").strip()
+        name = str(entry.get("name") or "")
         lib_type = str(entry.get("type") or "").strip()
-        if name:
+        if name.strip():
             configured_type_by_name[name] = lib_type or None
     if isinstance(config_data, dict):
         config_libraries = config_data.get("libraries")
         if isinstance(config_libraries, dict):
-            configured_library_names = [str(name).strip() for name in config_libraries.keys() if str(name).strip()]
+            # Preserve names exactly as they appear in the YAML — leading/trailing
+            # whitespace is meaningful for libraries named e.g. " Movies ".
+            configured_library_names = [str(name) for name in config_libraries.keys() if str(name).strip()]
             configured_library_entries = [{"name": name, "type": configured_type_by_name.get(name)} for name in configured_library_names]
     elif configured_type_by_name:
         configured_library_names = list(configured_type_by_name.keys())
@@ -250,11 +273,12 @@ def build_incomplete_progress_snapshot(progress=None, last_log_at=None, config_d
         "current_library": current_library,
         "phase_current": current_phase,
         "last_log_at": last_log_at or "",
-        "preparation_label": format_duration_brief(preparation_seconds) if isinstance(preparation_seconds, (int, float)) else "",
+        "preparation_label": (format_duration_brief(preparation_seconds) if isinstance(preparation_seconds, (int, float)) else ""),
         "footer_cells": [
-            format_duration_brief(totals.get(column["key"])) if isinstance(totals.get(column["key"]), (int, float)) and totals.get(column["key"]) > 0 else "" for column in columns
+            (format_duration_brief(totals.get(column["key"])) if isinstance(totals.get(column["key"]), (int, float)) and totals.get(column["key"]) > 0 else "")
+            for column in columns
         ],
-        "total_label": format_duration_brief(total_seconds) if total_seconds > 0 else "",
+        "total_label": (format_duration_brief(total_seconds) if total_seconds > 0 else ""),
     }
 
 

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -597,7 +597,7 @@ def _inject_library_section_headers(yaml_string, font):
 
         # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
         if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and stripped.endswith(":") and not stripped.startswith("-"):
-            library_name = stripped.rstrip(":")
+            library_name = stripped.rstrip(":").strip("'\"")
             output.append(render_section_header(library_name, font))
         else:
             subheader_title = None

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -38,7 +38,12 @@ from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.scalarstring import PlainScalarString
 
 from modules import database, helpers
-from modules.output_collections import _LOOKUP_LABELS_SUFFIX, _normalize_settings_section_value, _TEMPLATE_VARIABLE_COMMENTS_KEY, _parse_template_lookup_labels
+from modules.output_collections import (
+    _LOOKUP_LABELS_SUFFIX,
+    _normalize_settings_section_value,
+    _TEMPLATE_VARIABLE_COMMENTS_KEY,
+    _parse_template_lookup_labels,
+)
 from modules.output_headers import render_section_header
 from modules.output_values import _normalize_asset_directory_values
 
@@ -338,7 +343,13 @@ def _apply_mal_trakt_int_coercions(cleaned_data, dump_name):
     _coerce_int_or_ignore(section, "cache_expiration")
 
 
-_TRAKT_PREFERRED_ORDER = ("authorization", "client_id", "client_secret", "pin", "force_refresh")
+_TRAKT_PREFERRED_ORDER = (
+    "authorization",
+    "client_id",
+    "client_secret",
+    "pin",
+    "force_refresh",
+)
 
 
 def _apply_trakt_reorder(cleaned_data):
@@ -597,7 +608,13 @@ def _inject_library_section_headers(yaml_string, font):
 
         # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
         if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and stripped.endswith(":") and not stripped.startswith("-"):
-            library_name = stripped.rstrip(":").strip("'\"")
+            key_str = stripped.rstrip(":")
+            # Strip only the outermost matching YAML quote pair, not all quotes.
+            # A name like `" Movies "` is serialised as `'" Movies "'` — the inner
+            # `"` chars are part of the name and must be kept.
+            if len(key_str) >= 2 and key_str[0] == key_str[-1] and key_str[0] in ("'", '"'):
+                key_str = key_str[1:-1]
+            library_name = key_str
             output.append(render_section_header(library_name, font))
         else:
             subheader_title = None

--- a/modules/output_libraries_data.py
+++ b/modules/output_libraries_data.py
@@ -159,6 +159,16 @@ def extract_libraries_bundle(nested_libraries_data, *, debug=False):
     movie_libraries = _select_libraries(nested_libraries_data, "mov-library_")
     show_libraries = _select_libraries(nested_libraries_data, "sho-library_")
 
+    # Authoritative display names from Plex (id_str → name with spaces preserved).
+    # Stored `-library` values may have been stripped; prefer the name map when the
+    # key contains a numeric section ID (i.e. after the ID-based migration has run).
+    from modules import persistence  # local import to avoid load-order cycle
+
+    plex_name_map = persistence.get_library_names()
+    if plex_name_map:
+        movie_libraries = {k: plex_name_map.get(helpers.extract_library_name(k), v) for k, v in movie_libraries.items()}
+        show_libraries = {k: plex_name_map.get(helpers.extract_library_name(k), v) for k, v in show_libraries.items()}
+
     movie_library_names = {helpers.extract_library_name(k) for k in movie_libraries}
     show_library_names = {helpers.extract_library_name(k) for k in show_libraries}
 

--- a/modules/output_yaml_header.py
+++ b/modules/output_yaml_header.py
@@ -120,16 +120,22 @@ def _render_kometa_ascii_art(header_style):
     return add_border_to_ascii_art(heading)
 
 
-def _sorted_library_display_names(libraries):
-    """Return ``libraries.values()`` sorted case-insensitively.
+def _sorted_library_id_map(libraries):
+    """Return an ordered ``{section_id_str: display_name}`` dict, sorted by display name.
 
-    Empty / whitespace-only names are dropped.  ``libraries`` is the
-    ``{key: display_name}`` dict shape used throughout ``build_config``.
+    ``libraries`` is the ``{persistence_key: display_name}`` dict used throughout
+    ``build_config``; the section ID is the segment extracted from the key by
+    :func:`helpers.extract_library_name`.  Entries with blank display names are
+    dropped.
     """
-    return sorted(
-        (str(name) for name in libraries.values() if str(name).strip()),
-        key=lambda value: value.strip().casefold(),
-    )
+    pairs = []
+    for key, name in libraries.items():
+        lib_id = helpers.extract_library_name(key)
+        name_str = str(name)
+        if lib_id and name_str.strip():
+            pairs.append((lib_id, name_str))
+    pairs.sort(key=lambda pair: pair[1].strip().casefold())
+    return dict(pairs)
 
 
 def _get_kometa_schema_header(kometa_branch):
@@ -176,8 +182,11 @@ def render_yaml_header(header_style, config_name, movie_libraries, show_librarie
     qs_settings_lines = helpers.get_quickstart_settings_summary()
     qs_settings_block = "\n".join(qs_settings_lines) if qs_settings_lines else ""
 
-    library_names = _sorted_library_display_names(movie_libraries) + _sorted_library_display_names(show_libraries)
-    library_details = helpers.get_library_summaries(library_names)
+    library_id_map = {
+        **_sorted_library_id_map(movie_libraries),
+        **_sorted_library_id_map(show_libraries),
+    }
+    library_details = helpers.get_library_summaries(library_id_map)
 
     schema_header = _get_kometa_schema_header(kometa_branch)
     ascii_heading = _render_kometa_ascii_art(header_style)

--- a/modules/output_yaml_header.py
+++ b/modules/output_yaml_header.py
@@ -127,8 +127,8 @@ def _sorted_library_display_names(libraries):
     ``{key: display_name}`` dict shape used throughout ``build_config``.
     """
     return sorted(
-        (str(name).strip() for name in libraries.values() if str(name).strip()),
-        key=lambda value: value.casefold(),
+        (str(name) for name in libraries.values() if str(name).strip()),
+        key=lambda value: value.strip().casefold(),
     )
 
 

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -198,6 +198,9 @@ def clean_form_data(form_data):
                 clean_data[key] = True
             elif lc_value == "false":
                 clean_data[key] = False
+            elif key.endswith("-library"):
+                # Library display names from Plex — preserve exactly (leading/trailing spaces are significant)
+                clean_data[key] = value
             else:
                 clean_data[key] = value.strip()
 
@@ -454,8 +457,122 @@ def get_stored_plex_credentials(name):
     return None, None
 
 
+def decode_library_ids(value):
+    """Decode a stored library-ID list into a list of string IDs.
+
+    Handles three forms:
+    - Already a list of dicts  → extract 'id' field from each
+    - Already a list           → returned as-is (strings or ints → coerced to str)
+    - CSV string of integers   → split on comma (current format)
+    - JSON string              → parsed; if it's a list of dicts, extract 'id'
+    - Legacy JSON of names     → returned as-is (old pre-ID format; callers
+                                 should detect non-integer items and treat as names)
+    """
+    if isinstance(value, list):
+        if value and isinstance(value[0], dict):
+            return [str(item["id"]) for item in value if "id" in item]
+        return [str(v) for v in value if v or v == 0]
+    if not isinstance(value, str) or not value:
+        return []
+    try:
+        result = json.loads(value)
+        if isinstance(result, list):
+            if result and isinstance(result[0], dict):
+                return [str(item["id"]) for item in result if "id" in item]
+            return [str(v) for v in result if v or v == 0]
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return [v for v in value.split(",") if v]
+
+
+def get_library_names(config_name="010-plex"):
+    """Return the stored Plex section-ID → display-name mapping.
+
+    Returns a dict like ``{"10": " Movies L", "3": "TV Shows"}``.
+    Keys are string-coerced Plex section IDs.  Returns an empty dict
+    when no mapping has been stored yet (fresh install, pre-validation).
+    """
+    plex_data = retrieve_settings(config_name).get("plex", {})
+    raw = plex_data.get("tmp_library_names", "")
+    if not raw:
+        return {}
+    try:
+        result = json.loads(raw)
+        if isinstance(result, dict):
+            return {str(k): v for k, v in result.items()}
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return {}
+
+
+def migrate_library_keys_to_plex_ids(config_name, all_plex_libraries):
+    """Rekey existing settings from normalised-name keys to Plex section-ID keys.
+
+    Runs once at Plex validation time.  ``all_plex_libraries`` is a flat list
+    of ``{"id": int, "name": str}`` dicts covering all library types.
+
+    Returns the number of keys that were renamed (0 = already migrated or
+    no matching keys found).
+    """
+    from modules.helpers._misc import normalize_id, extract_library_name  # local import to avoid circularity
+
+    # Build normalised-name → Plex-ID lookup using the same dedup logic that
+    # originally created the keys.
+    existing_ids: set = set()
+    norm_to_plex_id: dict = {}
+    for lib in all_plex_libraries:
+        norm = normalize_id(lib["name"].strip(), existing_ids)
+        norm_to_plex_id[norm] = str(lib["id"])
+
+    settings = retrieve_settings(config_name)
+    libraries = settings.get("libraries", {})
+    if not libraries:
+        return 0
+
+    # Short-circuit: if every library key already uses a numeric ID, skip.
+    def _id_is_numeric(key):
+        lib_id = extract_library_name(key)
+        return lib_id is not None and lib_id.lstrip("-").isdigit()
+
+    keyed_keys = [k for k in libraries if extract_library_name(k) is not None]
+    if keyed_keys and all(_id_is_numeric(k) for k in keyed_keys):
+        return 0
+
+    new_libraries = {}
+    rename_count = 0
+    for key, value in libraries.items():
+        lib_id = extract_library_name(key)
+        if lib_id and lib_id in norm_to_plex_id:
+            new_key = key.replace(f"library_{lib_id}-", f"library_{norm_to_plex_id[lib_id]}-", 1)
+            new_libraries[new_key] = value
+            rename_count += 1
+        else:
+            new_libraries[key] = value
+
+    if rename_count > 0:
+        try:
+            database.save_section_data(
+                name=config_name,
+                section="libraries",
+                validated=True,
+                user_entered=False,
+                data={"libraries": new_libraries},
+            )
+        except Exception as e:
+            helpers.ts_log(f"Library key migration failed: {e}", level="WARNING")
+            return 0
+
+    return rename_count
+
+
 def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_libraries, user_list=None):
-    """Update stored Plex cache fields in the database and preserve `validated`."""
+    """Update stored Plex cache fields in the database and preserve `validated`.
+
+    ``movie_libraries``, ``show_libraries``, and ``music_libraries`` are lists
+    of ``{"id": int|str, "name": str}`` dicts as returned by the Plex validation
+    endpoint.  IDs are stored as a simple comma-separated list of integers;
+    the display-name lookup is stored as a JSON dict keyed by string ID.
+    """
     try:
         # Fetch existing settings from DB before updating
         settings_before = retrieve_settings(name)
@@ -469,10 +586,23 @@ def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_li
         validated_before = settings_before.get("validated", True)
         validated_at_before = settings_before.get("validated_at")
 
-        # Update library data
-        settings_before["plex"]["tmp_movie_libraries"] = ",".join(movie_libraries) if movie_libraries else ""
-        settings_before["plex"]["tmp_show_libraries"] = ",".join(show_libraries) if show_libraries else ""
-        settings_before["plex"]["tmp_music_libraries"] = ",".join(music_libraries) if music_libraries else ""
+        # Store library IDs as simple CSV (integers — no encoding issues).
+        # Store the name lookup as a JSON dict so display names are preserved
+        # exactly as Plex provides them (leading spaces, commas, etc. all safe).
+        # Accept both new format ({id, name} dicts) and legacy format (name strings).
+        def _lib_id(lib):
+            return lib["id"] if isinstance(lib, dict) else lib
+
+        def _lib_name(lib):
+            return lib["name"] if isinstance(lib, dict) else str(lib)
+
+        all_libs = list(movie_libraries) + list(show_libraries) + list(music_libraries)
+        name_lookup = {str(_lib_id(lib)): _lib_name(lib) for lib in all_libs}
+
+        settings_before["plex"]["tmp_movie_libraries"] = ",".join(str(_lib_id(lib)) for lib in movie_libraries)
+        settings_before["plex"]["tmp_show_libraries"] = ",".join(str(_lib_id(lib)) for lib in show_libraries)
+        settings_before["plex"]["tmp_music_libraries"] = ",".join(str(_lib_id(lib)) for lib in music_libraries)
+        settings_before["plex"]["tmp_library_names"] = json.dumps(name_lookup)
         if user_list is not None:
             cleaned_users = [str(user).strip() for user in user_list if str(user).strip()]
             settings_before["plex"]["tmp_user_list"] = ",".join(cleaned_users)

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -524,7 +524,7 @@ def migrate_library_keys_to_plex_ids(config_name, all_plex_libraries):
         norm = normalize_id(lib["name"].strip(), existing_ids)
         norm_to_plex_id[norm] = str(lib["id"])
 
-    settings = retrieve_settings(config_name)
+    settings = retrieve_settings("025-libraries")
     libraries = settings.get("libraries", {})
     if not libraries:
         return 0

--- a/modules/validations_services.py
+++ b/modules/validations_services.py
@@ -121,13 +121,13 @@ def validate_plex_server(data):
 
         # Retrieve library sections once. This can be expensive on large Plex servers.
         sections = plex.library.sections()
-        music_libraries = [section.title for section in sections if section.type == "artist"]
-        movie_libraries = [section.title for section in sections if section.type == "movie"]
-        show_libraries = [section.title for section in sections if section.type == "show"]
+        music_libraries = [{"id": section.key, "name": section.title} for section in sections if section.type == "artist"]
+        movie_libraries = [{"id": section.key, "name": section.title} for section in sections if section.type == "movie"]
+        show_libraries = [{"id": section.key, "name": section.title} for section in sections if section.type == "show"]
 
-        helpers.ts_log(f"Music libraries: {music_libraries}", level="INFO")
-        helpers.ts_log(f"Movie libraries: {movie_libraries}", level="INFO")
-        helpers.ts_log(f"Show libraries: {show_libraries}", level="INFO")
+        helpers.ts_log(f"Music libraries: {[lib['name'] for lib in music_libraries]}", level="INFO")
+        helpers.ts_log(f"Movie libraries: {[lib['name'] for lib in movie_libraries]}", level="INFO")
+        helpers.ts_log(f"Show libraries: {[lib['name'] for lib in show_libraries]}", level="INFO")
 
     except Exception as e:
         helpers.ts_log(f"Error validating Plex server: {str(e)}", level="ERROR")

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,28 @@
   "packages": {
     "": {
       "name": "quickstart-js-tooling",
+      "dependencies": {
+        "opencode-omniroute-auth": "^1.2.2"
+      },
       "devDependencies": {
         "esbuild": "0.28.1",
         "eslint": "^9.30.0",
         "jsdom": "29.1.1",
         "vite": "8.1.0",
         "vitest": "4.1.9"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -928,6 +944,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -945,6 +1045,45 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.8.tgz",
+      "integrity": "sha512-ADO2XvuStRHWSXOhFYnDrM1ZOjcSokh5/6atp9xtgVZWic/UdW6BSXgJkOGB3Ud9+S0rEmYxTCRTH/7Mt4OSDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.8",
+        "effect": "4.0.0-beta.83",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.8.tgz",
+      "integrity": "sha512-8vi5UBKFFgc+fnyKhZhGUxiIWMtUuN00VAInnK9JO6g6EC8WvWefP+ccTBQD023zod69JaEoAzGgO8hdxXHUaw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "7.0.6"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1225,7 +1364,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1560,7 +1698,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1635,10 +1772,29 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/entities": {
@@ -1890,6 +2046,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1941,6 +2120,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2081,6 +2267,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2115,7 +2311,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-yaml": {
@@ -2189,6 +2384,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2212,6 +2414,13 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2558,6 +2767,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -2584,6 +2833,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -2596,6 +2861,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/opencode-omniroute-auth": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/opencode-omniroute-auth/-/opencode-omniroute-auth-1.2.2.tgz",
+      "integrity": "sha512-lq9fLHrbwnIB+c8xq+j4P2qbpt0G8Qpejb5MQM8G5x9Mfk59jZ3U4hdkBQkYtFLT0AxmyJ539HA6SQWQ4UIRQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": "*"
       }
     },
     "node_modules/optionator": {
@@ -2688,7 +2965,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2770,6 +3046,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2841,7 +3134,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2854,7 +3146,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2988,6 +3279,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -3053,6 +3354,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3275,7 +3590,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3331,6 +3645,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -3342,6 +3672,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "jsdom": "29.1.1",
     "vite": "8.1.0",
     "vitest": "4.1.9"
+  },
+  "dependencies": {
+    "opencode-omniroute-auth": "^1.2.2"
   }
 }

--- a/quickstart.py
+++ b/quickstart.py
@@ -2278,6 +2278,9 @@ def step(name):
             refresh_plex_libraries()
             all_libraries = persistence.retrieve_settings("010-plex")
             plex_data = all_libraries.get("plex", {})
+            if name == "025-libraries":
+                # Re-read after migration may have renamed old name-based keys to ID-based keys.
+                data = persistence.retrieve_settings(name)
 
     telemetry_payload = {}
     try:

--- a/quickstart.py
+++ b/quickstart.py
@@ -1131,6 +1131,17 @@ app = Flask(__name__)
 # so ``python quickstart.py`` after a fresh clone still works.
 # Roadmap #1334 Step 4 activation. See modules/helpers/_vite_manifest.py.
 app.jinja_env.globals["asset_url"] = helpers.asset_url
+app.jinja_env.globals["vite_dev_origin"] = helpers.vite_dev_origin
+
+
+def _nbsp_leading_spaces(s: str) -> str:
+    """Replace leading ASCII spaces with EM SPACE (U+2003) for visible indentation in native dropdowns."""
+    s = str(s)
+    stripped = s.lstrip(" ")
+    return " " * (len(s) - len(stripped)) + stripped
+
+
+app.jinja_env.filters["nbsp_leading_spaces"] = _nbsp_leading_spaces
 
 app.register_blueprint(validation_routes_bp)
 app.register_blueprint(asset_routes_bp)
@@ -2299,48 +2310,33 @@ def step(name):
 
     page_info["telemetry"] = telemetry_data
 
-    # Extract the movie and show libraries
+    # Extract the movie and show libraries by Plex section ID with display-name lookup.
+    _lib_name_map = persistence.get_library_names("010-plex")
     movie_libraries_raw = plex_data.get("tmp_movie_libraries", "")
     show_libraries_raw = plex_data.get("tmp_show_libraries", "")
 
-    # Debugging extracted values
     if app.config["QS_DEBUG"]:
         helpers.ts_log("Extracted movie libraries:", movie_libraries_raw, level="DEBUG")
         helpers.ts_log("Extracted show libraries:", show_libraries_raw, level="DEBUG")
 
-    # Ensure it's a string before splitting
-    if not isinstance(movie_libraries_raw, str):
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("tmp_movie_libraries is not a string!", level="ERROR")
-
-        movie_libraries_raw = ""
-
-    if not isinstance(show_libraries_raw, str):
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("tmp_show_libraries is not a string!", level="ERROR")
-
-        show_libraries_raw = ""
-
-    existing_ids = set()  # Track used IDs to prevent duplicates
-
     movie_libraries = [
         {
-            "id": f"mov-library_{helpers.normalize_id(lib.strip(), existing_ids)}",
-            "name": lib.strip(),
+            "id": f"mov-library_{lib_id}",
+            "name": _lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "movie",
         }
-        for lib in movie_libraries_raw.split(",")
-        if lib.strip()
+        for lib_id in persistence.decode_library_ids(movie_libraries_raw)
+        if lib_id
     ]
 
     show_libraries = [
         {
-            "id": f"sho-library_{helpers.normalize_id(lib.strip(), existing_ids)}",
-            "name": lib.strip(),
+            "id": f"sho-library_{lib_id}",
+            "name": _lib_name_map.get(str(lib_id), f"Library {lib_id}"),
             "type": "show",
         }
-        for lib in show_libraries_raw.split(",")
-        if lib.strip()
+        for lib_id in persistence.decode_library_ids(show_libraries_raw)
+        if lib_id
     ]
 
     # Ensure `libraries` dictionary exists
@@ -2379,9 +2375,10 @@ def step(name):
         data["sho-template_variables"] = {}
 
     # Ensure these are lists
-    plex_data["tmp_movie_libraries"] = plex_data.get("tmp_movie_libraries", "").split(",") if isinstance(plex_data.get("tmp_movie_libraries"), str) else []
-    plex_data["tmp_show_libraries"] = plex_data.get("tmp_show_libraries", "").split(",") if isinstance(plex_data.get("tmp_show_libraries"), str) else []
-    plex_data["tmp_music_libraries"] = plex_data.get("tmp_music_libraries", "").split(",") if isinstance(plex_data.get("tmp_music_libraries"), str) else []
+    plex_data["tmp_movie_libraries"] = persistence.decode_library_ids(plex_data.get("tmp_movie_libraries", ""))
+    plex_data["tmp_show_libraries"] = persistence.decode_library_ids(plex_data.get("tmp_show_libraries", ""))
+    plex_data["tmp_music_libraries"] = persistence.decode_library_ids(plex_data.get("tmp_music_libraries", ""))
+    plex_data["tmp_library_names"] = persistence.get_library_names("010-plex")
     plex_data["tmp_user_list"] = plex_data.get("tmp_user_list", "").split(",") if isinstance(plex_data.get("tmp_user_list"), str) else []
 
     # Ensure correct rendering for the Kometa page
@@ -2571,7 +2568,6 @@ def step(name):
         movie_libraries = []
         show_libraries = []
         library_dropdown = []
-        existing_ids = set()
 
         for key, value in library_settings.items():
             if key.startswith("mov-library_") and key.endswith("-library"):

--- a/quickstart.py
+++ b/quickstart.py
@@ -61,8 +61,16 @@ from werkzeug.datastructures import MultiDict
 
 from werkzeug.wrappers import Request
 from flask_session import Session
-from modules import validations, output, persistence, helpers, database, logscan, path_validation, url_validation
-from modules import importer  # noqa: F401 (load-bearing: tests do monkeypatch.setattr(qs_module.importer, ...))
+from modules import (
+    validations,
+    output,
+    persistence,
+    helpers,
+    database,
+    logscan,
+    path_validation,
+    url_validation,
+)
 from modules.dependency_reasons import (  # noqa: F401 (re-exports for tests/legacy in-module callers)
     QS_ANIDB_DEP_SOURCE_PREFIXES,
     QS_ANIDB_OVERLAY_IMAGE_VALUES,
@@ -192,7 +200,10 @@ from modules.background_jobs import (
     ensure_background_job as _ensure_background_job,
     complete_background_job as _complete_background_job,  # noqa: F401 (used directly by tests as qs_module._complete_background_job)
 )
-from blueprints.validation_routes import bp as validation_routes_bp, refresh_plex_libraries
+from blueprints.validation_routes import (
+    bp as validation_routes_bp,
+    refresh_plex_libraries,
+)
 from blueprints.asset_routes import bp as asset_routes_bp
 from blueprints.kometa_updates import bp as kometa_updates_bp
 from blueprints.imagemaid_updates import bp as imagemaid_updates_bp
@@ -232,7 +243,10 @@ from blueprints.imagemaid_routes import (  # noqa: F401 (re-exports for tests/le
     stop_imagemaid,
     validate_imagemaid,
 )
-from modules.assets import build_preview_image_data as _build_preview_image_data, list_overlay_fonts
+from modules.assets import (
+    build_preview_image_data as _build_preview_image_data,
+    list_overlay_fonts,
+)
 from modules.bundle_artifacts import dump_yaml_text as _dump_yaml_text
 from modules.tmdb_lookup import (
     get_active_tmdb_api_key as _get_active_tmdb_api_key,
@@ -429,8 +443,18 @@ ACTIVE_WORK_POLICIES = {
 }
 LOG_STATS_CACHE = {"mtime": None, "size": None, "stats": None}
 LOGSCAN_ANALYSIS_CACHE_VERSION = 3
-LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "version": LOGSCAN_ANALYSIS_CACHE_VERSION, "data": None}
-LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "aux_signature": None, "data": None}
+LOGSCAN_ANALYSIS_CACHE = {
+    "mtime": None,
+    "size": None,
+    "version": LOGSCAN_ANALYSIS_CACHE_VERSION,
+    "data": None,
+}
+LOGSCAN_PROGRESS_CACHE = {
+    "mtime": None,
+    "size": None,
+    "aux_signature": None,
+    "data": None,
+}
 
 VALIDATION_DOC_BASE = "/step/"
 VALIDATION_DOC_FALLBACK = "/step/900-kometa"
@@ -538,7 +562,10 @@ def _get_active_work_blocker(subject):
         elif kind == "process":
             process_lookup = {
                 "kometa_run": (helpers.is_kometa_running, helpers.get_kometa_pid),
-                "imagemaid_run": (helpers.is_imagemaid_running, helpers.get_imagemaid_pid),
+                "imagemaid_run": (
+                    helpers.is_imagemaid_running,
+                    helpers.get_imagemaid_pid,
+                ),
             }
             resolver = process_lookup.get(identifier)
             if resolver:
@@ -614,7 +641,16 @@ LIBRARY_SONARR_BOOL_FIELDS = {
     "monitor_existing",
     "ignore_cache",
 }
-LIBRARY_SONARR_MONITOR_VALUES = {"all", "none", "future", "missing", "existing", "pilot", "first", "latest"}
+LIBRARY_SONARR_MONITOR_VALUES = {
+    "all",
+    "none",
+    "future",
+    "missing",
+    "existing",
+    "pilot",
+    "first",
+    "latest",
+}
 LIBRARY_SONARR_SERIES_TYPE_VALUES = {"standard", "daily", "anime"}
 
 
@@ -859,7 +895,13 @@ def _validate_library_service_overrides(library_id, libraries_data, force_valida
 
     overrides = _extract_library_service_overrides(libraries_data, library_id, service_name)
     if not overrides and not force_validate:
-        return {"valid": True, "skipped": True, "service": service_name, "overrides": {}, "errors": []}
+        return {
+            "valid": True,
+            "skipped": True,
+            "service": service_name,
+            "overrides": {},
+            "errors": [],
+        }
 
     settings = persistence.retrieve_settings(definition["template_key"]) or {}
     global_section = settings.get(definition["section_name"], {}) if isinstance(settings, dict) else {}
@@ -944,7 +986,10 @@ def _validate_library_service_overrides(library_id, libraries_data, force_valida
 def _validate_and_organize_library_file_request(kind, data, type_key, location_key):
     validator_info = LIBRARY_FILE_VALIDATORS.get(kind)
     if not validator_info:
-        return jsonify({"valid": False, "error": f"Unsupported library file kind: {kind}"}), 400
+        return (
+            jsonify({"valid": False, "error": f"Unsupported library file kind: {kind}"}),
+            400,
+        )
 
     _payload_type_key, _payload_location_key, validator = validator_info
     valid, message, details = validations._normalize_metadata_validation_result(validator(data))
@@ -953,7 +998,7 @@ def _validate_and_organize_library_file_request(kind, data, type_key, location_k
         if details.get("message") or isinstance(details.get("files"), list):
             payload["error_details"] = {
                 "text": details.get("message") or message,
-                "files": details.get("files") if isinstance(details.get("files"), list) else [],
+                "files": (details.get("files") if isinstance(details.get("files"), list) else []),
             }
         if isinstance(details.get("files"), list):
             payload["files"] = details["files"]
@@ -1079,7 +1124,12 @@ def _library_save_prefix_from_key(key):
         return prefix
     if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
         return None
-    for suffix in ("-playlist", "-collection_files", "-metadata_files", "-overlay_files"):
+    for suffix in (
+        "-playlist",
+        "-collection_files",
+        "-metadata_files",
+        "-overlay_files",
+    ):
         if key.endswith(suffix):
             return key[: -len(suffix)]
     return None
@@ -1362,7 +1412,10 @@ def before_request():
 
     # Log request size if applicable
     if request.content_length:
-        helpers.ts_log(f"Incoming request size: {request.content_length / 1024:.2f} KB", level="DEBUG")
+        helpers.ts_log(
+            f"Incoming request size: {request.content_length / 1024:.2f} KB",
+            level="DEBUG",
+        )
 
     # Only applies to form-encoded POSTs
     if request.method == "POST" and (request.content_type or "").startswith("application/x-www-form-urlencoded"):
@@ -1447,7 +1500,10 @@ shutdown_event = threading.Event()
 helpers.ensure_json_schema()
 sanitized_section_count = database.sanitize_all_section_data()
 if sanitized_section_count:
-    helpers.ts_log(f"Sanitized transient config-manager fields from {sanitized_section_count} persisted section(s).", level="INFO")
+    helpers.ts_log(
+        f"Sanitized transient config-manager fields from {sanitized_section_count} persisted section(s).",
+        level="INFO",
+    )
 
 parser = argparse.ArgumentParser(description="Run Quickstart Flask App")
 parser.add_argument("--port", type=int, help="Specify the port number to run the server")
@@ -1463,7 +1519,10 @@ running_port = port
 app.config["QS_PORT"] = running_port
 debug_mode = args.debug if args.debug else helpers.booler(os.getenv("QS_DEBUG", "0"))
 
-helpers.ts_log(f"Running on port: {port} | Debug Mode: {'Enabled' if debug_mode else 'Disabled'}", level="INFO")
+helpers.ts_log(
+    f"Running on port: {port} | Debug Mode: {'Enabled' if debug_mode else 'Disabled'}",
+    level="INFO",
+)
 
 
 @app.route("/")
@@ -1596,7 +1655,14 @@ def _match_logscan_run_to_file(run_record, context=None, log_dir=None, allow_liv
             rank += 2
         if mtime_matches:
             rank += 2
-        candidates.append((rank, mtime_delta if mtime_delta is not None else 999999, -entry.get("mtime", 0), entry))
+        candidates.append(
+            (
+                rank,
+                mtime_delta if mtime_delta is not None else 999999,
+                -entry.get("mtime", 0),
+                entry,
+            )
+        )
     if not candidates:
         return None
     candidates.sort()
@@ -1735,9 +1801,23 @@ def _delete_logscan_run_artifact(run_key):
     target_run = run_record if run_record else incomplete_run
     info = _resolve_logscan_run_log_info(run_key, run_record=target_run)
     if not info or not info.get("path"):
-        return False, {"error": "Archived log file for this run could not be found.", "run_key": run_key}, 404
+        return (
+            False,
+            {
+                "error": "Archived log file for this run could not be found.",
+                "run_key": run_key,
+            },
+            404,
+        )
     if info.get("location") != "archive":
-        return False, {"error": "Only archived logs can be deleted from Analytics.", "run_key": run_key}, 409
+        return (
+            False,
+            {
+                "error": "Only archived logs can be deleted from Analytics.",
+                "run_key": run_key,
+            },
+            409,
+        )
     deleted_file = False
     try:
         Path(info["path"]).unlink()
@@ -1745,7 +1825,11 @@ def _delete_logscan_run_artifact(run_key):
     except FileNotFoundError:
         deleted_file = False
     except Exception as exc:
-        return False, {"error": f"Failed to delete archived log: {exc}", "run_key": run_key}, 500
+        return (
+            False,
+            {"error": f"Failed to delete archived log: {exc}", "run_key": run_key},
+            500,
+        )
 
     if run_record:
         database.delete_log_run(run_key)
@@ -1773,18 +1857,40 @@ def _compress_logscan_run_artifact(run_key):
     target_run = run_record if run_record else incomplete_run
     info = _resolve_logscan_run_archive_action_info(run_key, prefer_uncompressed=True) or _resolve_logscan_run_log_info(run_key, run_record=target_run)
     if not info or not info.get("path"):
-        return False, {"error": "Archived log file for this run could not be found.", "run_key": run_key}, 404
+        return (
+            False,
+            {
+                "error": "Archived log file for this run could not be found.",
+                "run_key": run_key,
+            },
+            404,
+        )
     source_path = Path(info["path"])
     if info.get("location") != "archive":
-        return False, {"error": "Only archived logs can be compressed from Analytics.", "run_key": run_key}, 409
+        return (
+            False,
+            {
+                "error": "Only archived logs can be compressed from Analytics.",
+                "run_key": run_key,
+            },
+            409,
+        )
     if _is_logscan_gzip_path(source_path):
-        return False, {"error": "Archived log is already compressed.", "run_key": run_key}, 409
+        return (
+            False,
+            {"error": "Archived log is already compressed.", "run_key": run_key},
+            409,
+        )
 
     tool_name = _normalize_logscan_tool_name((target_run or {}).get("tool_name") or _detect_logscan_tool_from_path(source_path))
     archive_dir = _get_logscan_archive_dir(tool_name)
     compressed_path = _archive_log_file(source_path, archive_dir)
     if not compressed_path or not compressed_path.exists():
-        return False, {"error": "Failed to compress archived log.", "run_key": run_key}, 500
+        return (
+            False,
+            {"error": "Failed to compress archived log.", "run_key": run_key},
+            500,
+        )
 
     cache = _load_logscan_ingest_cache()
     cache_logs = cache.get("logs", {}) if isinstance(cache, dict) else {}
@@ -1913,7 +2019,13 @@ def logscan_trends_log_invalid_delete():
     for entry in invalid_entries:
         raw_path = entry.get("path")
         if not raw_path:
-            failures.append({"error": "Invalid archived log path missing.", "name": entry.get("name"), "status": 500})
+            failures.append(
+                {
+                    "error": "Invalid archived log path missing.",
+                    "name": entry.get("name"),
+                    "status": 500,
+                }
+            )
             continue
         path = Path(raw_path)
         deleted_file = False
@@ -1923,7 +2035,14 @@ def logscan_trends_log_invalid_delete():
         except FileNotFoundError:
             deleted_file = False
         except Exception as exc:
-            failures.append({"error": f"Failed to delete invalid archived log: {exc}", "name": entry.get("name"), "path": raw_path, "status": 500})
+            failures.append(
+                {
+                    "error": f"Failed to delete invalid archived log: {exc}",
+                    "name": entry.get("name"),
+                    "path": raw_path,
+                    "status": 500,
+                }
+            )
             continue
         _remove_logscan_ingest_cache_entries(raw_path=str(path.resolve()))
         deleted.append(
@@ -2201,7 +2320,10 @@ def step(name):
         item = template_list[num]
     except (ValueError, IndexError, KeyError):
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Invalid step name '{name}' (stem={stem}, num={num}, b={b}).", level="ERROR")
+            helpers.ts_log(
+                f"Invalid step name '{name}' (stem={stem}, num={num}, b={b}).",
+                level="ERROR",
+            )
         return abort(404)
 
     if num in progress_keys and total_steps:
@@ -2277,7 +2399,10 @@ def step(name):
     if should_refresh_plex:
         if all_libraries.get("validated") or settings_needs_user_refresh:
             if settings_needs_user_refresh and app.config["QS_DEBUG"]:
-                helpers.ts_log("Auto-refreshing Plex cache for settings page because tmp_user_list is empty.", level="DEBUG")
+                helpers.ts_log(
+                    "Auto-refreshing Plex cache for settings page because tmp_user_list is empty.",
+                    level="DEBUG",
+                )
             refresh_plex_libraries()
             all_libraries = persistence.retrieve_settings("010-plex")
             plex_data = all_libraries.get("plex", {})
@@ -2309,7 +2434,10 @@ def step(name):
                 "update_channel": "Unavailable",
                 "libraries": {},
             }
-            helpers.ts_log(f"Telemetry fallback triggered due to missing or invalid telemetry for config: {selected_config}", level="WARNING")
+            helpers.ts_log(
+                f"Telemetry fallback triggered due to missing or invalid telemetry for config: {selected_config}",
+                level="WARNING",
+            )
     else:
         if app.config["QS_DEBUG"]:
             helpers.ts_log("Using telemetry from fresh plex_data", level="DEBUG")
@@ -2357,7 +2485,10 @@ def step(name):
         data["libraries"]["sho-template_variables"] = {}
 
     if app.config["QS_DEBUG"]:
-        helpers.ts_log("************************************************************************", level="DEBUG")
+        helpers.ts_log(
+            "************************************************************************",
+            level="DEBUG",
+        )
         helpers.ts_log(f"Data retrieved for {name}", level="DEBUG")
 
     (
@@ -2523,9 +2654,9 @@ def step(name):
                         "label": display_name,
                         "page": template_key,
                         "has_validation": has_validation,
-                        "validated": helpers.booler(settings.get("validated", False)) if has_validation else None,
-                        "validated_at": settings.get("validated_at", "") if has_validation else "",
-                        "validation_updated_at": validation_updated_at if has_validation else "",
+                        "validated": (helpers.booler(settings.get("validated", False)) if has_validation else None),
+                        "validated_at": (settings.get("validated_at", "") if has_validation else ""),
+                        "validation_updated_at": (validation_updated_at if has_validation else ""),
                         "validation_result": validation_result,
                     }
                 )
@@ -2543,7 +2674,13 @@ def step(name):
         saved_filename = ""
 
         if final_gate.get("can_build_config"):
-            validated, validation_error, config_data, yaml_content, validation_errors = output.build_config(header_style, config_name=config_name)
+            (
+                validated,
+                validation_error,
+                config_data,
+                yaml_content,
+                validation_errors,
+            ) = output.build_config(header_style, config_name=config_name)
             if isinstance(config_data, dict):
                 config_data, _normalized_changed, normalization_errors = _normalize_generated_config_library_files(config_data, config_name)
                 if normalization_errors:
@@ -2634,7 +2771,10 @@ def step(name):
 
         end_time = time.perf_counter()
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Rendered 900-kometa.html in {end_time - start_time:.2f} seconds", level="PROFILE")
+            helpers.ts_log(
+                f"Rendered 900-kometa.html in {end_time - start_time:.2f} seconds",
+                level="PROFILE",
+            )
         return html
 
     else:
@@ -2685,7 +2825,10 @@ def step(name):
 
     end_time = time.perf_counter()
     if app.config["QS_DEBUG"]:
-        helpers.ts_log(f"Rendered {name}.html in {end_time - start_time:.2f} seconds", level="PROFILE")
+        helpers.ts_log(
+            f"Rendered {name}.html in {end_time - start_time:.2f} seconds",
+            level="PROFILE",
+        )
     return html
 
 
@@ -2784,7 +2927,13 @@ def lookup_template_string_value():
     if preset == "tmdb_collection_id":
         api_key = _get_active_tmdb_api_key()
         if not api_key:
-            return jsonify({"valid": False, "verified": False, "message": "TMDb is not configured for the active config."})
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": False,
+                    "message": "TMDb is not configured for the active config.",
+                }
+            )
         try:
             response = requests.get(
                 f"https://api.themoviedb.org/3/collection/{value}",
@@ -2792,22 +2941,59 @@ def lookup_template_string_value():
                 timeout=10,
             )
         except requests.RequestException as exc:
-            return jsonify({"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."})
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": False,
+                    "message": f"TMDb lookup failed: {exc}.",
+                }
+            )
 
         if response.status_code == 200:
             payload = response.json() if response.content else {}
             label = str(payload.get("name") or "").strip()
             if label:
-                return jsonify({"valid": True, "verified": True, "label": label, "message": f"TMDb: {label}"})
-            return jsonify({"valid": False, "verified": True, "message": "TMDb collection found, but no collection name was returned."})
+                return jsonify(
+                    {
+                        "valid": True,
+                        "verified": True,
+                        "label": label,
+                        "message": f"TMDb: {label}",
+                    }
+                )
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": True,
+                    "message": "TMDb collection found, but no collection name was returned.",
+                }
+            )
 
         if response.status_code == 404:
-            return jsonify({"valid": False, "verified": True, "message": "TMDb collection ID not found."})
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": True,
+                    "message": "TMDb collection ID not found.",
+                }
+            )
 
         if response.status_code in {401, 403}:
-            return jsonify({"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."})
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": False,
+                    "message": "TMDb lookup could not be verified with the configured API key.",
+                }
+            )
 
-        return jsonify({"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."})
+        return jsonify(
+            {
+                "valid": False,
+                "verified": False,
+                "message": f"TMDb lookup failed with status {response.status_code}.",
+            }
+        )
 
     if preset == "numeric_id":
         tmdb_result = _lookup_tmdb_numeric_id(value, media_type=media_type)
@@ -2816,7 +3002,12 @@ def lookup_template_string_value():
         tmdb_result_type = str(tmdb_result.get("result_type") or "").strip().lower()
         expected_media_type = str(media_type or "").strip().lower()
 
-        warning_message = _build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_media_type, value_label="numeric ID")
+        warning_message = _build_tmdb_library_type_warning(
+            tmdb_message,
+            tmdb_result_type,
+            expected_media_type,
+            value_label="numeric ID",
+        )
         if tmdb_result.get("valid") and tmdb_result.get("verified") and warning_message:
             return jsonify(
                 {
@@ -2832,7 +3023,13 @@ def lookup_template_string_value():
             try:
                 plex_match = helpers.find_item_by_title(library_name, tmdb_label)
             except Exception as exc:
-                return jsonify({"valid": False, "verified": False, "message": f"Plex lookup failed: {exc}."})
+                return jsonify(
+                    {
+                        "valid": False,
+                        "verified": False,
+                        "message": f"Plex lookup failed: {exc}.",
+                    }
+                )
 
             if plex_match and plex_match.get("title"):
                 plex_title = str(plex_match.get("title")).strip()
@@ -2880,7 +3077,13 @@ def lookup_template_string_value():
             return jsonify(tmdb_result)
 
         if not library_name:
-            return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": False,
+                    "message": "Active Plex library is required for IMDb lookup.",
+                }
+            )
 
         find_item_by_imdb_id = helpers.find_item_by_imdb_id
         try:
@@ -2894,11 +3097,24 @@ def lookup_template_string_value():
             else:
                 result = find_item_by_imdb_id(library_name, value, media_type)
         except Exception as exc:
-            return jsonify({"valid": False, "verified": False, "message": f"Plex lookup failed: {exc}."})
+            return jsonify(
+                {
+                    "valid": False,
+                    "verified": False,
+                    "message": f"Plex lookup failed: {exc}.",
+                }
+            )
 
         if result and result.get("title"):
             title = str(result.get("title")).strip()
-            return jsonify({"valid": True, "verified": True, "label": title, "message": f"Plex: {title}"})
+            return jsonify(
+                {
+                    "valid": True,
+                    "verified": True,
+                    "label": title,
+                    "message": f"Plex: {title}",
+                }
+            )
 
         if tmdb_result.get("valid") and tmdb_result.get("verified"):
             if tmdb_label and tmdb_message:
@@ -2981,33 +3197,76 @@ def validate_all_services():
             "010-plex",
             "plex",
             validations.validate_plex_server,
-            lambda s: {"plex_url": s.get("plex", {}).get("url"), "plex_token": s.get("plex", {}).get("token")},
+            lambda s: {
+                "plex_url": s.get("plex", {}).get("url"),
+                "plex_token": s.get("plex", {}).get("token"),
+            },
             ["plex_url", "plex_token"],
         ),
-        ("020-tmdb", "tmdb", validations.validate_tmdb_server, lambda s: {"tmdb_apikey": s.get("tmdb", {}).get("apikey")}, ["tmdb_apikey"]),
+        (
+            "020-tmdb",
+            "tmdb",
+            validations.validate_tmdb_server,
+            lambda s: {"tmdb_apikey": s.get("tmdb", {}).get("apikey")},
+            ["tmdb_apikey"],
+        ),
         (
             "030-tautulli",
             "tautulli",
             validations.validate_tautulli_server,
-            lambda s: {"tautulli_url": s.get("tautulli", {}).get("url"), "tautulli_apikey": s.get("tautulli", {}).get("apikey")},
+            lambda s: {
+                "tautulli_url": s.get("tautulli", {}).get("url"),
+                "tautulli_apikey": s.get("tautulli", {}).get("apikey"),
+            },
             ["tautulli_url", "tautulli_apikey"],
         ),
-        ("040-github", "github", validations.validate_github_server, lambda s: {"github_token": s.get("github", {}).get("token")}, ["github_token"]),
-        ("050-omdb", "omdb", validations.validate_omdb_server, lambda s: {"omdb_apikey": s.get("omdb", {}).get("apikey")}, ["omdb_apikey"]),
-        ("060-mdblist", "mdblist", validations.validate_mdblist_server, lambda s: {"mdblist_apikey": s.get("mdblist", {}).get("apikey")}, ["mdblist_apikey"]),
-        ("070-notifiarr", "notifiarr", validations.validate_notifiarr_server, lambda s: {"notifiarr_apikey": s.get("notifiarr", {}).get("apikey")}, ["notifiarr_apikey"]),
+        (
+            "040-github",
+            "github",
+            validations.validate_github_server,
+            lambda s: {"github_token": s.get("github", {}).get("token")},
+            ["github_token"],
+        ),
+        (
+            "050-omdb",
+            "omdb",
+            validations.validate_omdb_server,
+            lambda s: {"omdb_apikey": s.get("omdb", {}).get("apikey")},
+            ["omdb_apikey"],
+        ),
+        (
+            "060-mdblist",
+            "mdblist",
+            validations.validate_mdblist_server,
+            lambda s: {"mdblist_apikey": s.get("mdblist", {}).get("apikey")},
+            ["mdblist_apikey"],
+        ),
+        (
+            "070-notifiarr",
+            "notifiarr",
+            validations.validate_notifiarr_server,
+            lambda s: {"notifiarr_apikey": s.get("notifiarr", {}).get("apikey")},
+            ["notifiarr_apikey"],
+        ),
         (
             "080-gotify",
             "gotify",
             validations.validate_gotify_server,
-            lambda s: {"gotify_url": s.get("gotify", {}).get("url"), "gotify_token": s.get("gotify", {}).get("token")},
+            lambda s: {
+                "gotify_url": s.get("gotify", {}).get("url"),
+                "gotify_token": s.get("gotify", {}).get("token"),
+            },
             ["gotify_url", "gotify_token"],
         ),
         (
             "085-ntfy",
             "ntfy",
             validations.validate_ntfy_server,
-            lambda s: {"ntfy_url": s.get("ntfy", {}).get("url"), "ntfy_token": s.get("ntfy", {}).get("token"), "ntfy_topic": s.get("ntfy", {}).get("topic")},
+            lambda s: {
+                "ntfy_url": s.get("ntfy", {}).get("url"),
+                "ntfy_token": s.get("ntfy", {}).get("token"),
+                "ntfy_topic": s.get("ntfy", {}).get("topic"),
+            },
             ["ntfy_url", "ntfy_token", "ntfy_topic"],
         ),
         (
@@ -3032,14 +3291,20 @@ def validate_all_services():
             "110-radarr",
             "radarr",
             validations.validate_radarr_server,
-            lambda s: {"radarr_url": s.get("radarr", {}).get("url"), "radarr_token": s.get("radarr", {}).get("token")},
+            lambda s: {
+                "radarr_url": s.get("radarr", {}).get("url"),
+                "radarr_token": s.get("radarr", {}).get("token"),
+            },
             ["radarr_url", "radarr_token"],
         ),
         (
             "120-sonarr",
             "sonarr",
             validations.validate_sonarr_server,
-            lambda s: {"sonarr_url": s.get("sonarr", {}).get("url"), "sonarr_token": s.get("sonarr", {}).get("token")},
+            lambda s: {
+                "sonarr_url": s.get("sonarr", {}).get("url"),
+                "sonarr_token": s.get("sonarr", {}).get("token"),
+            },
             ["sonarr_url", "sonarr_token"],
         ),
     ]
@@ -3100,7 +3365,10 @@ def validate_all_services():
                 user_entered=user_entered,
                 data=stored_data,
             )
-            results[template_key] = {"status": "validated", "validated_at": new_validated_at}
+            results[template_key] = {
+                "status": "validated",
+                "validated_at": new_validated_at,
+            }
             summary["validated"] += 1
         else:
             stored_data["validated"] = False
@@ -3120,7 +3388,11 @@ def validate_all_services():
                 user_entered=user_entered,
                 data=stored_data,
             )
-            results[template_key] = {"status": "failed", "validated_at": existing_validated_at, "reason": fail_reason}
+            results[template_key] = {
+                "status": "failed",
+                "validated_at": existing_validated_at,
+                "reason": fail_reason,
+            }
             if message:
                 results[template_key]["details"] = message
             summary["failed"] += 1
@@ -3143,7 +3415,10 @@ def validate_all_services():
                 user_entered=user_entered,
                 data=stored_data,
             )
-            results[template_key] = {"status": "validated", "validated_at": new_validated_at}
+            results[template_key] = {
+                "status": "validated",
+                "validated_at": new_validated_at,
+            }
             summary["validated"] += 1
             return
 
@@ -3235,7 +3510,15 @@ def validate_all_services():
             else:
 
                 def has_minimal_library_yaml_selection(lib_id):
-                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_", "-metadata_files", "-collection_files", "-overlay_files")
+                    allowed_markers = (
+                        "-collection_",
+                        "-overlay_",
+                        "-attribute_",
+                        "-top_level_",
+                        "-metadata_files",
+                        "-collection_files",
+                        "-overlay_files",
+                    )
                     for key, value in libraries_data.items():
                         if not isinstance(key, str) or not key.startswith(f"{lib_id}-"):
                             continue
@@ -3273,7 +3556,13 @@ def validate_all_services():
 
                 if libraries_reason is None:
                     for lib_id in selected_library_ids:
-                        use_separator = find_library_value(lib_id, ["template_variables[use_separator]", "attribute_use_separator"])
+                        use_separator = find_library_value(
+                            lib_id,
+                            [
+                                "template_variables[use_separator]",
+                                "attribute_use_separator",
+                            ],
+                        )
                         if is_blank_value(use_separator) or str(use_separator).strip().lower() == "none":
                             continue
                         placeholder_keys = [
@@ -3316,7 +3605,9 @@ def validate_all_services():
                 details=(
                     missing_placeholders
                     if libraries_reason == "missing_separator_placeholder"
-                    else arr_override_errors if libraries_reason == "invalid_arr_overrides" else auto_sort_hubs_errors if libraries_reason == "invalid_library_settings" else None
+                    else (
+                        arr_override_errors if libraries_reason == "invalid_arr_overrides" else (auto_sort_hubs_errors if libraries_reason == "invalid_library_settings" else None)
+                    )
                 ),
             )
 
@@ -3360,7 +3651,12 @@ def validate_all_services():
         if not _is_valid_auto_sort_hubs_value(settings_section.get("auto_sort_hubs")):
             invalid_fields.append("auto_sort_hubs")
 
-        check_regex("custom_repo", r"^(None|https?:\/\/[\da-z.-]+\.[a-z.]{2,6}([/\w.-]*)*\/?)$", flags=re.IGNORECASE, allow_blank=True)
+        check_regex(
+            "custom_repo",
+            r"^(None|https?:\/\/[\da-z.-]+\.[a-z.]{2,6}([/\w.-]*)*\/?)$",
+            flags=re.IGNORECASE,
+            allow_blank=True,
+        )
 
         asset_dirs = settings_section.get("asset_directory") if isinstance(settings_section, dict) else None
         if isinstance(asset_dirs, str):
@@ -3530,7 +3826,15 @@ def validate_all_services():
         user_entered=True,
         data=summary_payload,
     )
-    return jsonify({"success": True, "results": results, "summary": summary, "summary_text": summary_text, "summary_updated_at": summary_updated_at})
+    return jsonify(
+        {
+            "success": True,
+            "results": results,
+            "summary": summary,
+            "summary_text": summary_text,
+            "summary_updated_at": summary_updated_at,
+        }
+    )
 
 
 @app.route("/shutdown", methods=["POST"])
@@ -3591,16 +3895,38 @@ def start_kometa():
     _settings, kometa_section = _get_kometa_settings_section(config_name)
     selection = _resolve_kometa_selection(kometa_section)
     if selection.get("install_mode") == KOMETA_INSTALL_MODE_EXTERNAL:
-        return jsonify({"error": "External Kometa mode cannot launch Kometa from Quickstart. Quickstart can only sync config and optional logs in this mode."}), 400
+        return (
+            jsonify({"error": "External Kometa mode cannot launch Kometa from Quickstart. Quickstart can only sync config and optional logs in this mode."}),
+            400,
+        )
 
     if helpers.is_kometa_running():
         pid = helpers.get_kometa_pid()
         try:
             proc = psutil.Process(pid)
             started_at = datetime.fromtimestamp(proc.create_time()).isoformat()
-            return jsonify({"error": f"Kometa is already running (PID: {pid}) since {started_at}.", "status": "running", "pid": pid, "started_at": started_at}), 400
+            return (
+                jsonify(
+                    {
+                        "error": f"Kometa is already running (PID: {pid}) since {started_at}.",
+                        "status": "running",
+                        "pid": pid,
+                        "started_at": started_at,
+                    }
+                ),
+                400,
+            )
         except Exception:
-            return jsonify({"error": f"Kometa is already running (PID: {pid}).", "status": "running", "pid": pid}), 400
+            return (
+                jsonify(
+                    {
+                        "error": f"Kometa is already running (PID: {pid}).",
+                        "status": "running",
+                        "pid": pid,
+                    }
+                ),
+                400,
+            )
     else:
         proc = _find_running_kometa_process()
         if proc:
@@ -3610,7 +3936,11 @@ def start_kometa():
                 started_at = datetime.fromtimestamp(proc.create_time()).isoformat()
             except Exception:
                 started_at = None
-            payload = {"error": f"Kometa is already running (PID: {proc.pid}).", "status": "running", "pid": proc.pid}
+            payload = {
+                "error": f"Kometa is already running (PID: {proc.pid}).",
+                "status": "running",
+                "pid": proc.pid,
+            }
             if started_at:
                 payload["started_at"] = started_at
             return jsonify(payload), 400
@@ -3638,7 +3968,16 @@ def start_kometa():
         start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=maintenance_config_name)
     if _is_within_maintenance_window(datetime.now(), start_min, end_min):
         _set_pending_kometa_start(command, session.get("config_name"), start_mode=start_mode)
-        return jsonify({"status": "queued", "maintenance_window": window_str, "start_mode": start_mode}), 202
+        return (
+            jsonify(
+                {
+                    "status": "queued",
+                    "maintenance_window": window_str,
+                    "start_mode": start_mode,
+                }
+            ),
+            202,
+        )
 
     ok, result = _launch_kometa_command(command, session.get("config_name"), start_mode=start_mode)
     if ok:
@@ -3689,16 +4028,29 @@ def stop_kometa():
         _clear_process_metric_cache(pid, "kometa")
         _clear_run_context()
         try:
-            _write_quickstart_stop_marker(helpers.get_kometa_root_path(), config_name=run_config_name, reason="user_stop")
+            _write_quickstart_stop_marker(
+                helpers.get_kometa_root_path(),
+                config_name=run_config_name,
+                reason="user_stop",
+            )
         except Exception:
             pass
 
         if alive_after:
             alive_pids = ", ".join(str(p.pid) for p in alive_after if p is not None)
-            return jsonify({"warning": f"Kometa stop requested, but some processes are still running: {alive_pids}"}), 200
+            return (
+                jsonify({"warning": f"Kometa stop requested, but some processes are still running: {alive_pids}"}),
+                200,
+            )
         if not_kometa:
-            return jsonify({"warning": f"Cleaned PID file. Non-Kometa PIDs detected: {', '.join(map(str, not_kometa))}"}), 200
-        return jsonify({"success": True, "message": "Kometa stopped and cleaned up."}), 200
+            return (
+                jsonify({"warning": f"Cleaned PID file. Non-Kometa PIDs detected: {', '.join(map(str, not_kometa))}"}),
+                200,
+            )
+        return (
+            jsonify({"success": True, "message": "Kometa stopped and cleaned up."}),
+            200,
+        )
 
     except psutil.NoSuchProcess:
         # Process already gone; just clean up PID file
@@ -3708,7 +4060,11 @@ def stop_kometa():
             pass
         _clear_run_context()
         try:
-            _write_quickstart_stop_marker(helpers.get_kometa_root_path(), config_name=session.get("config_name"), reason="process_missing")
+            _write_quickstart_stop_marker(
+                helpers.get_kometa_root_path(),
+                config_name=session.get("config_name"),
+                reason="process_missing",
+            )
         except Exception:
             pass
         return jsonify({"warning": "Process not found. Cleaned up PID file."}), 200
@@ -3808,14 +4164,14 @@ def kometa_status():
                     started_at=started_at,
                     started_at_ts=started_at_ts,
                     elapsed_seconds=elapsed_seconds,
-                    cpu_percent=round(cpu_percent, 1) if cpu_percent is not None else None,
+                    cpu_percent=(round(cpu_percent, 1) if cpu_percent is not None else None),
                     memory_rss_mb=round(mem_rss_mb, 1),
-                    memory_percent=round(mem_percent, 2) if mem_percent is not None else None,
-                    disk_read_mb=round(io_stats.get("disk_read_mb"), 1) if io_stats.get("disk_read_mb") is not None else None,
-                    disk_write_mb=round(io_stats.get("disk_write_mb"), 1) if io_stats.get("disk_write_mb") is not None else None,
-                    disk_read_rate_mb_s=round(io_stats.get("disk_read_rate_mb_s"), 2) if io_stats.get("disk_read_rate_mb_s") is not None else None,
-                    disk_write_rate_mb_s=round(io_stats.get("disk_write_rate_mb_s"), 2) if io_stats.get("disk_write_rate_mb_s") is not None else None,
-                    system_cpu_percent=round(system_cpu_percent, 1) if system_cpu_percent is not None else None,
+                    memory_percent=(round(mem_percent, 2) if mem_percent is not None else None),
+                    disk_read_mb=(round(io_stats.get("disk_read_mb"), 1) if io_stats.get("disk_read_mb") is not None else None),
+                    disk_write_mb=(round(io_stats.get("disk_write_mb"), 1) if io_stats.get("disk_write_mb") is not None else None),
+                    disk_read_rate_mb_s=(round(io_stats.get("disk_read_rate_mb_s"), 2) if io_stats.get("disk_read_rate_mb_s") is not None else None),
+                    disk_write_rate_mb_s=(round(io_stats.get("disk_write_rate_mb_s"), 2) if io_stats.get("disk_write_rate_mb_s") is not None else None),
+                    system_cpu_percent=(round(system_cpu_percent, 1) if system_cpu_percent is not None else None),
                     system_memory_percent=round(vm.percent, 1),
                     system_memory_used_mb=round(system_mem_used_mb, 1),
                     system_memory_total_mb=round(system_mem_total_mb, 1),
@@ -4100,7 +4456,14 @@ def logscan_analyze():
                 _start_logscan_auto_reingest(log_path.parent)
 
     result["cached"] = False
-    LOGSCAN_ANALYSIS_CACHE.update({"mtime": stats.st_mtime, "size": stats.st_size, "version": LOGSCAN_ANALYSIS_CACHE_VERSION, "data": dict(result)})
+    LOGSCAN_ANALYSIS_CACHE.update(
+        {
+            "mtime": stats.st_mtime,
+            "size": stats.st_size,
+            "version": LOGSCAN_ANALYSIS_CACHE_VERSION,
+            "data": dict(result),
+        }
+    )
     return jsonify(result)
 
 
@@ -4147,7 +4510,13 @@ def logscan_progress():
                 try:
                     if aux_path.exists() and aux_path.is_file():
                         aux_stats = aux_path.stat()
-                        signature.append((aux_path.name.lower(), aux_stats.st_mtime, aux_stats.st_size))
+                        signature.append(
+                            (
+                                aux_path.name.lower(),
+                                aux_stats.st_mtime,
+                                aux_stats.st_size,
+                            )
+                        )
                 except Exception:
                     continue
             return tuple(signature)
@@ -4291,9 +4660,20 @@ def logscan_progress():
             is_running=running,
         )
         phase_order = _get_progress_run_order(config_data=config_data)
-        allowed_phases = phase_order or ["operations", "metadata", "collections", "overlays"]
+        allowed_phases = phase_order or [
+            "operations",
+            "metadata",
+            "collections",
+            "overlays",
+        ]
         playlists_configured = bool(config_data.get("playlists")) if isinstance(config_data, dict) else False
-        if run_mode in ("collections", "overlays", "operations", "metadata", "playlists"):
+        if run_mode in (
+            "collections",
+            "overlays",
+            "operations",
+            "metadata",
+            "playlists",
+        ):
             allowed_phases = [run_mode]
             progress["phase_current"] = run_mode
             progress["phases_completed"] = []
@@ -4431,7 +4811,10 @@ def logscan_trends_ingest_health():
 def logscan_trends_archive_storage():
     snapshot = _logscan_reingest_snapshot()
     if logscan_ingest_lock.locked() or snapshot.get("status") == "running":
-        return jsonify({"status": "running", "archive_storage": None, "reingest": snapshot}), 202
+        return (
+            jsonify({"status": "running", "archive_storage": None, "reingest": snapshot}),
+            202,
+        )
     resolution_context = _build_logscan_resolution_context()
     all_runs = database.get_log_runs(limit=None) if database.get_log_runs_count() else []
     all_incomplete_runs = _get_logscan_incomplete_runs(limit=None)
@@ -4451,7 +4834,17 @@ def logscan_trends_archive_storage():
 def logscan_trends_incomplete_runs():
     snapshot = _logscan_reingest_snapshot()
     if logscan_ingest_lock.locked() or snapshot.get("status") == "running":
-        return jsonify({"status": "running", "incomplete_runs": [], "total_incomplete_runs": 0, "reingest": snapshot}), 202
+        return (
+            jsonify(
+                {
+                    "status": "running",
+                    "incomplete_runs": [],
+                    "total_incomplete_runs": 0,
+                    "reingest": snapshot,
+                }
+            ),
+            202,
+        )
     raw_limit = str(request.args.get("limit", "50")).strip().lower()
     if raw_limit == "all":
         limit = None
@@ -4464,7 +4857,13 @@ def logscan_trends_incomplete_runs():
     resolution_context = _build_logscan_resolution_context()
     runs = _annotate_logscan_runs(_get_logscan_incomplete_runs(limit=limit), context=resolution_context)
     all_runs = _get_logscan_incomplete_runs(limit=None)
-    return jsonify({"status": "idle", "incomplete_runs": runs, "total_incomplete_runs": len(all_runs)})
+    return jsonify(
+        {
+            "status": "idle",
+            "incomplete_runs": runs,
+            "total_incomplete_runs": len(all_runs),
+        }
+    )
 
 
 @app.route("/logscan/trends/recommendations", methods=["GET"])
@@ -4618,7 +5017,13 @@ def _normalize_logscan_archive_filenames(archive_dir=None):
     if archive_dir:
         archive_dirs.append(Path(archive_dir))
     else:
-        archive_dirs.extend([_get_logscan_archive_dir("kometa"), _get_logscan_archive_dir("imagemaid"), _get_logscan_archive_root_dir()])
+        archive_dirs.extend(
+            [
+                _get_logscan_archive_dir("kometa"),
+                _get_logscan_archive_dir("imagemaid"),
+                _get_logscan_archive_root_dir(),
+            ]
+        )
 
     for current_archive_dir in archive_dirs:
         if not current_archive_dir.exists():
@@ -4635,7 +5040,10 @@ def _normalize_logscan_archive_filenames(archive_dir=None):
                 except Exception as exc:
                     errors.append(f"Failed to remove archived Quickstart marker artifact {sidecar_path}: {exc}")
 
-    for path in sorted(_iter_logscan_candidate_files(include_archive=True, include_compressed=True), key=lambda item: item.name.lower()):
+    for path in sorted(
+        _iter_logscan_candidate_files(include_archive=True, include_compressed=True),
+        key=lambda item: item.name.lower(),
+    ):
         if _classify_logscan_file_location(path) != "archive":
             continue
         try:
@@ -4834,7 +5242,12 @@ def _start_logscan_auto_reingest(log_dir):
         sample_incomplete=[],
         sample_errors=[],
     )
-    thread = threading.Thread(target=_run_logscan_reingest_job, args=(job_id, False), daemon=True, name="logscan-auto-reingest")
+    thread = threading.Thread(
+        target=_run_logscan_reingest_job,
+        args=(job_id, False),
+        daemon=True,
+        name="logscan-auto-reingest",
+    )
     thread.start()
     return True
 
@@ -4854,7 +5267,13 @@ def _ingest_completed_live_logs(tool_name="kometa", log_dir=None):
         candidates = [live_dir / "meta.log"]
     else:
         candidates = [
-            path for path in sorted(live_dir.glob("*.log*"), key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True) if path.is_file() and ".log" in path.name.lower()
+            path
+            for path in sorted(
+                live_dir.glob("*.log*"),
+                key=lambda p: p.stat().st_mtime if p.exists() else 0,
+                reverse=True,
+            )
+            if path.is_file() and ".log" in path.name.lower()
         ]
 
     ingest_cache = _load_logscan_ingest_cache()
@@ -5181,7 +5600,11 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
     if not logscan_ingest_lock.acquire(blocking=False):
         message = "Logscan ingest already running."
         if update_state:
-            _update_logscan_reingest_state(status="error", error=message, finished_at=datetime.now(timezone.utc).isoformat())
+            _update_logscan_reingest_state(
+                status="error",
+                error=message,
+                finished_at=datetime.now(timezone.utc).isoformat(),
+            )
         return {"success": False, "error": message}
     started_at = datetime.now(timezone.utc).isoformat()
     if update_state:
@@ -5231,7 +5654,11 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
         if not kometa_log_dir.exists() and not imagemaid_log_dir.exists():
             message = f"Log folders not found at: {kometa_log_dir} or {imagemaid_log_dir}"
             if update_state:
-                _update_logscan_reingest_state(status="error", error=message, finished_at=datetime.now(timezone.utc).isoformat())
+                _update_logscan_reingest_state(
+                    status="error",
+                    error=message,
+                    finished_at=datetime.now(timezone.utc).isoformat(),
+                )
             return {"success": False, "error": message}
 
         log_files = _get_logscan_log_files(log_dir=kometa_log_dir, include_archive=True) if reset else _get_logscan_delta_files(log_dir=kometa_log_dir, include_archive=True)
@@ -5240,7 +5667,10 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
             _update_logscan_reingest_state(total=total_files)
 
         analyzer = logscan.LogscanAnalyzer()
-        preload_path = next((path for path in log_files if _detect_logscan_tool_from_path(path, log_dir=kometa_log_dir) == "kometa"), None)
+        preload_path = next(
+            (path for path in log_files if _detect_logscan_tool_from_path(path, log_dir=kometa_log_dir) == "kometa"),
+            None,
+        )
         if preload_path:
             analyzer.preload_people_index(preload_path)
         ingested = 0
@@ -5348,14 +5778,14 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                             "config_hash": summary.get("config_hash"),
                             "run_command": summary.get("run_command"),
                             "command_signature": summary.get("command_signature"),
-                            "section_runtimes": summary.get("section_runtimes") if isinstance(summary.get("section_runtimes"), dict) else {},
+                            "section_runtimes": (summary.get("section_runtimes") if isinstance(summary.get("section_runtimes"), dict) else {}),
                             "log_size": summary.get("log_size"),
-                            "log_counts": summary.get("log_counts") if isinstance(summary.get("log_counts"), dict) else {},
-                            "analysis_counts": summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {},
-                            "library_counts": summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {},
-                            "maintenance_summary": summary.get("maintenance_summary") if isinstance(summary.get("maintenance_summary"), dict) else {},
-                            "quiet_period_summary": summary.get("quiet_period_summary") if isinstance(summary.get("quiet_period_summary"), dict) else {},
-                            "progress_snapshot": summary.get("progress_snapshot") if isinstance(summary.get("progress_snapshot"), dict) else {},
+                            "log_counts": (summary.get("log_counts") if isinstance(summary.get("log_counts"), dict) else {}),
+                            "analysis_counts": (summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {}),
+                            "library_counts": (summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {}),
+                            "maintenance_summary": (summary.get("maintenance_summary") if isinstance(summary.get("maintenance_summary"), dict) else {}),
+                            "quiet_period_summary": (summary.get("quiet_period_summary") if isinstance(summary.get("quiet_period_summary"), dict) else {}),
+                            "progress_snapshot": (summary.get("progress_snapshot") if isinstance(summary.get("progress_snapshot"), dict) else {}),
                             "quickstart_run_marker": bool(summary.get("quickstart_run_marker")),
                             "start_mode": summary.get("start_mode"),
                             "config_line_count": summary.get("config_line_count"),
@@ -5639,7 +6069,10 @@ def _start_pending_logscan_startup_migration(app_in):
                 level="INFO",
             )
         elif required_level > 0 and completed_level >= required_level:
-            helpers.ts_log(f"Analytics migration level {required_level} already applied.", level="DEBUG")
+            helpers.ts_log(
+                f"Analytics migration level {required_level} already applied.",
+                level="DEBUG",
+            )
         return state
 
     started_at = datetime.now(timezone.utc).isoformat()
@@ -5895,7 +6328,10 @@ def logscan_trends_preferences_update():
     saved = database.save_analytics_preferences(config_name, preferences)
     result = database.get_analytics_preferences(config_name)
     status_code = 200 if saved else 400
-    return jsonify({"success": saved, "config_name": config_name, "preferences": result}), status_code
+    return (
+        jsonify({"success": saved, "config_name": config_name, "preferences": result}),
+        status_code,
+    )
 
 
 @app.route("/logscan/trends/people-missing", methods=["GET"])
@@ -6002,21 +6438,28 @@ def support_info():
         plex_summary = "Plex info unavailable."
 
     library_settings = persistence.retrieve_settings("025-libraries").get("libraries", {})
-    movie_libraries = []
-    show_libraries = []
+    plex_name_map = persistence.get_library_names()
+    movie_id_map = {}
+    show_id_map = {}
     for key, value in library_settings.items():
         if not key.endswith("-library") or value in [None, "", False]:
             continue
+        lib_id = helpers.extract_library_name(key)
+        if not lib_id:
+            continue
+        display_name = plex_name_map.get(lib_id, str(value))
+        if not display_name.strip():
+            continue
         if key.startswith("mov-library_"):
-            movie_libraries.append(str(value))
+            movie_id_map[lib_id] = display_name
         elif key.startswith("sho-library_"):
-            show_libraries.append(str(value))
+            show_id_map[lib_id] = display_name
 
-    movie_libraries = sorted((name.strip() for name in movie_libraries if str(name).strip()), key=lambda value: value.casefold())
-    show_libraries = sorted((name.strip() for name in show_libraries if str(name).strip()), key=lambda value: value.casefold())
-    library_names = movie_libraries + show_libraries
-    if library_names:
-        library_details = helpers.get_library_summaries(library_names)
+    movie_id_map = dict(sorted(movie_id_map.items(), key=lambda x: x[1].strip().casefold()))
+    show_id_map = dict(sorted(show_id_map.items(), key=lambda x: x[1].strip().casefold()))
+    library_id_map = {**movie_id_map, **show_id_map}
+    if library_id_map:
+        library_details = helpers.get_library_summaries(library_id_map)
         if library_details.lower().startswith("plex library summary unavailable"):
             library_details = "Library details unavailable."
     else:
@@ -6037,7 +6480,7 @@ def support_info():
     lines.extend([f"# {line}" for line in plex_summary.splitlines()])
     lines.append(f"# Quickstart: {quickstart_version} | Branch: {quickstart_branch} | Environment: {quickstart_environment}")
     lines.append("###")
-    lines.append(f"# Libraries configured with Quickstart: {len(movie_libraries)} movie, {len(show_libraries)} show")
+    lines.append(f"# Libraries configured with Quickstart: {len(movie_id_map)} movie, {len(show_id_map)} show")
     if library_details:
         for line in library_details.splitlines():
             if line.strip():
@@ -6179,7 +6622,10 @@ def update_quickstart_settings():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             if sock.connect_ex(("localhost", new_port)) == 0:
-                return jsonify(success=False, message=f"Port {new_port} is already in use."), 409
+                return (
+                    jsonify(success=False, message=f"Port {new_port} is already in use."),
+                    409,
+                )
         finally:
             sock.close()
 
@@ -6239,7 +6685,13 @@ def update_quickstart_settings():
             try:
                 os.makedirs(desired_session_dir, exist_ok=True)
             except Exception:
-                return jsonify(success=False, message="Failed to create the session storage directory."), 500
+                return (
+                    jsonify(
+                        success=False,
+                        message="Failed to create the session storage directory.",
+                    ),
+                    500,
+                )
             helpers.update_env_variable("QS_FLASK_SESSION_DIR", desired_session_dir)
             app.config["QS_FLASK_SESSION_DIR"] = desired_session_dir
             app.config["SESSION_CACHELIB"] = FileSystemCache(
@@ -6382,7 +6834,7 @@ def validate_playlist_file():
         if details.get("message") or isinstance(details.get("files"), list):
             payload["error_details"] = {
                 "text": details.get("message") or message,
-                "files": details.get("files") if isinstance(details.get("files"), list) else [],
+                "files": (details.get("files") if isinstance(details.get("files"), list) else []),
             }
         if isinstance(details.get("files"), list):
             payload["files"] = details["files"]
@@ -6508,7 +6960,10 @@ if __name__ == "__main__":
         if app.config["QUICKSTART_DOCKER"]:
             helpers.ts_log("Quickstart is Running inside Docker.", level="INFO")
             helpers.ts_log(f"Access it at http://<your-server-ip>:{running_port}", level="INFO")
-            helpers.ts_log("Note: This IP is the HOST machine IP, not the container IP.", level="INFO")
+            helpers.ts_log(
+                "Note: This IP is the HOST machine IP, not the container IP.",
+                level="INFO",
+            )
         else:
             ip_address = get_lan_ip()
             helpers.ts_log("Quickstart is Running", level="INFO")
@@ -6593,8 +7048,14 @@ if __name__ == "__main__":
                 )
 
                 helpers.ts_log("Quickstart is Running", level="INFO")
-                helpers.ts_log(f"Access it locally at: http://localhost:{running_port}", level="INFO")
-                helpers.ts_log(f"Access it from other devices at: http://{ip_address}:{running_port}", level="INFO")
+                helpers.ts_log(
+                    f"Access it locally at: http://localhost:{running_port}",
+                    level="INFO",
+                )
+                helpers.ts_log(
+                    f"Access it from other devices at: http://{ip_address}:{running_port}",
+                    level="INFO",
+                )
                 helpers.ts_log(
                     f"Port and Debug Settings can be amended via the Settings cog in the UI, " f"right-clicking the system tray icon, or by editing your {DOTENV} file",
                     level="INFO",

--- a/quickstart.py
+++ b/quickstart.py
@@ -1135,10 +1135,13 @@ app.jinja_env.globals["vite_dev_origin"] = helpers.vite_dev_origin
 
 
 def _nbsp_leading_spaces(s: str) -> str:
-    """Replace leading ASCII spaces with EM SPACE (U+2003) for visible indentation in native dropdowns."""
+    """Replace leading/trailing ASCII spaces with EM SPACE (U+2003) so they are visible in dropdowns."""
     s = str(s)
-    stripped = s.lstrip(" ")
-    return " " * (len(s) - len(stripped)) + stripped
+    lstripped = s.lstrip(" ")
+    leading = len(s) - len(lstripped)
+    rstripped = lstripped.rstrip(" ")
+    trailing = len(lstripped) - len(rstripped)
+    return " " * leading + rstripped + " " * trailing
 
 
 app.jinja_env.filters["nbsp_leading_spaces"] = _nbsp_leading_spaces

--- a/static/local-js/010-plex.js
+++ b/static/local-js/010-plex.js
@@ -55,30 +55,47 @@ function applyPlexResponse (data) {
   // correct (it reflects what the user actually wants right now).
   const dbCacheInput = document.getElementById('plex_db_cache')
   const currentDbCache = dbCacheInput ? normalizeDbCacheValue(dbCacheInput.value) : ''
+  const defaultDbCache = dbCacheInput ? normalizeDbCacheValue(dbCacheInput.defaultValue) : ''
   const serverDbCache = normalizeDbCacheValue(data.db_cache)
   if (!serverDbCache) return
+
+  // if we got something back from the server, stick it in the field
+  if (dbCacheInput) dbCacheInput.value = serverDbCache
 
   if (plexDbCache) {
     plexDbCache.textContent = 'Database cache value retrieved from server is: ' + serverDbCache + ' MB'
     plexDbCache.style.color = '#75b798'
     plexDbCache.style.display = 'block'
 
-    if (currentDbCache && currentDbCache !== serverDbCache) {
+    // Only warn if the user deliberately set a value (differs from the field's
+    // HTML default) that doesn't match what the server reports.  Firing on the
+    // default value would claim a mismatch against a number the user never chose.
+    const userModified = currentDbCache !== defaultDbCache
+    if (userModified && currentDbCache !== serverDbCache) {
       plexDbCache.textContent += '.\nWarning: The value in the input box (' + currentDbCache + ' MB) does not match the value retrieved from the server (' + serverDbCache + ' MB).'
       plexDbCache.style.color = '#ea868f'
     }
   }
-  if (dbCacheInput) dbCacheInput.value = serverDbCache
 
   // Hidden tmp_ inputs that hold the lists for the next wizard pages.
+  // Library lists are stored as comma-separated Plex section IDs (integers).
+  // The name lookup is stored as a JSON object keyed by string ID.
   const tmpUserList = document.getElementById('tmp_user_list')
   const tmpMusicLibraries = document.getElementById('tmp_music_libraries')
   const tmpMovieLibraries = document.getElementById('tmp_movie_libraries')
   const tmpShowLibraries = document.getElementById('tmp_show_libraries')
+  const tmpLibraryNames = document.getElementById('tmp_library_names')
+
+  const toIdCsv = (libs) => (libs ?? []).map(lib => lib.id ?? lib).join(',')
+  const toNameMap = (libs) => Object.fromEntries((libs ?? []).map(lib => [String(lib.id ?? lib), lib.name ?? String(lib)]))
+
+  const allLibs = [...(data.movie_libraries ?? []), ...(data.show_libraries ?? []), ...(data.music_libraries ?? [])]
+
   if (tmpUserList) tmpUserList.value = data.user_list
-  if (tmpMusicLibraries) tmpMusicLibraries.value = data.music_libraries
-  if (tmpMovieLibraries) tmpMovieLibraries.value = data.movie_libraries
-  if (tmpShowLibraries) tmpShowLibraries.value = data.show_libraries
+  if (tmpMusicLibraries) tmpMusicLibraries.value = toIdCsv(data.music_libraries)
+  if (tmpMovieLibraries) tmpMovieLibraries.value = toIdCsv(data.movie_libraries)
+  if (tmpShowLibraries) tmpShowLibraries.value = toIdCsv(data.show_libraries)
+  if (tmpLibraryNames) tmpLibraryNames.value = JSON.stringify(toNameMap(allLibs))
 
   // Reveal the "hidden" section that holds the db_cache configuration.
   if (hiddenSection) hiddenSection.style.display = 'block'

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6011,12 +6011,18 @@ function updateConfiguredCounts () {
   configuredCountsDisplay.textContent = `Configured: ${counts.movie} ${movieLabel} / ${counts.show} ${showLabel}`
 }
 
+function nbspLeadingSpaces (s) {
+  const stripped = s.replace(/^ +/, '')
+  return ' '.repeat(s.length - stripped.length) + stripped
+}
+
 function refreshPickerLabels () {
   if (!libraryPicker) return
   libraryPicker.querySelectorAll('option[value]').forEach(opt => {
     const base = opt.dataset.label || opt.textContent.replace(/\s+\(configured\)$/, '')
     const configured = opt.dataset.configured === 'true'
-    opt.textContent = configured ? `${base} (configured)` : base
+    const displayBase = nbspLeadingSpaces(base)
+    opt.textContent = configured ? `${displayBase} (configured)` : displayBase
   })
   updateConfiguredCounts()
 }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6012,8 +6012,11 @@ function updateConfiguredCounts () {
 }
 
 function nbspLeadingSpaces (s) {
-  const stripped = s.replace(/^ +/, '')
-  return ' '.repeat(s.length - stripped.length) + stripped
+  const lstripped = s.replace(/^ +/, '')
+  const leading = s.length - lstripped.length
+  const rstripped = lstripped.replace(/ +$/, '')
+  const trailing = lstripped.length - rstripped.length
+  return ' '.repeat(leading) + rstripped + ' '.repeat(trailing)
 }
 
 function refreshPickerLabels () {

--- a/static/local-js/modules/kometa/_runProgress.js
+++ b/static/local-js/modules/kometa/_runProgress.js
@@ -59,7 +59,7 @@
 //   module importable in test contexts.
 
 import { kometaState } from './_state.js'
-import { coerceRunSeconds, formatRunSeconds } from './_util.js'
+import { coerceRunSeconds, formatRunSeconds, nbspLeadingSpaces } from './_util.js'
 
 /**
  * Canonical phase order for the run-progress panel. Server can
@@ -290,7 +290,7 @@ function renderLibraryRows (payload, visibleLibraries, phasesToShow, phaseIndexL
 
     return `
         <tr>
-          <td>${entry.name}</td>
+          <td><code>${nbspLeadingSpaces(entry.name)}</code></td>
           <td>${typeLabel}</td>
           <td><span class="badge ${klass}">${entry.status}</span></td>
           ${durationCells}

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -56,6 +56,20 @@ export function escapeHtml (value) {
 }
 
 /**
+ * Replace leading/trailing ASCII spaces with EM SPACE (U+2003) so
+ * they survive HTML rendering without being collapsed. Mirrors the
+ * server-side `nbsp_leading_spaces` Jinja filter.
+ */
+export function nbspLeadingSpaces (value) {
+  const s = String(value == null ? '' : value)
+  const lstripped = s.replace(/^ +/, '')
+  const leading = s.length - lstripped.length
+  const rstripped = lstripped.replace(/ +$/, '')
+  const trailing = lstripped.length - rstripped.length
+  return ' '.repeat(leading) + rstripped + ' '.repeat(trailing)
+}
+
+/**
  * Turn plain text into HTML with any http(s) URLs converted to
  * anchor tags. `[https://...]` bracket-wrapped URLs are also
  * detected (the brackets are stripped from the display text).

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -71,6 +71,10 @@
     window.QS_TRAKT_REQUIREMENT_REASONS = {{ (trakt_requirement_reasons if trakt_requirement_reasons is defined else []) | tojson }};
     window.QS_MAL_REQUIREMENT_REASONS = {{ (mal_requirement_reasons if mal_requirement_reasons is defined else []) | tojson }};
   </script>
+  {% set _vite_origin = vite_dev_origin() %}
+  {% if _vite_origin %}
+  <script type="module" src="{{ _vite_origin }}/@vite/client"></script>
+  {% endif %}
   <script type="module" src="{{ asset_url('000-base') }}"></script>
   <script type="module" src="{{ asset_url('pathValidation') }}"></script>
   <script type="module" src="{{ asset_url('urlValidation') }}"></script>

--- a/templates/010-plex.html
+++ b/templates/010-plex.html
@@ -52,6 +52,8 @@
     value="{{ data['plex']['tmp_movie_libraries'] }}" title="">
 <input type="hidden" class="form-control" id="tmp_show_libraries" name="tmp_show_libraries"
     value="{{ data['plex']['tmp_show_libraries'] }}" title="">
+<input type="hidden" class="form-control" id="tmp_library_names" name="tmp_library_names"
+    value="{{ data['plex']['tmp_library_names'] | default('') }}" title="">
 <div class="form-floating" style="display:none;">
     <input type="text" class="form-control" id="plex_validated" name="plex_validated" value="{{ data['validated'] }}"
         title="">
@@ -73,7 +75,7 @@
                 </span>
                 <input type="number" class="form-control" id="plex_db_cache" name="plex_db_cache"
                     value="{{ data['plex']['db_cache'] }}"
-                    title="Set the size of the Plex Database Cache (in Megabytes), default is 40" min="40">
+                    title="Set the size of the Plex Database Cache (in Megabytes), default is 40" min="722">
             </div>
             <div id="plexDbCache" class="status-message mb-2"></div>
         </div>

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -181,7 +181,7 @@
         {% for library in movie_libraries %}
         <option value="{{ library.id }}" data-library-type="{{ library.type }}"
           data-configured="{{ 'true' if library.id in configured_ids else 'false' }}" data-label="{{ library.name }}">
-          {{ library.name }}{% if library.id in configured_ids %} (configured){% endif %}
+          {{ library.name | nbsp_leading_spaces }}{% if library.id in configured_ids %} (configured){% endif %}
         </option>
         {% endfor %}
       </optgroup>
@@ -191,7 +191,7 @@
         {% for library in show_libraries %}
         <option value="{{ library.id }}" data-library-type="{{ library.type }}"
           data-configured="{{ 'true' if library.id in configured_ids else 'false' }}" data-label="{{ library.name }}">
-          {{ library.name }}{% if library.id in configured_ids %} (configured){% endif %}
+          {{ library.name | nbsp_leading_spaces }}{% if library.id in configured_ids %} (configured){% endif %}
         </option>
         {% endfor %}
       </optgroup>

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -135,7 +135,7 @@
             <tbody>
               {% for lib_name, lib_info in page_info.telemetry.libraries.items() %}
               <tr>
-                <td>{{ lib_name }}</td>
+                <td>{{ lib_name | nbsp_leading_spaces }}</td>
                 <td><span class="badge bg-secondary text-uppercase">{{ lib_info.type }}</span></td>
                 <td><code>{{ lib_info.scanner }}</code></td>
                 <td><code>{{ lib_info.agent }}</code></td>

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -135,7 +135,7 @@
             <tbody>
               {% for lib_name, lib_info in page_info.telemetry.libraries.items() %}
               <tr>
-                <td>{{ lib_name | nbsp_leading_spaces }}</td>
+                <td><code>{{ lib_name | nbsp_leading_spaces }}</code></td>
                 <td><span class="badge bg-secondary text-uppercase">{{ lib_info.type }}</span></td>
                 <td><code>{{ lib_info.scanner }}</code></td>
                 <td><code>{{ lib_info.agent }}</code></td>

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -133,9 +133,9 @@
               </tr>
             </thead>
             <tbody>
-              {% for lib_name, lib_info in page_info.telemetry.libraries.items() %}
+              {% for lib_id, lib_info in page_info.telemetry.libraries.items() %}
               <tr>
-                <td><code>{{ lib_name | nbsp_leading_spaces }}</code></td>
+                <td><code>{{ (lib_info.name or lib_id) | nbsp_leading_spaces }}</code></td>
                 <td><span class="badge bg-secondary text-uppercase">{{ lib_info.type }}</span></td>
                 <td><code>{{ lib_info.scanner }}</code></td>
                 <td><code>{{ lib_info.agent }}</code></td>

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -174,7 +174,7 @@
           Bulk updated:
           <span id="validate-all-status-bulk-time" data-validation-iso="{{ validation_bulk_rollup_at | default('', true) }}">—</span>
         </div>
-        {% set bulk_pages = ['010-plex','020-tmdb','025-libraries','030-tautulli','040-github','050-omdb','060-mdblist','070-notifiarr','080-gotify','085-ntfy','087-apprise','088-yamtrack','090-webhooks','100-anidb','110-radarr','120-sonarr','150-settings','130-trakt','140-mal'] %}
+        {% set bulk_pages = ['010-plex','020-tmdb','025-libraries','150-settings','030-tautulli','040-github','050-omdb','060-mdblist','070-notifiarr','080-gotify','085-ntfy','087-apprise','088-yamtrack','090-webhooks','100-anidb','110-radarr','120-sonarr','130-trakt','140-mal'] %}
         {% set interactive_pages = [] %}
         {% set nonservice_pages = ['001-start','900-kometa','910-sponsor','905-analytics'] %}
         <div class="table-responsive" data-qs-sticky-first="true">

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -1044,7 +1044,7 @@
                         <tbody>
                           {% for row in incomplete_resume_hint.progress_snapshot.rows %}
                           <tr>
-                            <td>{{ row.name }}</td>
+                            <td><code>{{ row.name | nbsp_leading_spaces }}</code></td>
                             <td>{{ row.type }}</td>
                             <td><span class="badge {{ row.status_class }}">{{ row.status }}</span></td>
                             {% for cell in row.phase_cells %}

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -174,7 +174,7 @@
           Bulk updated:
           <span id="validate-all-status-bulk-time" data-validation-iso="{{ validation_bulk_rollup_at | default('', true) }}">—</span>
         </div>
-        {% set bulk_pages = ['010-plex','020-tmdb','025-libraries','150-settings','030-tautulli','040-github','050-omdb','060-mdblist','070-notifiarr','080-gotify','085-ntfy','087-apprise','088-yamtrack','090-webhooks','100-anidb','110-radarr','120-sonarr','130-trakt','140-mal'] %}
+        {% set bulk_pages = ['010-plex','020-tmdb','025-libraries','030-tautulli','040-github','050-omdb','060-mdblist','070-notifiarr','080-gotify','085-ntfy','087-apprise','088-yamtrack','090-webhooks','100-anidb','110-radarr','120-sonarr','150-settings','130-trakt','140-mal'] %}
         {% set interactive_pages = [] %}
         {% set nonservice_pages = ['001-start','900-kometa','910-sponsor','905-analytics'] %}
         <div class="table-responsive" data-qs-sticky-first="true">

--- a/templates/partials/_library_card.html
+++ b/templates/partials/_library_card.html
@@ -6,7 +6,7 @@
     role="button">
 
     <h4 class="mb-0 text-white">
-      <i class="bi bi-film text-muted me-2" title="Movie"></i>{{ library.name }}
+      <i class="bi bi-film text-muted me-2" title="Movie"></i>{{ library.name | nbsp_leading_spaces }}
       <span class="small accordion-override-summary ms-2 d-none" data-library-total-summary></span>
     </h4>
     {% set include_checked = data.get('libraries', {}).get(library.id ~ '-library') %}
@@ -48,7 +48,7 @@
     role="button">
 
     <h4 class="mb-0 text-white">
-      <i class="bi bi-tv text-muted me-2" title="TV Show"></i>{{ library.name }}
+      <i class="bi bi-tv text-muted me-2" title="TV Show"></i>{{ library.name | nbsp_leading_spaces }}
       <span class="small accordion-override-summary ms-2 d-none" data-library-total-summary></span>
     </h4>
     {% set include_checked = data.get('libraries', {}).get(library.id ~ '-library') %}

--- a/templates/partials/_library_card.html
+++ b/templates/partials/_library_card.html
@@ -14,9 +14,9 @@
     <div class="d-flex align-items-center gap-2">
       <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
         <input type="hidden" id="{{ library.id }}-library-value" name="{{ library.id }}-library"
-          value="{{ include_checked or '' }}">
+          value="{{ 'true' if include_checked else '' }}">
         <input class="form-check-input include-library-toggle" type="checkbox" id="{{ library.id }}-include"
-          data-target-input="{{ library.id }}-library-value" value="{{ library.name }}"
+          data-target-input="{{ library.id }}-library-value" value="true"
           {% if include_checked %}checked{% endif %}>
         <label class="form-check-label small text-white-50 mb-0" for="{{ library.id }}-include"
           title="Controls whether this library is written to the final config and validated.">Include in config</label>
@@ -56,9 +56,9 @@
     <div class="d-flex align-items-center gap-2">
       <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
         <input type="hidden" id="{{ library.id }}-library-value" name="{{ library.id }}-library"
-          value="{{ include_checked or '' }}">
+          value="{{ 'true' if include_checked else '' }}">
         <input class="form-check-input include-library-toggle" type="checkbox" id="{{ library.id }}-include"
-          data-target-input="{{ library.id }}-library-value" value="{{ library.name }}"
+          data-target-input="{{ library.id }}-library-value" value="true"
           {% if include_checked %}checked{% endif %}>
         <label class="form-check-label small text-white-50 mb-0" for="{{ library.id }}-include"
           title="Controls whether this library is written to the final config and validated.">Include in config</label>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4379,17 +4379,18 @@ def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):
             return [FakeUser()]
 
     class FakeSection:
-        def __init__(self, title, section_type):
+        def __init__(self, title, section_type, key=1):
             self.title = title
             self.type = section_type
+            self.key = key
 
     class FakeLibrary:
         def sections(self):
             calls["sections"] += 1
             return [
-                FakeSection("Movies", "movie"),
-                FakeSection("Shows", "show"),
-                FakeSection("Music", "artist"),
+                FakeSection("Movies", "movie", key=1),
+                FakeSection("Shows", "show", key=2),
+                FakeSection("Music", "artist", key=3),
             ]
 
     class FakePlex:
@@ -4414,9 +4415,9 @@ def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):
 
     payload = resp.get_json()
     assert payload["validated"] is True
-    assert payload["movie_libraries"] == ["Movies"]
-    assert payload["show_libraries"] == ["Shows"]
-    assert payload["music_libraries"] == ["Music"]
+    assert payload["movie_libraries"] == [{"id": 1, "name": "Movies"}]
+    assert payload["show_libraries"] == [{"id": 2, "name": "Shows"}]
+    assert payload["music_libraries"] == [{"id": 3, "name": "Music"}]
     assert calls["sections"] == 1
 
 

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -91,7 +91,7 @@ def test_prepare_import_payload_maps_playlist_files_to_library_toggles():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-library"] == "true"
     assert libraries["mov-library_movies-playlist"] == "true"
     assert "playlist_files" not in payload
     assert any("libraries.Movies.playlist_files" in line for line in report.lines)
@@ -113,9 +113,9 @@ def test_prepare_import_payload_accepts_comma_separated_playlist_libraries():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-library"] == "true"
     assert libraries["mov-library_movies-playlist"] == "true"
-    assert libraries["mov-library_tvshows-library"] == "TV Shows"
+    assert libraries["mov-library_tvshows-library"] == "true"
     assert libraries["mov-library_tvshows-playlist"] == "true"
     assert any("playlist_files[0].template_variables.libraries" in line for line in report.lines)
 
@@ -156,7 +156,7 @@ def test_prepare_import_payload_maps_playlist_template_variables_into_libraries_
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-library"] == "true"
     assert libraries["mov-library_movies-playlist"] == "true"
     assert libraries["playlist-template_variables[sync_to_users]"] == "alice, bob"
     assert libraries["playlist-template_variables[delete_playlist]"] is True

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -20,7 +20,7 @@ def test_prepare_import_payload_maps_library_radarr_overrides():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-library"] == "true"
     assert libraries["mov-library_movies-attribute_radarr_url"] == "http://radarr.local:7878"
     assert libraries["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
     assert libraries["mov-library_movies-attribute_radarr_search"] == "true"
@@ -45,7 +45,7 @@ libraries:
     payload, report = importer.prepare_import_payload(config_data, {"Movies"}, set())
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-library"] == "true"
     assert libraries["mov-library_movies-attribute_radarr_url"] == "http://radarr.local:7878"
     assert libraries["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
     assert libraries["mov-library_movies-attribute_radarr_search"] == "true"
@@ -72,7 +72,7 @@ def test_prepare_import_payload_maps_library_sonarr_overrides():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["sho-library_shows-library"] == "Shows"
+    assert libraries["sho-library_shows-library"] == "true"
     assert libraries["sho-library_shows-attribute_sonarr_url"] == "http://sonarr.local:8989"
     assert libraries["sho-library_shows-attribute_sonarr_language_profile"] == "English"
     assert libraries["sho-library_shows-attribute_sonarr_monitor"] == "future"

--- a/tests/test_vite_manifest.py
+++ b/tests/test_vite_manifest.py
@@ -36,6 +36,8 @@ from modules.helpers._vite_manifest import (
     _load_manifest,
     asset_url,
     reload_manifest,
+    vite_dev_mode,
+    vite_dev_origin,
 )
 
 # ---------------------------------------------------------------------------
@@ -276,6 +278,80 @@ class TestManifestCaching:
 
 
 # ---------------------------------------------------------------------------
+# vite_dev_mode / vite_dev_origin
+# ---------------------------------------------------------------------------
+
+
+class TestViteDevMode:
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("QS_VITE_DEV", raising=False)
+        assert vite_dev_mode() is False
+
+    def test_enabled_by_1(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        assert vite_dev_mode() is True
+
+    def test_enabled_by_true(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "true")
+        assert vite_dev_mode() is True
+
+    def test_disabled_by_0(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "0")
+        assert vite_dev_mode() is False
+
+    def test_disabled_by_false(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "false")
+        assert vite_dev_mode() is False
+
+
+class TestViteDevOrigin:
+    def test_returns_empty_when_not_in_dev_mode(self, monkeypatch):
+        monkeypatch.delenv("QS_VITE_DEV", raising=False)
+        assert vite_dev_origin() == ""
+
+    def test_returns_default_origin_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.delenv("QS_VITE_DEV_HOST", raising=False)
+        monkeypatch.delenv("QS_VITE_DEV_PORT", raising=False)
+        assert vite_dev_origin() == "http://localhost:5173"
+
+    def test_respects_custom_port(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.delenv("QS_VITE_DEV_HOST", raising=False)
+        monkeypatch.setenv("QS_VITE_DEV_PORT", "3000")
+        assert vite_dev_origin() == "http://localhost:3000"
+
+    def test_respects_custom_host(self, monkeypatch):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.setenv("QS_VITE_DEV_HOST", "10.10.10.11")
+        monkeypatch.delenv("QS_VITE_DEV_PORT", raising=False)
+        assert vite_dev_origin() == "http://10.10.10.11:5173"
+
+
+class TestAssetUrlDevMode:
+    def test_returns_vite_url_in_dev_mode(self, monkeypatch, fake_manifest):
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        monkeypatch.delenv("QS_VITE_DEV_PORT", raising=False)
+        assert asset_url("010-plex") == "http://localhost:5173/static/local-js/010-plex.js"
+
+    def test_dev_mode_bypasses_manifest(self, monkeypatch, fake_manifest):
+        """When QS_VITE_DEV is set, the manifest is never consulted."""
+        monkeypatch.setenv("QS_VITE_DEV", "1")
+        _touch_dist_file("010-plex-abc.js")
+        fake_manifest.write_text(json.dumps({"static/local-js/010-plex.js": {"file": "010-plex-abc.js", "isEntry": True}}))
+        url = asset_url("010-plex")
+        assert url.startswith("http://localhost:"), url
+        assert "dist" not in url
+
+    def test_dev_mode_off_still_uses_manifest(self, monkeypatch, fake_manifest):
+        monkeypatch.setenv("QS_VITE_DEV", "0")
+        _touch_dist_file("010-plex-abc.js")
+        fake_manifest.write_text(json.dumps({"static/local-js/010-plex.js": {"file": "010-plex-abc.js", "isEntry": True}}))
+        reload_manifest()
+        assert asset_url("010-plex") == "/static/dist/010-plex-abc.js"
+
+
+# ---------------------------------------------------------------------------
 # Package re-export contract
 # ---------------------------------------------------------------------------
 
@@ -299,6 +375,18 @@ class TestPackageExports:
 
         assert hasattr(helpers, "reload_manifest")
         assert helpers.reload_manifest is reload_manifest
+
+    def test_vite_dev_mode_is_reexported_from_helpers(self):
+        from modules import helpers
+
+        assert hasattr(helpers, "vite_dev_mode")
+        assert helpers.vite_dev_mode is vite_dev_mode
+
+    def test_vite_dev_origin_is_reexported_from_helpers(self):
+        from modules import helpers
+
+        assert hasattr(helpers, "vite_dev_origin")
+        assert helpers.vite_dev_origin is vite_dev_origin
 
 
 # ---------------------------------------------------------------------------

--- a/vite.config.js
+++ b/vite.config.js
@@ -127,6 +127,7 @@ export default defineConfig({
     sourcemap: true
   },
   server: {
+    host: '0.0.0.0',
     port: 5173,
     strictPort: false,
     // Surface stack traces in the terminal in dev so refactor-time errors


### PR DESCRIPTION
## Related Issues

Addresses #1680 

## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)

## Description

Replaces name-based library identity with Plex integer section IDs throughout Quickstart. This fixes a class of bugs where libraries with identical or whitespace-differing names (e.g. `Movies`, ` Movies `, `Movies `) were silently conflated or not found.

**Core refactor:**
- Plex section `.key` (integer) is now the canonical library identifier stored in settings. Display names are read from Plex at validation time and stored in `tmp_library_names` (`010-plex` settings) as `{id_str: display_name}`.
- `-library` hidden inputs store `"true"` (included) or `""` (excluded) instead of the library name. Display names are always looked up from `tmp_library_names` via section ID.
- `get_library_metadata()` is keyed by `str(section.key)` with `"name"` in each value dict.
- `get_library_summaries()` accepts `{id_str: display_name}` and looks up by section ID.
- Config output (`output_yaml_header.py`, `quickstart.py`) builds an ID→name map from `plex_name_map` for the header and library summary comments.

**Library names with spaces:**
- YAML config section headers preserve quote characters that are part of library names (e.g. `" Movies "` stays quoted in the header).
- Library name columns in the Plex Information table, library card titles, and the Preparation table all use `nbsp_leading_spaces` (EM SPACE U+2003) so leading/trailing spaces survive HTML rendering.

**Preparation table fixes:**
- `get_progress_library_list` now looks up display names from `plex_name_map` (via section ID) instead of using the stored `-library` value (which is now `"true"`).
- `build_incomplete_progress_snapshot` no longer strips authoritative names from `plex_name_map` or YAML config keys.
- `match_library_name` now tries exact string equality before fuzzy normalization, so libraries differing only in whitespace are correctly distinguished.
- Both server-rendered and JS-rendered Preparation table rows apply `nbsp_leading_spaces` for visible leading/trailing spaces.

**Other fixes:**
- `BASE_DIR` uses `os.path.abspath()` to collapse `../../` in displayed paths.
- DB migration (`migrate_library_keys_to_plex_ids`) converts stored name-keyed library settings to section-ID-keyed on first load.

**Tested on:** Local Install (Linux via `python quickstart.py`) with a Plex server containing libraries named `Movies`, ` Movies `, `Movies `, ` Movies `, `Movies L`, `Movies L-T`, `" Movies "`, `' Movies '`.