### PR TITLE
Add missing module docstrings to iso.py and assets.py

### DIFF
--- a/modules/assets.py
+++ b/modules/assets.py
@@ -1,3 +1,5 @@
+"""Filesystem paths and folder setup for uploaded, default, and cached library asset images."""
+
 import os
 
 from flask import has_request_context, session

--- a/modules/iso.py
+++ b/modules/iso.py
@@ -1,3 +1,5 @@
+"""ISO country, language, and IETF tag lookups sourced from the datasets/*-codes GitHub CSVs."""
+
 import csv
 import io
 


### PR DESCRIPTION
## Related Issues

N/A

## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [x] Other

## Description

Same no-op change as the companion same-repo PR (adds a one-line module docstring to `modules/iso.py` and `modules/assets.py`, both previously undocumented), opened from a fork this time on purpose.

This one carries the `build` label too, deliberately, to prove the fork-vs-same-repo gate itself, not just the label gate: `build-vars` should still skip here even with `build` applied, since `github.event.pull_request.head.repo.full_name == github.repository` is false for a fork PR. If it skips, that confirms the safety gate is doing real work and not just relying on nobody labelling fork PRs. `guard`, `validate`, and `tests` should still run and pass.