### PR TITLE
improve settings message and telated dependencies

### DIFF
--- a/modules/workspace_status.py
+++ b/modules/workspace_status.py
@@ -144,29 +144,17 @@ def _build_workspace_app_readiness_from_status(config_name, workspace_status, te
             href=_step_href(blocker_key),
             target_step=blocker_key,
         )
-    elif final_gate.get("stage") == "freshness":
+    else:
+        detail = "Open Kometa to validate, review, download, prepare, or run this config."
+        if install_context.get("kometa_is_external_install"):
+            detail = "Open Kometa to validate, review, download, and sync this config for your external Kometa install."
         kometa.update(
-            state="review",
-            summary="Validation refresh recommended",
-            detail=f"Open Kometa to refresh bulk validation before running. Quickstart expects validation within the last {QS_FINAL_VALIDATION_TTL_HOURS} hours, but the app itself is still available.",
+            state="ready",
+            summary="Ready",
+            detail=detail,
             action_label="Open Kometa",
             href=_step_href("900-kometa"),
             target_step="900-kometa",
-        )
-    elif install_context.get("kometa_can_launch"):
-        kometa.update(
-            state="ready",
-            summary="Ready in Quickstart",
-            detail="Open Kometa to prepare the runtime if needed, then review or run this config.",
-        )
-    elif install_context.get("kometa_can_sync_config"):
-        detail = "Open Kometa to review and sync this config."
-        if install_context.get("kometa_is_external_install"):
-            detail = "Open Kometa to review and sync this config for your external Kometa install."
-        kometa.update(
-            state="review",
-            summary="Config ready",
-            detail=detail,
         )
 
     imagemaid_settings, imagemaid_section = _get_imagemaid_settings_section(config_name)

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -2318,8 +2318,8 @@ function applyDynamicValidationCalloutState (alert, isConfiguredOverride = null)
   if (heading && !isReview) {
     heading.innerHTML = `<b>${
       isConfigured
-        ? (isRequired ? 'This required page is configured' : 'This optional page is configured')
-        : (isRequired ? 'This page is mandatory and must be completed' : 'This page is optional')
+        ? (isRequired ? 'This required page passed validation' : 'This optional page is configured')
+        : (isRequired ? 'This required page needs validation' : 'This page is optional')
     }</b>`
   }
 

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -51,9 +51,9 @@
                   </span>
                 </div>
                 {% if kometa_ready %}
-                <p class="small text-muted mb-3">This config is valid for Kometa. Open the final Kometa page when you want to validate, review, download, or generate output.  You can also launch Kometa depending on the mode selected below.</p>
+                <p class="small text-muted mb-3">This config has a saved, valid Kometa workflow choice. Open Kometa when you want to validate, review, download, prepare, or run it.</p>
                 {% else %}
-                <p class="small text-muted mb-3">Plex, TMDb, libraries, or final validation still need attention before this config is fully ready for Kometa.</p>
+                <p class="small text-muted mb-3">Save a valid Kometa install ownership choice and finish required setup before this workflow is ready.</p>
                 {% endif %}
                 <div class="border rounded p-3 mb-3" id="start-kometa-install-settings"
                   data-install-mode="{{ page_info.kometa_install_mode }}"

--- a/templates/modals/150-settings.html
+++ b/templates/modals/150-settings.html
@@ -1,7 +1,8 @@
 <div class="alert alert-warning qs-validation-callout" role="alert">
-  <h6><b>This page should be reviewed</b></h6>
-  Navigating away from this page will accept these settings. Alternatively, since default values were selected on your behalf, you should go through each
-  section and modify settings accordingly.
+  <h6><b>Settings validation</b></h6>
+  Settings is required. Quickstart marks this page green only after the current values pass validation.
+  Navigating away validates the current settings first; if they pass, the saved defaults or changes are accepted.
+  Review each section when you want to customize the generated config.
   <br><br><a href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/config/settings/" target="_blank">Click
     Here</a> to go to the Kometa wiki for the Settings attributes.
 </div>

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -589,7 +589,7 @@ def test_workspace_app_readiness_imagemaid_missing_plex_points_to_plex(monkeypat
     assert payload["imagemaid"]["target_step"] == "010-plex"
 
 
-def test_workspace_app_readiness_kometa_freshness_keeps_app_available(monkeypatch, qs_module, workspace_status_module):
+def test_workspace_app_readiness_kometa_freshness_stays_ready(monkeypatch, qs_module, workspace_status_module):
     monkeypatch.setattr(qs_module.helpers, "get_menu_list", _template_list)
     monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
     monkeypatch.setattr(workspace_status_module, "_build_workspace_status_context", lambda *_args, **_kwargs: {"readiness": {}})
@@ -611,9 +611,10 @@ def test_workspace_app_readiness_kometa_freshness_keeps_app_available(monkeypatc
 
     payload = qs_module._build_workspace_app_readiness("cfg")
 
-    assert payload["kometa"]["state"] == "review"
-    assert payload["kometa"]["summary"] == "Validation refresh recommended"
+    assert payload["kometa"]["state"] == "ready"
+    assert payload["kometa"]["summary"] == "Ready"
     assert payload["kometa"]["action_label"] == "Open Kometa"
+    assert payload["kometa"]["href"] == "/step/900-kometa"
 
 
 def test_workspace_status_context_aligns_app_steps_with_app_readiness(monkeypatch, qs_module, workspace_status_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR clarifies Quickstart app readiness semantics and Settings validation messaging.

## Changes

- Treat Kometa workflow readiness as valid once required setup is complete and the Kometa install ownership choice is saved/valid.
- Stop downgrading Kometa app readiness to a yellow/review state just because bulk validation freshness is stale.
- Keep Kometa runtime install/update/validation freshness concerns on the Kometa run page instead of the Start page/sidebar readiness state.
- Update Start page copy to distinguish “workflow is ready” from “runtime may still need review/prep.”
- Update Settings guidance so users understand that navigating away validates the current Settings values first.
- Rename required-page guidance from “configured/mandatory” language to clearer validation language:
  - `This required page passed validation`
  - `This required page needs validation`
- Update workspace readiness tests for the new behavior.

## Validation

- `venv\Scripts\python.exe -m pytest tests\test_workspace_dependency_logic.py`
- `npx eslint static\local-js\000-base.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1693 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
