### PR TITLE
Add Floppy token visibility toggle

### DIFF
--- a/static/local-js/067-floppy.js
+++ b/static/local-js/067-floppy.js
@@ -9,6 +9,8 @@ createApiKeyValidator({
   optionalFieldIds: floppyTokenRequired ? [] : ['floppy_token'],
   validatedFieldId: 'floppy_validated',
   validatedAtFieldId: 'floppy_validated_at',
+  toggleButtonId: 'toggleFloppyTokenVisibility',
+  toggleFieldId: 'floppy_token',
   endpoint: '/validate_floppy',
   maskPrimaryField: false,
   buildPayload: (url, extras) => ({

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -75,6 +75,8 @@ const DEFAULT_MESSAGES = {
  * @param {string} config.validatedFieldId       Element id of the hidden "<service>_validated" input.
  * @param {string} [config.validatedAtFieldId]   Element id of the hidden "<service>_validated_at" timestamp input.
  * @param {string} [config.toggleButtonId='toggleApikeyVisibility']  Id of the show/hide toggle button.
+ * @param {string} [config.toggleFieldId]        Optional non-primary secret field controlled by the toggle.
+ *                                               Defaults to fieldId when omitted.
  * @param {string} [config.validateButtonId='validateButton']        Id of the validate button.
  * @param {string} [config.statusMessageId='statusMessage']          Id of the status callout element.
  * @param {string} [config.formId='configForm']                      Id of the wrapping form (for submit reset).
@@ -134,6 +136,7 @@ export function createApiKeyValidator (config) {
     validatedFieldId,
     validatedAtFieldId,
     toggleButtonId = 'toggleApikeyVisibility',
+    toggleFieldId,
     validateButtonId = 'validateButton',
     statusMessageId = 'statusMessage',
     formId = 'configForm',
@@ -163,6 +166,7 @@ export function createApiKeyValidator (config) {
   const validatedAtInput = validatedAtFieldId ? document.getElementById(validatedAtFieldId) : null
   const validateButton = document.getElementById(validateButtonId)
   const toggleButton = document.getElementById(toggleButtonId)
+  const toggleInput = toggleFieldId ? document.getElementById(toggleFieldId) : apiKeyInput
   const form = document.getElementById(formId)
 
   // If the credential or validate button isn't on the page, this wizard
@@ -190,6 +194,11 @@ export function createApiKeyValidator (config) {
   } else {
     apiKeyInput.setAttribute('type', 'password')
     if (toggleButton) setToggleButtonIcon(toggleButton, false)
+  }
+  if (toggleFieldId && toggleInput) {
+    const showPlainText = toggleInput.value.trim() === ''
+    toggleInput.setAttribute('type', showPlainText ? 'text' : 'password')
+    if (toggleButton) setToggleButtonIcon(toggleButton, showPlainText)
   }
 
   // ── initial button state ────────────────────────────────────────────
@@ -324,10 +333,10 @@ export function createApiKeyValidator (config) {
   }
 
   // ── show/hide toggle for the credential field ───────────────────────
-  if (maskPrimaryField && toggleButton) {
+  if ((maskPrimaryField || toggleFieldId) && toggleButton && toggleInput) {
     toggleButton.addEventListener('click', function () {
-      const currentType = apiKeyInput.getAttribute('type')
-      apiKeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
+      const currentType = toggleInput.getAttribute('type')
+      toggleInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
       setToggleButtonIcon(this, currentType === 'password')
     })
   }

--- a/templates/067-floppy.html
+++ b/templates/067-floppy.html
@@ -23,6 +23,9 @@
   </span>
   <input type="password" class="form-control" id="floppy_token" name="floppy_token"
     value="{{ floppy.get('token', '') or '' }}" autocomplete="off" aria-describedby="floppy_token_text">
+  <button class="btn btn-secondary" id="toggleFloppyTokenVisibility" type="button" aria-label="Show or hide API token">
+    <i class="fas fa-eye"></i>
+  </button>
   <button class="btn btn-success" id="validateButton" type="button">
     Validate <i id="spinner_validate" class="spinner-border spinner-border-sm" style="display:none;"></i>
   </button>

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -154,6 +154,27 @@ describe('createApiKeyValidator initial field state', () => {
     expect(document.getElementById('test_apikey').getAttribute('type')).toBe('text')
   })
 
+  it('can target a non-primary secret field with the visibility toggle', () => {
+    document.body.innerHTML = buildBaseHTML({
+      keyValue: 'https://example.com',
+      extraInputs: '<input id="test_token" type="password" value="secret">'
+    })
+    createApiKeyValidator(defaultConfig({
+      maskPrimaryField: false,
+      toggleFieldId: 'test_token'
+    }))
+
+    const primaryInput = document.getElementById('test_apikey')
+    const tokenInput = document.getElementById('test_token')
+    const toggleButton = document.getElementById('toggleApikeyVisibility')
+    expect(primaryInput.getAttribute('type')).toBe('text')
+    expect(tokenInput.getAttribute('type')).toBe('password')
+
+    toggleButton.click()
+    expect(tokenInput.getAttribute('type')).toBe('text')
+    expect(primaryInput.getAttribute('type')).toBe('text')
+  })
+
   it('treats whitespace-only credential as empty (still password initially, then text)', () => {
     document.body.innerHTML = buildBaseHTML({ keyValue: '   ' })
     createApiKeyValidator(defaultConfig())

--- a/tests/test_floppy_support.py
+++ b/tests/test_floppy_support.py
@@ -95,6 +95,8 @@ def test_floppy_step_renders_configured_url_and_module_script(client):
     assert f'value="{configured_url}"' in page
     assert "floppy.example.com" not in page
     assert 'id="floppy_token"' in page
+    assert 'id="toggleFloppyTokenVisibility"' in page
+    assert 'aria-label="Show or hide API token"' in page
     assert 'src="/static/local-js/067-floppy.js"' in page
     assert 'src="/static/images/service-icons/floppy.png"' in page
 


### PR DESCRIPTION
## Related Issues

N/A

## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds a show/hide visibility button to the Floppy API token field, matching the existing Serializd password experience.

Floppy uses its URL as the validator’s primary field and its API token as a secondary field. The shared credential helper previously supported toggling only the primary field. This change adds an optional `toggleFieldId`, allowing a secondary secret to use the shared visibility behavior without changing Floppy’s public-list validation rules.

The Floppy page now renders an accessible token visibility button, connects it to `floppy_token`, and includes Python and JavaScript regression coverage.

Testing:

- `pytest -q tests/test_floppy_support.py` — 11 passed
- `git diff --check` — passed
- JavaScript tests were not run locally because Node/npm was unavailable.

## Which Environment Did You Test On?

- [X] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [x] Other — automated test suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788580770&installation_model_id=431096&pr_number=1749&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1749&signature=117a17876d844487f0f7827b07e0da4990fd46538e8153dbc5f4d7fcaf8fac11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->