### PR TITLE
Add hash-based log ingestion deduplication

### DIFF
--- a/modules/logscan_cache.py
+++ b/modules/logscan_cache.py
@@ -215,11 +215,7 @@ def get_logscan_delta_files(log_dir=None, include_archive=True):
 
     ingest_cache = quickstart._load_logscan_ingest_cache()
     cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
-    known_md5s = {
-        entry.get("content_md5")
-        for entry in cache_logs.values()
-        if isinstance(entry, dict) and entry.get("content_md5")
-    }
+    known_md5s = {entry.get("content_md5") for entry in cache_logs.values() if isinstance(entry, dict) and entry.get("content_md5")}
     candidates = []
     for path in get_logscan_log_files(log_dir=log_dir, include_archive=include_archive):
         cache_entry = cache_logs.get(str(path.resolve()), {})

--- a/modules/logscan_cache.py
+++ b/modules/logscan_cache.py
@@ -1,3 +1,5 @@
+import gzip
+import hashlib
 import json
 import re
 from datetime import datetime, timezone
@@ -7,6 +9,35 @@ from modules import helpers
 from modules.process_control import is_logscan_maintenance_sidecar
 
 _is_logscan_gzip_path = helpers.is_logscan_gzip_path
+
+
+def calculate_logscan_file_md5(path, chunk_size=1024 * 1024):
+    """Return an MD5 for the logical log bytes, decompressing gzip archives."""
+    path = Path(path)
+    opener = gzip.open if _is_logscan_gzip_path(path) else open
+    try:
+        digest = hashlib.md5(usedforsecurity=False)
+    except TypeError:  # pragma: no cover - compatibility with older Python builds
+        digest = hashlib.md5()
+    try:
+        with opener(path, "rb") as handle:
+            while chunk := handle.read(chunk_size):
+                digest.update(chunk)
+    except Exception:
+        return None
+    return digest.hexdigest()
+
+
+def find_logscan_cache_entry_by_md5(cache_logs, content_md5, exclude_path=None):
+    if not content_md5 or not isinstance(cache_logs, dict):
+        return None, None
+    excluded = str(Path(exclude_path).resolve()) if exclude_path else None
+    for cache_key, entry in cache_logs.items():
+        if cache_key == excluded or not isinstance(entry, dict):
+            continue
+        if entry.get("content_md5") == content_md5:
+            return cache_key, entry
+    return None, None
 
 
 def get_logscan_cache_dir():
@@ -166,6 +197,9 @@ def logscan_cache_entry_matches(path, cache_entry=None, stats=None, require_comp
         stats = stats or Path(path).stat()
     except Exception:
         return False
+    cached_md5 = cache_entry.get("content_md5")
+    if cached_md5:
+        return calculate_logscan_file_md5(path) == cached_md5
     cached_mtime = cache_entry.get("mtime")
     cached_size = cache_entry.get("size")
     try:
@@ -181,11 +215,22 @@ def get_logscan_delta_files(log_dir=None, include_archive=True):
 
     ingest_cache = quickstart._load_logscan_ingest_cache()
     cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    known_md5s = {
+        entry.get("content_md5")
+        for entry in cache_logs.values()
+        if isinstance(entry, dict) and entry.get("content_md5")
+    }
     candidates = []
     for path in get_logscan_log_files(log_dir=log_dir, include_archive=include_archive):
         cache_entry = cache_logs.get(str(path.resolve()), {})
-        if not logscan_cache_entry_matches(path, cache_entry=cache_entry):
-            candidates.append(path)
+        if logscan_cache_entry_matches(path, cache_entry=cache_entry):
+            continue
+        content_md5 = calculate_logscan_file_md5(path)
+        if content_md5 and content_md5 in known_md5s:
+            continue
+        candidates.append(path)
+        if content_md5:
+            known_md5s.add(content_md5)
 
     def _mtime_desc(value):
         try:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = .
 testpaths = tests
 norecursedirs = .git .venv venv config config/kometa config/kometa/kometa-venv
 addopts = -q -m "not e2e"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-pythonpath = .
 testpaths = tests
 norecursedirs = .git .venv venv config config/kometa config/kometa/kometa-venv
 addopts = -q -m "not e2e"

--- a/quickstart.py
+++ b/quickstart.py
@@ -255,6 +255,8 @@ from modules.logscan_cache import (
     build_logscan_archive_destination as _build_logscan_archive_destination,
     iter_logscan_candidate_files as _iter_logscan_candidate_files,
     get_logscan_log_files as _get_logscan_log_files,
+    calculate_logscan_file_md5 as _calculate_logscan_file_md5,
+    find_logscan_cache_entry_by_md5 as _find_logscan_cache_entry_by_md5,
     logscan_cache_entry_matches as _logscan_cache_entry_matches,
     get_logscan_delta_files as _get_logscan_delta_files,
     classify_logscan_file_location as _classify_logscan_file_location,
@@ -1719,7 +1721,7 @@ def _delete_logscan_run_artifact(run_key):
     if not run_record and not incomplete_run:
         return False, {"error": "Run not found.", "run_key": run_key}, 404
     target_run = run_record if run_record else incomplete_run
-    info = _resolve_logscan_run_log_info(run_key, run_record=target_run)
+    info = _resolve_logscan_run_archive_action_info(run_key) or _resolve_logscan_run_log_info(run_key, run_record=target_run)
     if not info or not info.get("path"):
         return False, {"error": "Archived log file for this run could not be found.", "run_key": run_key}, 404
     if info.get("location") != "archive":
@@ -1735,7 +1737,9 @@ def _delete_logscan_run_artifact(run_key):
 
     if run_record:
         database.delete_log_run(run_key)
-    _remove_logscan_ingest_cache_entries(run_key=run_key, raw_path=str(Path(info["path"]).resolve()))
+    # A copied live meta.log must remain hashed after its archive artifact is
+    # deleted, otherwise the next analytics refresh would ingest it again.
+    _remove_logscan_ingest_cache_entries(raw_path=str(Path(info["path"]).resolve()))
     return (
         True,
         {
@@ -4927,6 +4931,18 @@ def _ingest_completed_live_logs(tool_name="kometa", log_dir=None):
             cached_entry = cache_logs.get(cache_key, {})
             if _logscan_cache_entry_matches(path, cache_entry=cached_entry, stats=stats):
                 continue
+            content_md5 = _calculate_logscan_file_md5(path)
+            _duplicate_key, duplicate_entry = _find_logscan_cache_entry_by_md5(cache_logs, content_md5, exclude_path=path)
+            if duplicate_entry:
+                cache_logs[cache_key] = {
+                    **duplicate_entry,
+                    "mtime": stats.st_mtime,
+                    "size": stats.st_size,
+                    "content_md5": content_md5,
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+                cache_dirty = True
+                continue
 
             content = _read_logscan_text(path, encoding="utf-8", errors="replace")
             if tool_name == "imagemaid":
@@ -4958,6 +4974,7 @@ def _ingest_completed_live_logs(tool_name="kometa", log_dir=None):
                 cache_logs[cache_key] = {
                     "mtime": stats.st_mtime,
                     "size": stats.st_size,
+                    "content_md5": content_md5,
                     "run_key": summary.get("run_key"),
                     "tool_name": tool_name,
                     "run_complete": False,
@@ -4983,6 +5000,7 @@ def _ingest_completed_live_logs(tool_name="kometa", log_dir=None):
             cache_logs[cache_key] = {
                 "mtime": stats.st_mtime,
                 "size": stats.st_size,
+                "content_md5": content_md5,
                 "run_key": summary.get("run_key"),
                 "tool_name": tool_name,
                 "run_complete": True,
@@ -4997,10 +5015,12 @@ def _ingest_completed_live_logs(tool_name="kometa", log_dir=None):
             if archived_path:
                 try:
                     archived_stats = archived_path.stat()
-                    cache_logs.pop(cache_key, None)
+                    if not path.exists():
+                        cache_logs.pop(cache_key, None)
                     cache_logs[str(archived_path.resolve())] = {
                         "mtime": archived_stats.st_mtime,
                         "size": archived_stats.st_size,
+                        "content_md5": content_md5,
                         "run_key": summary.get("run_key"),
                         "tool_name": tool_name,
                         "run_complete": True,
@@ -5048,16 +5068,19 @@ def _archive_log_file(path, archive_dir, log_dir=None, allow_live_meta=False):
         src_stats = path.stat()
         should_compress = not _is_logscan_gzip_path(path)
         preferred_suffix = ".log.gz" if should_compress else None
+        copy_source = path.name.lower() == "meta.log" and log_dir and path.resolve().parent == Path(log_dir).resolve()
         dest = _build_logscan_archive_destination(path, archive_dir, stats=src_stats, preferred_suffix=preferred_suffix)
         if dest.exists():
-            path.unlink()
+            if not copy_source:
+                path.unlink()
             return dest
         if should_compress:
             try:
                 with path.open("rb") as source, gzip.open(dest, "wb") as target:
                     shutil.copyfileobj(source, target)
                 os.utime(dest, (src_stats.st_atime, src_stats.st_mtime))
-                path.unlink()
+                if not copy_source:
+                    path.unlink()
             except Exception:
                 try:
                     if dest.exists():
@@ -5105,6 +5128,13 @@ def _archive_finished_live_meta_log_if_idle(log_dir=None):
     if not live_entry.get("run_key"):
         return None
 
+    content_md5 = _calculate_logscan_file_md5(live_path)
+    existing_archive_key, _existing_archive_entry = _find_logscan_cache_entry_by_md5(cache_logs, content_md5, exclude_path=live_path)
+    if existing_archive_key:
+        existing_archive_path = Path(existing_archive_key)
+        if existing_archive_path.exists() and _classify_logscan_file_location(existing_archive_path) == "archive":
+            return existing_archive_path
+
     archive_dir = _get_logscan_archive_dir()
     archived_path = _archive_log_file(live_path, archive_dir, log_dir=log_dir, allow_live_meta=True)
     if not archived_path:
@@ -5119,8 +5149,10 @@ def _archive_finished_live_meta_log_if_idle(log_dir=None):
     updated_entry = dict(live_entry)
     updated_entry["mtime"] = archived_stats.st_mtime
     updated_entry["size"] = archived_stats.st_size
+    updated_entry["content_md5"] = content_md5
     updated_entry["updated_at"] = datetime.now(timezone.utc).isoformat()
-    cache_logs.pop(live_key, None)
+    live_entry["content_md5"] = content_md5
+    cache_logs[live_key] = live_entry
     cache_logs[archived_key] = updated_entry
     ingest_cache["logs"] = cache_logs
     _save_logscan_ingest_cache(ingest_cache)
@@ -5323,6 +5355,30 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                 cache_key = str(path.resolve())
                 cached_entry = cache_logs.get(cache_key, {})
                 cached_run_key = cached_entry.get("run_key")
+                content_md5 = _calculate_logscan_file_md5(path)
+                _duplicate_key, duplicate_entry = _find_logscan_cache_entry_by_md5(cache_logs, content_md5, exclude_path=path)
+                if duplicate_entry:
+                    cache_logs[cache_key] = {
+                        **duplicate_entry,
+                        "mtime": stats.st_mtime,
+                        "size": stats.st_size,
+                        "content_md5": content_md5,
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    cache_dirty = True
+                    duplicates += 1
+                    if update_state:
+                        _update_logscan_reingest_state(
+                            scanned=idx,
+                            ingested=ingested,
+                            duplicates=duplicates,
+                            skipped_incomplete=skipped_incomplete,
+                            skipped_invalid=skipped_invalid,
+                            errors=errors,
+                        )
+                    if idx % LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL == 0:
+                        _flush_ingest_cache_progress(force=True)
+                    continue
                 skip_save_if_cached = cached_entry.get("run_complete") is True and cached_run_key
                 tool_name = _detect_logscan_tool_from_path(path, log_dir=kometa_log_dir)
                 live_dir = _get_logscan_live_dir(tool_name, log_dir=kometa_log_dir if tool_name == "kometa" else None)
@@ -5381,6 +5437,7 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                     cache_logs[cache_key] = {
                         "mtime": stats.st_mtime,
                         "size": stats.st_size,
+                        "content_md5": content_md5,
                         "run_key": summary.get("run_key"),
                         "tool_name": tool_name,
                         "run_complete": False,
@@ -5462,6 +5519,7 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                 cache_logs[cache_key] = {
                     "mtime": stats.st_mtime,
                     "size": stats.st_size,
+                    "content_md5": content_md5,
                     "run_key": summary.get("run_key"),
                     "tool_name": tool_name,
                     "run_complete": True,
@@ -5480,6 +5538,7 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                             cache_logs[str(archived_path.resolve())] = {
                                 "mtime": archived_stats.st_mtime,
                                 "size": archived_stats.st_size,
+                                "content_md5": content_md5,
                                 "run_key": summary.get("run_key"),
                                 "tool_name": tool_name,
                                 "run_complete": True,

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -661,6 +661,48 @@ def test_logscan_trends_log_delete_removes_archived_log_and_run(client, isolated
     assert qs_module.database.get_log_run("run-delete-1") is None
 
 
+def test_logscan_trends_log_delete_keeps_live_copy_hash_cached(client, isolated_config_dir, monkeypatch, qs_module):
+    log_dir = isolated_config_dir / "kometa" / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    live_path = log_dir / "meta.log"
+    archived_path = archive_dir / "meta-delete-copy.log.gz"
+    content = b"copied complete run\n"
+    live_path.write_bytes(content)
+    with gzip.open(archived_path, "wb") as handle:
+        handle.write(content)
+    content_md5 = qs_module._calculate_logscan_file_md5(live_path)
+    stats = archived_path.stat()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-delete-copy-1",
+            "finished_at": "2026-04-23T11:00:00Z",
+            "config_name": "cleanup",
+            "created_at": "2026-04-23T11:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    cache = {
+        "version": 1,
+        "logs": {
+            str(live_path.resolve()): {"run_key": "run-delete-copy-1", "run_complete": True, "content_md5": content_md5},
+            str(archived_path.resolve()): {"run_key": "run-delete-copy-1", "run_complete": True, "content_md5": content_md5},
+        },
+    }
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: copy.deepcopy(cache))
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda value: (cache.clear(), cache.update(copy.deepcopy(value))))
+
+    resp = client.post("/logscan/trends/log/delete", json={"run_key": "run-delete-copy-1"})
+
+    assert resp.status_code == 200
+    assert live_path.exists()
+    assert not archived_path.exists()
+    assert str(live_path.resolve()) in cache["logs"]
+    assert str(archived_path.resolve()) not in cache["logs"]
+
+
 def test_logscan_trends_log_compress_compresses_archived_log_and_updates_cache(client, isolated_config_dir, monkeypatch, qs_module):
     archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
     archive_dir.mkdir(parents=True, exist_ok=True)
@@ -799,7 +841,7 @@ def test_archive_log_file_uses_canonical_timestamp_size_name(isolated_config_dir
         assert handle.read() == "abc123\n"
 
 
-def test_archive_finished_live_meta_log_if_idle_moves_live_file_and_cache(isolated_config_dir, monkeypatch, qs_module):
+def test_archive_finished_live_meta_log_if_idle_copies_live_file_and_caches_hash(isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     log_dir = kometa_root / "config" / "logs"
     archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa"
@@ -831,12 +873,29 @@ def test_archive_finished_live_meta_log_if_idle_moves_live_file_and_cache(isolat
     assert archived is not None
     assert archived.exists()
     assert archived.parent == archive_dir
-    assert not live_path.exists()
+    assert live_path.exists()
     saved_cache = saved["cache"]
-    assert str(live_path.resolve()) not in saved_cache["logs"]
+    assert str(live_path.resolve()) in saved_cache["logs"]
     assert str(archived.resolve()) in saved_cache["logs"]
     assert saved_cache["logs"][str(archived.resolve())]["run_key"] == "run-live-finished-1"
+    assert saved_cache["logs"][str(live_path.resolve())]["content_md5"] == saved_cache["logs"][str(archived.resolve())]["content_md5"]
     assert archived.suffixes[-2:] == [".log", ".gz"]
+
+    archived_again = qs_module._archive_finished_live_meta_log_if_idle(log_dir=log_dir)
+
+    assert archived_again == archived
+    assert len(list(archive_dir.glob("*.log.gz"))) == 1
+
+
+def test_logscan_md5_matches_live_and_compressed_copy(isolated_config_dir, qs_module):
+    live_path = isolated_config_dir / "meta.log"
+    archived_path = isolated_config_dir / "meta-copy.log.gz"
+    content = b"same logical log bytes\n"
+    live_path.write_bytes(content)
+    with gzip.open(archived_path, "wb") as handle:
+        handle.write(content)
+
+    assert qs_module._calculate_logscan_file_md5(live_path) == qs_module._calculate_logscan_file_md5(archived_path)
 
 
 def test_classify_rotated_log_in_live_dir_as_archive(isolated_config_dir, qs_module):
@@ -1325,7 +1384,7 @@ def test_logscan_reingest_flushes_ingest_cache_incrementally(isolated_config_dir
     log_files = []
     for idx in range(qs_module.LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL + 1):
         path = log_dir / f"meta-{idx:02d}.log"
-        path.write_text("finished run\n", encoding="utf-8")
+        path.write_text(f"finished run {idx}\n", encoding="utf-8")
         log_files.append(path)
 
     cache = {"version": 1, "logs": {}}
@@ -1346,6 +1405,65 @@ def test_logscan_reingest_flushes_ingest_cache_incrementally(isolated_config_dir
     assert result["scanned"] == len(log_files)
     assert save_sizes[0] == qs_module.LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL
     assert save_sizes[-1] == len(log_files)
+
+
+def test_logscan_full_reingest_rebuilds_md5_cache_and_skips_copied_meta_log(isolated_config_dir, monkeypatch, qs_module):
+    class FakeAnalyzer:
+        _people_index = {}
+
+        def __init__(self):
+            self.analyze_calls = 0
+
+        def preload_people_index(self, *_args, **_kwargs):
+            return None
+
+        def analyze_content(self, _content, **_kwargs):
+            self.analyze_calls += 1
+            return {
+                "summary": {
+                    "run_key": "same-run",
+                    "finished_at": "2026-04-30T10:00:00Z",
+                    "run_complete": True,
+                    "tool_name": "kometa",
+                    "created_at": "2026-04-30T10:00:00Z",
+                },
+                "recommendations": [],
+                "missing_people": [],
+            }
+
+        def collect_missing_people_lines(self, *_args, **_kwargs):
+            return []
+
+    log_dir = isolated_config_dir / "kometa" / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    live_path = log_dir / "meta.log"
+    archived_path = archive_dir / "meta-copy.log.gz"
+    content = b"one completed log\n"
+    live_path.write_bytes(content)
+    with gzip.open(archived_path, "wb") as handle:
+        handle.write(content)
+
+    analyzer = FakeAnalyzer()
+    saved = {}
+    monkeypatch.setattr(qs_module.logscan, "LogscanAnalyzer", lambda: analyzer)
+    monkeypatch.setattr(qs_module, "_get_logscan_log_files", lambda *_args, **_kwargs: [live_path, archived_path])
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: {"version": 1, "logs": {}})
+    monkeypatch.setattr(qs_module, "_clear_logscan_ingest_cache", lambda: None)
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda payload: saved.update(copy.deepcopy(payload)))
+    monkeypatch.setattr(qs_module, "_build_completed_log_progress_snapshot", lambda **_kwargs: {})
+    monkeypatch.setattr(qs_module.database, "clear_log_runs", lambda: True)
+    monkeypatch.setattr(qs_module.database, "save_log_run", lambda *_args, **_kwargs: True)
+
+    result = qs_module._perform_logscan_reingest(reset=True, update_state=False)
+
+    assert result["success"] is True
+    assert result["scanned"] == 2
+    assert result["ingested"] == 1
+    assert result["duplicates"] == 1
+    assert analyzer.analyze_calls == 1
+    assert saved["logs"][str(live_path.resolve())]["content_md5"] == saved["logs"][str(archived_path.resolve())]["content_md5"]
 
 
 def test_logscan_reingest_archives_incomplete_rotated_live_log(client, isolated_config_dir, monkeypatch, qs_module):
@@ -1998,6 +2116,56 @@ def test_ingest_completed_live_logs_caches_unchanged_incomplete_live_kometa_log(
     second = qs_module._ingest_completed_live_logs("kometa")
     assert second == {"ingested": 0, "archived": 0}
     assert analyze_calls["count"] == 1
+
+
+def test_ingest_completed_live_meta_log_copies_once_and_preserves_source(isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = isolated_config_dir / "kometa"
+    log_dir = kometa_root / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    runtime_log = log_dir / "meta.log"
+    runtime_log.write_text("completed live log\n", encoding="utf-8")
+
+    cache = {"version": 1, "logs": {}}
+    analyze_calls = {"count": 0}
+
+    class _CompleteAnalyzer:
+        def analyze_content(self, _content, **_kwargs):
+            analyze_calls["count"] += 1
+            return {
+                "summary": {
+                    "run_key": "run-complete-live-1",
+                    "tool_name": "kometa",
+                    "run_complete": True,
+                    "finished_at": "2026-04-30T18:00:00Z",
+                },
+                "recommendations": [],
+            }
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module, "_get_logscan_archive_dir", lambda *_args, **_kwargs: archive_dir)
+    monkeypatch.setattr(qs_module, "_flush_quickstart_pending_markers", lambda *_args, **_kwargs: {"flushed": True})
+    monkeypatch.setattr(qs_module, "_build_completed_log_progress_snapshot", lambda **_kwargs: {})
+    monkeypatch.setattr(qs_module.logscan, "LogscanAnalyzer", _CompleteAnalyzer)
+    monkeypatch.setattr(qs_module.database, "save_log_run", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: copy.deepcopy(cache))
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda value: (cache.clear(), cache.update(copy.deepcopy(value))))
+    monkeypatch.setattr(qs_module, "_prune_logscan_archive", lambda *_args, **_kwargs: 0)
+
+    first = qs_module._ingest_completed_live_logs("kometa")
+    second = qs_module._ingest_completed_live_logs("kometa")
+
+    archived_paths = list(archive_dir.glob("*.log.gz"))
+    assert first == {"ingested": 1, "archived": 1}
+    assert second == {"ingested": 0, "archived": 0}
+    assert analyze_calls["count"] == 1
+    assert runtime_log.exists()
+    assert len(archived_paths) == 1
+    live_entry = cache["logs"][str(runtime_log.resolve())]
+    archive_entry = cache["logs"][str(archived_paths[0].resolve())]
+    assert live_entry["content_md5"] == archive_entry["content_md5"]
 
 
 def test_logscan_reingest_reset_false_scans_only_delta_files(client, isolated_config_dir, monkeypatch, qs_module):

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -2118,14 +2118,15 @@ def test_ingest_completed_live_logs_caches_unchanged_incomplete_live_kometa_log(
     assert analyze_calls["count"] == 1
 
 
-def test_ingest_completed_live_meta_log_copies_once_and_preserves_source(isolated_config_dir, monkeypatch, qs_module):
+def test_completed_recovery_log_remains_downloadable_after_archive(client, isolated_config_dir, monkeypatch, qs_module):
     kometa_root = isolated_config_dir / "kometa"
     log_dir = kometa_root / "config" / "logs"
     archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa"
     log_dir.mkdir(parents=True, exist_ok=True)
     archive_dir.mkdir(parents=True, exist_ok=True)
     runtime_log = log_dir / "meta.log"
-    runtime_log.write_text("completed live log\n", encoding="utf-8")
+    log_content = "completed recovery log\n"
+    runtime_log.write_text(log_content, encoding="utf-8")
 
     cache = {"version": 1, "logs": {}}
     analyze_calls = {"count": 0}
@@ -2139,11 +2140,13 @@ def test_ingest_completed_live_meta_log_copies_once_and_preserves_source(isolate
                     "tool_name": "kometa",
                     "run_complete": True,
                     "finished_at": "2026-04-30T18:00:00Z",
+                    "start_mode": "recovery",
                 },
                 "recommendations": [],
             }
 
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module, "_get_logscan_archive_dir", lambda *_args, **_kwargs: archive_dir)
     monkeypatch.setattr(qs_module, "_flush_quickstart_pending_markers", lambda *_args, **_kwargs: {"flushed": True})
@@ -2166,6 +2169,13 @@ def test_ingest_completed_live_meta_log_copies_once_and_preserves_source(isolate
     live_entry = cache["logs"][str(runtime_log.resolve())]
     archive_entry = cache["logs"][str(archived_paths[0].resolve())]
     assert live_entry["content_md5"] == archive_entry["content_md5"]
+
+    download = client.get("/tail-log?size=all&download=1")
+
+    assert download.status_code == 200
+    assert download.mimetype == "text/plain"
+    assert download.data.decode("utf-8") == log_content
+    assert download.headers["Content-Disposition"].startswith("attachment; filename=meta.log")
 
 
 def test_logscan_reingest_reset_false_scans_only_delta_files(client, isolated_config_dir, monkeypatch, qs_module):


### PR DESCRIPTION
## Related Issues

Closes #1717

## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Preserves the live `meta.log` when archiving a completed run by creating a compressed archive copy instead of moving the source file. Adds logical-content MD5 hashes for plain and gzip logs so live/archive copies are deduplicated during normal ingestion, delta scans, and full reingestion. Cache cleanup retains the live-copy hash when an archive artifact is deleted.

Automated coverage was added for copied live logs, gzip/plain hash equivalence, full-reingest deduplication, repeated archive attempts, and archive deletion behavior.

## Which Environment Did You Test On?

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other