### PR TITLE
chore: add missing module docstrings to iso.py and assets.py

### DIFF
--- a/modules/assets.py
+++ b/modules/assets.py
@@ -1,3 +1,5 @@
+"""Filesystem paths and folder setup for uploaded, default, and cached library asset images."""
+
 import os
 
 from flask import has_request_context, session

--- a/modules/iso.py
+++ b/modules/iso.py
@@ -1,3 +1,5 @@
+"""ISO country, language, and IETF tag lookups sourced from the datasets/*-codes GitHub CSVs."""
+
 import csv
 import io
 


### PR DESCRIPTION
## Related Issues

N/A

## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [x] Other

## Description

No functional change. Adds a one-line module docstring to `modules/iso.py` and `modules/assets.py`, both of which previously had none. Purely additive documentation, nothing else touched.

This is deliberately a same-repo, `modules/`-path PR carrying the `build` label, so it exercises the same build-trigger path as #1722: `validate` sets `build=true`, `build-vars` runs, and `docker-build` plus `build-executable` should actually complete. Meant as a clean end-to-end confirmation of the `ci.yml` pipeline now that #1742 and the `master` hotfix are both in, since neither #1738 nor #1722 has made it past `tests` yet due to their own unrelated `pytest.ini` issue.



(This is just here to test on-branch PR's)