### PR TITLE
fix: disable old pull_request_target validate-pull.yml on master too

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -1,8 +1,8 @@
 name: Validate Pull Request
 
+# Disabled: workflow_dispatch is a placeholder to keep this file registered, not a working trigger (pull_request is undefined here). Rollback = restore pull_request_target below, then delete once ci.yml is proven.
 on:
-  pull_request_target:
-    types: [ opened, synchronize, reopened, labeled ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Related Issues

Refs #1742

## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

`pull_request_target` reads its workflow definition from the repo's default branch, which for Quickstart is `master`, not from the PR's base branch. #1742 disabled `validate-pull.yml`'s `pull_request_target` trigger on `develop`, but that never took effect for `pull_request_target` events, since `master` still had the original file.

Confirmed this live on #1738. The old workflow's `Format Code and Add Part File` job ran and pushed an unrequested `Part` bump commit straight to that contributor's branch, using the App token with write access, the exact behaviour this whole change is meant to stop.

This applies the same one-line fix used in #1742 to `master`. `validate-pull.yml`'s trigger changes from `pull_request_target` to `workflow_dispatch`, and the comment is updated to make clear that `workflow_dispatch` here is a placeholder to keep the file registered, not a working manual trigger (`github.event.pull_request` is undefined for `workflow_dispatch`). A real rollback means restoring the `pull_request_target` trigger, not running this via the Actions tab.