### PR TITLE
fix: replace pull_request_target CI with a safe pull_request orchestrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-# PR CI Orchestrator -- single entry point for all PR checks against develop, replaces validate-pull.yml.
-# See docs/quickstart-ci-redesign-plan.md (in the "Kometa issues and Dev" project) for the design rationale.
+# PR CI Orchestrator -- replaces validate-pull.yml; see quickstart-ci-redesign-plan.md for the design rationale.
 name: CI
 
 on:
@@ -20,10 +19,7 @@ jobs:
       contains(fromJSON('["build","build-full"]'), github.event.label.name)
     steps:
       - name: Check Base Branch
-        # Decision point: this fails loudly rather than auto-closing the PR (the old job used an App token
-        # + `gh pr close`, which isn't available here since fork PRs get no secrets under `pull_request`).
-        # If auto-close is wanted, add a tiny separate `pull_request_target` workflow that only calls the
-        # close API and never checks out code.
+        # Fails loudly instead of auto-closing (no App token available for fork PRs under pull_request); add a separate pull_request_target close-only workflow later if auto-close matters.
         if: github.base_ref == 'master'
         run: |
           echo "ERROR: Pull Requests cannot be submitted to master. Please submit the Pull Request to the develop branch."
@@ -64,16 +60,13 @@ jobs:
               fi
           done
 
-      # Markdown spellcheck is NOT duplicated here -- the pyspelling pre-commit hook in lint.yml already
-      # covers *.md on every pull_request, including locally via `pre-commit run`.
+      # Markdown spellcheck isn't duplicated here -- the pyspelling pre-commit hook in lint.yml already covers *.md on every pull_request.
 
   tests:
     needs: [guard]
     uses: ./.github/workflows/test.yml
 
-  # Computes the shared build identity (tag name, PART-equivalent, commit message) once, on the runner,
-  # never committed back to the branch. Gated here so docker-build and build-executable don't each
-  # re-implement the same gate and risk drifting apart.
+  # Computes the shared build identity once so docker-build and build-executable don't each re-implement the same gate and drift apart.
   build-vars:
     runs-on: ubuntu-latest
     needs: [validate, tests]
@@ -203,9 +196,7 @@ jobs:
           name: ${{ steps.build-executable.outputs.filename }}
           path: dist/${{ steps.build-executable.outputs.filename }}
 
-      # Written to a per-OS artifact instead of a shared job-outputs map -- the old add-links job read
-      # windows/ubuntu/macos keys off one outputs map shared across all three matrix legs, and whichever
-      # leg finished last could blank the other two links. This avoids that race entirely.
+      # Per-OS artifact instead of a shared job-outputs map -- avoids the race where the last-finishing matrix leg blanks the other links.
       - name: Save link file
         shell: bash
         env:
@@ -282,8 +273,7 @@ jobs:
           author: ${{ vars.DOCKER_NAME }}
           author_icon_url: ${{ vars.DOCKER_IMAGE }}
 
-  # Single stable context for branch protection -- immune to job renames inside test.yml, and
-  # guard/validate/tests skips (from the label filter above) count as pass, not pending.
+  # Single stable context for branch protection -- immune to job renames inside test.yml; skipped jobs count as pass, not pending.
   ci-status:
     runs-on: ubuntu-latest
     needs: [guard, validate, tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,300 @@
+# PR CI Orchestrator -- single entry point for all PR checks against develop, replaces validate-pull.yml.
+# See docs/quickstart-ci-redesign-plan.md (in the "Kometa issues and Dev" project) for the design rationale.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event.action == 'synchronize' || github.event.action == 'opened' }}
+
+jobs:
+
+  guard:
+    runs-on: ubuntu-latest
+    # Irrelevant label events (anything but build/build-full) skip the whole DAG instead of re-running everything.
+    if: >-
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      contains(fromJSON('["build","build-full"]'), github.event.label.name)
+    steps:
+      - name: Check Base Branch
+        # Decision point: this fails loudly rather than auto-closing the PR (the old job used an App token
+        # + `gh pr close`, which isn't available here since fork PRs get no secrets under `pull_request`).
+        # If auto-close is wanted, add a tiny separate `pull_request_target` workflow that only calls the
+        # close API and never checks out code.
+        if: github.base_ref == 'master'
+        run: |
+          echo "ERROR: Pull Requests cannot be submitted to master. Please submit the Pull Request to the develop branch."
+          exit 1
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: [guard]
+    # Read-only: this job only diffs filenames, no secrets needed.
+    permissions:
+      contents: read
+    outputs:
+      build: ${{ steps.list-changes.outputs.build }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Get changes
+        id: get-changes
+        # HEAD^1 is the base tip on the PR's auto-generated merge commit, so this is always the full PR-vs-base diff.
+        run: |
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          git diff --name-only HEAD^1 HEAD >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: List changed files
+        id: list-changes
+        run: |
+          readarray -t files <<< "${{ steps.get-changes.outputs.files }}"
+          for file in "${files[@]}"; do
+              if [[ -n "$file" ]] && [[ "$file" =~ ^(modules|static|templates|quickstart.py|requirements.txt|.dockerignore|Dockerfile).*$ ]]; then
+                  echo "$file will trigger a build"
+                  echo "build=true" >> $GITHUB_OUTPUT
+              else
+                  echo "$file will not trigger a build"
+              fi
+          done
+
+      # Markdown spellcheck is NOT duplicated here -- the pyspelling pre-commit hook in lint.yml already
+      # covers *.md on every pull_request, including locally via `pre-commit run`.
+
+  tests:
+    needs: [guard]
+    uses: ./.github/workflows/test.yml
+
+  # Computes the shared build identity (tag name, PART-equivalent, commit message) once, on the runner,
+  # never committed back to the branch. Gated here so docker-build and build-executable don't each
+  # re-implement the same gate and risk drifting apart.
+  build-vars:
+    runs-on: ubuntu-latest
+    needs: [validate, tests]
+    if: >-
+      needs.validate.outputs.build == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (contains(github.event.pull_request.labels.*.name, 'build') ||
+       contains(github.event.pull_request.labels.*.name, 'build-full'))
+    outputs:
+      tag-name: ${{ steps.vars.outputs.tag-name }}
+      part-value: ${{ steps.vars.outputs.part-value }}
+      commit-msg: ${{ steps.vars.outputs.commit-msg }}
+      extra-text: ${{ steps.vars.outputs.extra-text }}
+      full-build: ${{ steps.vars.outputs.full-build }}
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v7
+
+      - name: Compute build variables
+        id: vars
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          COMMITS: ${{ github.event.pull_request.commits }}
+          FULL_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'build-full') }}
+        run: |
+          branch_name="${GITHUB_HEAD_REF}"
+          branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          repo_name="${HEAD_REPO}"
+          base_name="${repo_name%/*}"
+          if [[ "${branch_name}" =~ ^(master|develop)$ ]]; then
+              tag_name="${base_name}"
+          else
+              tag_name="${branch_name}"
+          fi
+          echo "tag-name=${tag_name}" >> $GITHUB_OUTPUT
+
+          if [[ "${base_name}" == "Kometa-Team" ]]; then
+              extra=""
+          else
+              extra=" from the ${HEAD_REPO} repo"
+          fi
+          echo "extra-text=${extra}" >> $GITHUB_OUTPUT
+
+          old_msg=$(git log -1 HEAD --pretty=format:%s)
+          echo "commit-msg=${old_msg}" >> $GITHUB_OUTPUT
+
+          # Stable integer proxy for "which push is this" -- replaces the old committed PART file.
+          echo "part-value=${COMMITS}" >> $GITHUB_OUTPUT
+          echo "full-build=${FULL_BUILD}" >> $GITHUB_OUTPUT
+
+  docker-build:
+    name: Docker
+    needs: [build-vars]
+    uses: ./.github/workflows/docker-build.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      branch: ${{ github.event.pull_request.head.sha }}
+      branch_name: ${{ needs.build-vars.outputs.tag-name }}
+      tag_name: ${{ needs.build-vars.outputs.tag-name }}
+      full_build: ${{ needs.build-vars.outputs.full-build == 'true' }}
+
+  build-executable:
+    name: Build ${{ matrix.os_upper }} Executable
+    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
+    needs: [build-vars]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: 'windows'
+            os_upper: 'Windows'
+            os_version: 'latest'
+            ext: '.exe'
+          - os: 'ubuntu'
+            os_upper: 'Linux'
+            os_version: 'latest'
+            ext: ''
+          - os: 'macos'
+            os_upper: 'MacOS'
+            os_version: '13'
+            ext: ''
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Build JS Bundles
+        run: |
+          npm ci --no-fund --no-audit
+          npm run build
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install Requirements
+        run: pip install -r requirements.txt pyinstaller
+
+      - name: Build Executable
+        id: build-executable
+        shell: bash
+        env:
+          TAG_NAME: ${{ needs.build-vars.outputs.tag-name }}
+          PART: ${{ needs.build-vars.outputs.part-value }}
+          EXT: ${{ matrix.ext }}
+        run: |
+          version="$(cat VERSION)-build$(cat BUILDNUM)"
+          filename="Quickstart-v${version}.${TAG_NAME}${PART}-${RUNNER_OS}${EXT}"
+          echo "filename=${filename}" >> $GITHUB_OUTPUT
+          pyinstaller -y ./quickstart.spec -- --branch pull --build "${RUNNER_OS}"
+          mv "dist/Quickstart${EXT}" "dist/${filename}"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        id: artifact-upload-step
+        with:
+          name: ${{ steps.build-executable.outputs.filename }}
+          path: dist/${{ steps.build-executable.outputs.filename }}
+
+      # Written to a per-OS artifact instead of a shared job-outputs map -- the old add-links job read
+      # windows/ubuntu/macos keys off one outputs map shared across all three matrix legs, and whichever
+      # leg finished last could blank the other two links. This avoids that race entirely.
+      - name: Save link file
+        shell: bash
+        env:
+          FILENAME: ${{ steps.build-executable.outputs.filename }}
+          ARTIFACT_URL: ${{ steps.artifact-upload-step.outputs.artifact-url }}
+        run: echo "[${FILENAME}](${ARTIFACT_URL})" > "link-${{ matrix.os }}.txt"
+
+      - name: Upload link file
+        uses: actions/upload-artifact@v7
+        with:
+          name: link-${{ matrix.os }}
+          path: link-${{ matrix.os }}.txt
+
+  add-links:
+    name: Add Links to PR
+    runs-on: ubuntu-latest
+    needs: [build-vars, docker-build, build-executable]
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_TOKEN }}
+
+      - name: Download link artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: link-*
+          path: links
+          merge-multiple: true
+
+      - name: Generate Body
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BODY_RAW: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DOCKER_TEAM: ${{ vars.DOCKER_TEAM }}
+          DOCKER_REPO: ${{ vars.DOCKER_REPO }}
+          TAG_NAME: ${{ needs.build-vars.outputs.tag-name }}
+        run: |
+          WIN_LINK=$(cat links/link-windows.txt 2>/dev/null || echo "unavailable")
+          UBUNTU_LINK=$(cat links/link-ubuntu.txt 2>/dev/null || echo "unavailable")
+          MACOS_LINK=$(cat links/link-macos.txt 2>/dev/null || echo "unavailable")
+
+          PR_BODY=$(echo "$PR_BODY_RAW" | sed -z 's/\n## Executables.*//')
+          PR_BODY+=$'\n\n## Executables'
+          PR_BODY+=$'\n\n**'"$WIN_LINK"'**'
+          PR_BODY+=$'\n\n**'"$UBUNTU_LINK"'**'
+          PR_BODY+=$'\n\n**'"$MACOS_LINK"'**'
+          PR_BODY+=$'\n\n## Docker Image'
+          PR_BODY+=$'\n\n**`'"$DOCKER_TEAM"'/'"$DOCKER_REPO"':'"$TAG_NAME"'`**'
+
+          gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+
+  failure-notification:
+    name: Failure Notification
+    runs-on: ubuntu-latest
+    needs: [tests, build-vars, docker-build, build-executable, add-links]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Discord Failure Notification
+        uses: Kometa-Team/discord-notifications@master
+        with:
+          webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
+          message: "QS Broke Needs Fix"
+          title: "${{ vars.NAME }} ${{ needs.build-vars.outputs.tag-name }}: ${{ vars.TEXT_FAILURE }}"
+          url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
+          color: ${{ vars.COLOR_FAILURE }}
+          username: ${{ vars.BOT_NAME }}
+          avatar_url: ${{ vars.BOT_IMAGE }}
+          author: ${{ vars.DOCKER_NAME }}
+          author_icon_url: ${{ vars.DOCKER_IMAGE }}
+
+  # Single stable context for branch protection -- immune to job renames inside test.yml, and
+  # guard/validate/tests skips (from the label filter above) count as pass, not pending.
+  ci-status:
+    runs-on: ubuntu-latest
+    needs: [guard, validate, tests]
+    if: always()
+    steps:
+      - name: Check required jobs
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "$results" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          failed=$(echo "$results" | jq '[.[] | select(.result != "success" and .result != "skipped")] | length')
+          if [ "$failed" -gt 0 ]; then
+            echo "One or more required jobs did not succeed."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,8 @@ jobs:
     name: Failure Notification
     runs-on: ubuntu-latest
     needs: [tests, build-vars, docker-build, build-executable, add-links]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    # Same-repo only -- fork PRs get no secrets under pull_request, so BUILD_WEBHOOK is unset there and this would just fail; fork-branch test failures also aren't a "page the team" event.
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Discord Failure Notification
         uses: Kometa-Team/discord-notifications@master

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -93,7 +93,6 @@ jobs:
           version=$(cat VERSION)
           build_value=$(cat BUILDNUM)
           next_build_value="$((${build_value} + 1))"
-          part_value=$(cat PART)
 
           old_msg=$(git log -1 HEAD --pretty=format:%s)
           new_msg="[${next_build_value}] ${old_msg}"
@@ -109,8 +108,25 @@ jobs:
           git config --local user.name "GitHub Action"
           git add BUILDNUM
           git add PART
-          git commit -m "${new_msg}" --amend
-          git push origin develop --force-with-lease
+
+          # Plain commit + push, not --amend/--force-with-lease -- concurrency group increment-build-develop already serializes runs, so a normal push is safe; retry loop is just a safety net.
+          git commit -m "${new_msg}"
+
+          push_ok=false
+          for attempt in 1 2 3; do
+            if git push origin develop; then
+              push_ok=true
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); fetching and rebasing before retry."
+            git fetch origin develop
+            git rebase origin/develop
+          done
+
+          if [ "$push_ok" != "true" ]; then
+            echo "::error::Could not push the build-number commit to develop after 3 attempts."
+            exit 1
+          fi
 
           hash=$(git rev-parse HEAD)
           echo "$hash"

--- a/.github/workflows/promote-fork-pr.yml
+++ b/.github/workflows/promote-fork-pr.yml
@@ -1,0 +1,253 @@
+name: Promote Fork PR
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: promote-fork-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    name: Create or update internal PR
+
+    # Fork PRs only, gated on the approval label; this job never checks out or executes fork code, only git fetch/push of commit objects and GitHub API calls.
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'internal-test')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Do not use context.actor/sender here -- on synchronize that's the PR author, not the labeler -- so check the timeline for who last applied internal-test instead.
+      - name: Verify a maintainer applied the current internal-test label
+        id: permission
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const events = await github.paginate(
+              github.rest.issues.listEvents,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+
+            const labelEvents = events.filter(
+              e => e.event === 'labeled' && e.label && e.label.name === 'internal-test'
+            );
+
+            if (labelEvents.length === 0) {
+              core.setFailed('No "labeled: internal-test" event found in PR timeline.');
+              return;
+            }
+
+            const lastLabelEvent = labelEvents[labelEvents.length - 1];
+            const labeler = lastLabelEvent.actor && lastLabelEvent.actor.login;
+
+            if (!labeler) {
+              core.setFailed('Could not determine who applied the internal-test label.');
+              return;
+            }
+
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: labeler
+            });
+
+            const allowed = ['admin', 'maintain', 'write'];
+
+            if (!allowed.includes(data.permission)) {
+              core.setFailed(
+                `Most recent internal-test label was applied by ${labeler}, ` +
+                `who has '${data.permission}' permission; write permission is ` +
+                `required to promote a fork PR.`
+              );
+              return;
+            }
+
+            core.notice(`internal-test label was applied by ${labeler} (${data.permission}) -- OK to promote.`);
+
+      # Use the GitHub App token, not GITHUB_TOKEN, so the created PR/push actually triggers downstream workflows.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_TOKEN }}
+
+      # This checks out only the trusted base repository/default branch.
+      - name: Check out trusted base repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Copy fork PR commit to internal branch
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Fetch via the base repo's own refs/pull/<N>/head -- no need to add the fork as a remote.
+          git fetch --no-tags origin \
+            "pull/${PR_NUMBER}/head:refs/remotes/origin/fork-pr-${PR_NUMBER}"
+
+          FETCHED_SHA="$(git rev-parse "refs/remotes/origin/fork-pr-${PR_NUMBER}")"
+
+          # Guard against the PR changing mid-flight: fetched SHA must match the SHA that triggered this run.
+          if [[ "${FETCHED_SHA}" != "${PR_HEAD_SHA}" ]]; then
+            echo "::error::PR changed while the promotion workflow was running."
+            echo "::error::Expected ${PR_HEAD_SHA}, fetched ${FETCHED_SHA}."
+            exit 1
+          fi
+
+          # Copy the commit object only -- never checked out or executed.
+          git push --force origin \
+            "${FETCHED_SHA}:refs/heads/${INTERNAL_BRANCH}"
+
+      - name: Create or update internal pull request
+        uses: actions/github-script@v9
+        env:
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+          SOURCE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_PR_TITLE: ${{ github.event.pull_request.title }}
+          SOURCE_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          SOURCE_PR_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = process.env.INTERNAL_BRANCH;
+            const sourceNumber = process.env.SOURCE_PR_NUMBER;
+
+            const title = `[Promoted #${sourceNumber}] ${process.env.SOURCE_PR_TITLE}`;
+
+            const body = [
+              `Automated internal copy of #${sourceNumber}.`,
+              ``,
+              `Original author: @${process.env.SOURCE_PR_AUTHOR}`,
+              `Copied commit: \`${process.env.SOURCE_PR_SHA}\``,
+              ``,
+              `This branch is force-updated when the original fork PR changes`,
+              `and a maintainer keeps the \`internal-test\` label applied.`,
+              ``,
+              `The \`build\`/\`build-full\` label is NOT copied automatically --`,
+              `a maintainer must re-add it here after reviewing this exact`,
+              `commit before a build with secrets will run.`,
+              ``,
+              `Do not merge this PR instead of the original contributor PR.`
+            ].join("\n");
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner, repo, state: "open",
+              head: `${owner}:${head}`, base: "develop"
+            });
+
+            if (existing.length > 0) {
+              await github.rest.pulls.update({
+                owner, repo, pull_number: existing[0].number, title, body
+              });
+              core.notice(`Updated internal PR #${existing[0].number}`);
+            } else {
+              const { data: created } = await github.rest.pulls.create({
+                owner, repo, head, base: "develop", title, body, draft: true
+              });
+              core.notice(`Created internal PR #${created.number}`);
+            }
+
+      - name: Comment on source pull request
+        uses: actions/github-script@v9
+        env:
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner, repo, state: "open",
+              head: `${owner}:${process.env.INTERNAL_BRANCH}`, base: "develop"
+            });
+
+            if (pulls.length === 0) {
+              core.setFailed("Internal pull request could not be located.");
+              return;
+            }
+
+            const marker = "<!-- quickstart-internal-test-pr -->";
+            const body = [
+              marker,
+              `Internal testing PR: #${pulls[0].number}`,
+              ``,
+              `This PR tracks commit \`${context.payload.pull_request.head.sha}\`.`
+            ].join("\n");
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: context.issue.number, per_page: 100 }
+            );
+
+            const existing = comments.find(
+              c => c.user?.type === "Bot" && c.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: context.issue.number, body });
+            }
+
+  cleanup:
+    name: Remove internal testing branch
+
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_TOKEN }}
+
+      - name: Delete internal branch
+        uses: actions/github-script@v9
+        env:
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${process.env.INTERNAL_BRANCH}`
+              });
+            } catch (error) {
+              if (error.status === 422 || error.status === 404) {
+                core.notice("Internal branch did not exist or was already deleted.");
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,4 @@
-# ─────────────────────────────────────────────────────────────────────────────
-# Testing
-#
-# Called as a job (workflow_call) from ci.yml for PRs targeting develop; also
-# runs standalone on push to develop for post-merge validation.
-#
-# Single job for now -- Quickstart has no schema/pyright/imports surface yet
-# to justify Kometa's seven-stage split. Extend here if/when that changes.
-# ─────────────────────────────────────────────────────────────────────────────
+# Reusable test workflow: called by ci.yml for PRs and runs on push to develop; single job for now since Quickstart has no schema/pyright surface yet to justify more stages.
 name: Tests
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,13 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
+      # config/kometa/defaults is gitignored and normally populated by installing Kometa locally; this mirrors the app's nightly-branch default so the contract tests have real data to check.
+      - name: Fetch Kometa defaults for contract tests
+        run: |
+          git clone --depth 1 --filter=blob:none --sparse --branch nightly https://github.com/Kometa-Team/Kometa.git /tmp/kometa-defaults
+          git -C /tmp/kometa-defaults sparse-checkout set defaults
+          mkdir -p config/kometa
+          cp -r /tmp/kometa-defaults/defaults config/kometa/defaults
+
       - name: Run Tests
         run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Testing
+#
+# Called as a job (workflow_call) from ci.yml for PRs targeting develop; also
+# runs standalone on push to develop for post-merge validation.
+#
+# Single job for now -- Quickstart has no schema/pyright/imports surface yet
+# to justify Kometa's seven-stage split. Extend here if/when that changes.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Tests
+
+on:
+  workflow_call:
+  push:
+    branches: [develop]
+
+env:
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  test:
+    name: Run Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set Up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache pip
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-test-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: ${{ runner.os }}-pip-test-
+
+      - name: Install Dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run Tests
+        run: python -m pytest

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -1,10 +1,6 @@
 name: Validate Pull Request
 
-# Disabled as an automatic trigger during the ci.yml rollout (see the "Decisions" section of
-# quickstart-ci-redesign-plan.md) -- this ran on pull_request_target and executed fork PR code
-# with repo secrets, which is what ci.yml + promote-fork-pr.yml replace. Left as workflow_dispatch
-# only, runnable manually as a rollback path, until ci.yml has been green on a handful of real PRs.
-# Delete this whole file once that's confirmed.
+# Disabled: trigger changed to workflow_dispatch during the ci.yml rollout (see quickstart-ci-redesign-plan.md); kept as a manual rollback path until ci.yml is proven, then delete.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -1,8 +1,12 @@
 name: Validate Pull Request
 
+# Disabled as an automatic trigger during the ci.yml rollout (see the "Decisions" section of
+# quickstart-ci-redesign-plan.md) -- this ran on pull_request_target and executed fork PR code
+# with repo secrets, which is what ci.yml + promote-fork-pr.yml replace. Left as workflow_dispatch
+# only, runnable manually as a rollback path, until ci.yml has been green on a handful of real PRs.
+# Delete this whole file once that's confirmed.
 on:
-  pull_request_target:
-    types: [ opened, synchronize, reopened, labeled ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Related Issues

Refs #1728, #1731, #1739, #1740, #1741

## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Replaces `validate-pull.yml`'s `pull_request_target` trigger with a `pull_request` based CI orchestrator (`ci.yml`). This closes the fork PR code execution hole that #1728 tried to patch in place and broke doing so (reverted in #1731, patched forward with #1739/#1740/#1741 as a stopgap, not a real fix). Under `pull_request_target`, `validate-pull.yml` checked out a fork's head ref while carrying the base repo's full secrets and an App token with write access. `actions/checkout@v7` now refuses that outright as a security protection, which is what surfaced the problem on this PR's own first run.

Adds three new workflow files, based on Kometa's own CI redesign and adapted for Quickstart's develop/master branches and PyInstaller executable builds.

`ci.yml` is the orchestrator. `guard` blocks PRs targeting `master`. `validate` checks which files changed. `tests` calls the new `test.yml`. `build-vars` computes a build identity (tag name, build number) and only runs for same-repo PRs with the `build` or `build-full` label. `docker-build` and `build-executable` run from there, followed by `add-links` and a same-repo-only `failure-notification`. `ci-status` is the single required check.

`test.yml` is the pytest run, pulled out as a reusable workflow.

`promote-fork-pr.yml` is the safe path for fork PRs that genuinely need a secrets-backed build. A maintainer applies the `internal-test` label. The workflow checks the PR timeline (not just who triggered the run) to confirm a maintainer with write access applied it, then copies the commit itself, never checks it out, into an `automation/fork-pr-<n>` branch and opens a draft PR against `develop` for review before any build labels are reapplied there.

Also fixes `increment-build.yml`, which did `git commit --amend` and `git push --force-with-lease` to `develop` on every merge, rewriting the just-merged commit on a shared branch. It now adds the `BUILDNUM`/`PART` bump as a normal commit with a plain push, relying on the workflow's existing concurrency lock instead of a force-push.

`validate-pull.yml` is left in place but disabled (trigger changed to `workflow_dispatch` only) as a manual rollback option. It can be deleted once `ci.yml` has run cleanly on a handful of real PRs.

Branch protection has already been updated to match. The `Pull Request Validation` ruleset required the `Validate Changes` check, which can no longer pass for any fork PR. Swapped for `ci-status`.

Design decisions (test scope, executable build label gating, GitHub App permission check, when to retire the `approved` label, rollout order) were worked through with @YozoraXCII before this was opened.

Two pytest failures (`test_collection_seasonal_contract.py`, `test_collection_streaming_contract.py`) showed up once tests could actually finish running in CI. They read from `config/kometa/defaults/...`, which is gitignored and only exists after running the app locally, so they've likely never passed in a clean checkout. This is unrelated to this PR and has been flagged separately to @bullmoose20 ref #1614/#1615.

Tested: `ci.yml`'s `guard`, `validate`, and `tests` jobs pass on this PR. `build-vars`, `docker-build`, `build-executable`, and `add-links` correctly skip, since this is a fork PR without secrets, which is the intended behavior. `promote-fork-pr.yml` hasn't been tested end to end yet and is worth a separate throwaway fork PR once this merges.