### PR TITLE
Fix default name for config imports

### DIFF
--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -2006,6 +2006,9 @@ document.addEventListener('DOMContentLoaded', function () {
         suggested = selectorValue
       }
       suggested = sanitizeConfigName(suggested)
+      if (suggested && isDuplicateName(suggested)) {
+        suggested = suggestDuplicateName(suggested)
+      }
       importConfigName.value = suggested
       if (!suggested) return
       if (isDuplicateName(suggested)) {

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1270,6 +1270,29 @@ def test_config_workspace_modal_changing_selector_shows_new_config_input(page, l
 
 
 @pytest.mark.e2e
+def test_import_config_modal_suggests_next_available_name(page, live_server):
+    """Import should never prefill the name of an existing config.
+
+    It reuses Duplicate's naming sequence so an active ``example`` config
+    becomes ``example_copy``, or ``example_copy_2`` when the first copy
+    already exists.
+    """
+    source_config = "pytest_import_source"
+    _seed_config(source_config)
+    _seed_config(f"{source_config}_copy")
+    _activate_config(page, live_server, source_config)
+    page.reload(wait_until="domcontentloaded")
+
+    page.locator("#configSelector").select_option(source_config)
+    page.evaluate("""() => {
+        document.getElementById('importConfigModal').dispatchEvent(new Event('show.bs.modal'))
+    }""")
+
+    expect(page.locator("#importConfigName")).to_have_value(f"{source_config}_copy_2")
+    expect(page.locator("#importConfigError")).to_be_hidden()
+
+
+@pytest.mark.e2e
 def test_config_workspace_reset_dispatches_to_clear_session(page, live_server):
     """Clicking the Reset button in the config workspace modal, then
     confirming, should POST to /clear_session with the selected config


### PR DESCRIPTION
## Related Issues

Closes #1702

## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes Import Config pre-filling the currently selected config name and immediately rejecting it as already in use.

When a user opens Import Config without first selecting Add Config, Quickstart now reuses the Duplicate Config naming sequence to propose a valid, unique name automatically. For example, `example` becomes `example_copy`. If that name exists, Quickstart tries `example_copy_2`, then `example_copy_3`, and so on.

A unique name entered through Add Config remains unchanged.

An end-to-end regression test covers importing while an existing config is selected and the first suggested copy name is already occupied.

Testing:

- `pytest -q tests/test_core_backend.py -k 'duplicate_config or import_config'` — 10 passed
- `ruff check tests/e2e/test_wizard_e2e.py` — passed
- `git diff --check` — passed
- The new Playwright browser test was not run locally because Playwright is unavailable in this environment; it is included for CI.

## Which Environment Did You Test On?

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [x] Other — automated test suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788584927&installation_model_id=431096&pr_number=1750&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1750&signature=0bc56a258b1d107cedef613b985a24ae37892417b813540eea0ed9aa30402655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->