### PR TITLE
improved git detection during install

### DIFF
--- a/modules/helpers/_zip_update.py
+++ b/modules/helpers/_zip_update.py
@@ -46,6 +46,40 @@ def _write_text(p: Path, s: str):
     p.write_text(s, encoding="utf-8")
 
 
+def _requirements_file_has_git_dependency(requirements_path: Path) -> bool:
+    try:
+        text = requirements_path.read_text(encoding="utf-8")
+    except Exception:
+        return False
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "git+" in line or line.startswith("git://") or "github.com" in line:
+            return True
+    return False
+
+
+def _ensure_git_available_for_requirements(requirements_path: Path, logs: list[str]) -> bool:
+    if not _requirements_file_has_git_dependency(requirements_path):
+        return True
+
+    git_path = shutil.which("git")
+    if git_path:
+        try:
+            git_version = subprocess.check_output([git_path, "--version"], stderr=subprocess.STDOUT, text=True)
+            logs.append(f"🔧 Detected Git version: {git_version.strip()}")
+        except Exception as e:
+            logs.append(f"⚠️ Git is present but failed to run: {e}")
+        return True
+
+    logs.append("❌ Required tool not found: git")
+    logs.append("❌ Git is required to install Git-based dependencies from requirements.txt.")
+    logs.append("⚠️ Kometa dependencies include a Git-based package. " "Install Git and ensure it is available on PATH before retrying.")
+    return False
+
+
 def _get_upstream_sha(branch: str, logs: list[str], api_url_template: str = GITHUB_API_BRANCH, label: str = "Kometa") -> str | None:
     try:
         url = api_url_template.format(branch=branch)
@@ -320,6 +354,10 @@ def _ensure_venv(kometa_dir: Path, logs: list[str], venv_name: str = "kometa-ven
 
 def _pip_install(python_bin: Path, kometa_dir: Path, logs: list[str], requirements_file: str = "requirements.txt") -> bool:
     is_windows = os.name == "nt"
+    requirements_path = kometa_dir / requirements_file
+
+    if not _ensure_git_available_for_requirements(requirements_path, logs):
+        return False
 
     logs.append("⬆️ Upgrading pip...")
     p = subprocess.run(
@@ -346,7 +384,10 @@ def _pip_install(python_bin: Path, kometa_dir: Path, logs: list[str], requiremen
     if p.stdout.strip():
         logs.append(p.stdout.strip())
     if p.returncode != 0:
-        logs.append((p.stderr or p.stdout or "").strip() or "requirements install failed")
+        stderr = (p.stderr or p.stdout or "").strip()
+        if "Cannot find command 'git'" in stderr or "No such file or directory: 'git'" in stderr:
+            logs.append("❌ Git is required to install Git-based dependencies from requirements.txt.")
+        logs.append(stderr or "requirements install failed")
         return False
 
     return True

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -1,4 +1,5 @@
 import io
+import shutil
 import zipfile
 
 import requests
@@ -556,3 +557,24 @@ def test_perform_kometa_update_zip_only_writes_branch_metadata(tmp_path, monkeyp
     assert result["success"] is True
     assert (kometa_dir / ".kometa_sha").read_text(encoding="utf-8").strip() == "sha123"
     assert (kometa_dir / ".kometa_branch").read_text(encoding="utf-8").strip() == "develop"
+
+
+def test_pip_install_requires_git_for_git_based_requirements(tmp_path, monkeypatch):
+    kometa_dir = tmp_path / "kometa"
+    kometa_dir.mkdir(parents=True, exist_ok=True)
+    requirements_txt = kometa_dir / "requirements.txt"
+    requirements_txt.write_text(
+        "requests==2.34.2\ngit+https://github.com/Velocidensity/serializd-py.git\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(shutil, "which", lambda tool: None if tool == "git" else "/usr/bin/python")
+    logs = []
+
+    from modules.helpers._zip_update import _pip_install
+
+    result = _pip_install(kometa_dir / "python", kometa_dir, logs)
+
+    assert result is False
+    assert any("Required tool not found: git" in line for line in logs)
+    assert any("Git is required to install Git-based dependencies" in line for line in logs)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Reviewing the new regression test and the helper behavior before finalizing the PR description.

Read [](file:///c%3A/Users/bullmoose20/Quickstart/tests/test_update_flows.py#540-540), lines 540 to 581

Running the Kometa update tests to confirm the Git pre-check and regression coverage.

Ran terminal command: .\venv\Scripts\Activate.ps1 ; python -m pytest tests/test_update_flows.py -q

Reading the exact helper function implementation to see why the expected log message is missing.

Read [](file:///c%3A/Users/bullmoose20/Quickstart/modules/helpers/_zip_update.py#40-40), lines 40 to 140

Fixing the regression test expectation by aligning the helper log message with the intended failure wording.

Replacing 7 lines with 8 lines in [](file:///c%3A/Users/bullmoose20/Quickstart/modules/helpers/_zip_update.py)


```

```


Ran terminal command: .\venv\Scripts\Activate.ps1 ; python -m pytest tests/test_update_flows.py -q

## PR Description

### Summary
Add a pre-check for `git` before running `pip install -r requirements.txt` during Kometa zip-based updates.

### What changed
- _zip_update.py
  - Added `_requirements_file_has_git_dependency()` to detect Git-based requirements lines like:
    - `git+https://...`
    - `git://...`
    - any `github.com` URL
  - Added `_ensure_git_available_for_requirements()` to:
    - inspect the extracted Kometa requirements.txt
    - detect whether Git is required
    - fail early with a clear message if `git` is missing
  - Updated `_pip_install()` to call the new check before upgrading pip/installing requirements.

- test_update_flows.py
  - Added regression coverage for `_pip_install()` when requirements.txt contains a Git dependency and `git` is not available.
  - Verifies the helper returns `False` and logs the expected Git-missing failure message.

### Why
The nightly Kometa branch includes:
- `serializd-py @ git+https://github.com/Velocidensity/serializd-py.git`

That means `pip` needs the system `git` CLI to install the package. Quickstart already depends on `GitPython`, but that does not satisfy `pip` for `git+...` installs. This fix prevents a confusing downstream pip failure by checking for `git` first and returning a user-friendly diagnostic.

### Test coverage
- `python -m pytest test_update_flows.py -q`
- Result: `..........................` (all passed)

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788867941&installation_model_id=431096&pr_number=1753&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1753&signature=837845958eeb17b61643874817483d3accc588b013eca476a0bfd32d8c90f8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->