### PR TITLE
added better wording

### DIFF
--- a/templates/partials/_config_workspace_modal.html
+++ b/templates/partials/_config_workspace_modal.html
@@ -107,7 +107,7 @@
 
             <button type="button" class="btn btn-outline-secondary" id="orphanedArtifactsButton" data-bs-toggle="modal"
               data-bs-target="#orphanedArtifactsModal">
-              <i class="bi bi-hdd-stack"></i> Review File Drift
+              <i class="bi bi-hdd-stack"></i> Review Orphaned Config Bundles
             </button>
           </div>
         </div>
@@ -166,7 +166,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="orphanedArtifactsModalLabel">
-          <i class="bi bi-hdd-stack me-2"></i>Review File Drift
+          <i class="bi bi-hdd-stack me-2"></i>Review Orphaned Config Bundles
         </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
@@ -188,7 +188,7 @@
         <div class="small text-muted mt-2">Selected: <span id="orphanedArtifactsCount">0</span></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" id="cancelOrphanedArtifactsDelete" data-bs-dismiss="modal">Keep for now</button>
+        <button type="button" class="btn btn-secondary" id="cancelOrphanedArtifactsDelete" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-danger" id="confirmOrphanedArtifactsDelete" disabled>Delete Selected</button>
       </div>
     </div>

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1293,6 +1293,27 @@ def test_import_config_modal_suggests_next_available_name(page, live_server):
 
 
 @pytest.mark.e2e
+def test_config_workspace_modal_uses_clear_orphaned_bundle_labels(page, live_server):
+    """The orphaned-artifact workflow should use wording that matches the
+    underlying action of reviewing orphaned config bundles on disk.
+    """
+    page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
+
+    page.evaluate("""
+        const modalEl = document.getElementById('configSwitchModal')
+        if (modalEl) {
+            modalEl.classList.add('show')
+            modalEl.style.display = 'block'
+            modalEl.removeAttribute('aria-hidden')
+        }
+    """)
+
+    expect(page.locator("#orphanedArtifactsButton")).to_have_text("Review Orphaned Config Bundles")
+    expect(page.locator("#orphanedArtifactsModalLabel")).to_contain_text("Review Orphaned Config Bundles")
+    expect(page.locator("#cancelOrphanedArtifactsDelete")).to_have_text("Cancel")
+
+
+@pytest.mark.e2e
 def test_config_workspace_reset_dispatches_to_clear_session(page, live_server):
     """Clicking the Reset button in the config workspace modal, then
     confirming, should POST to /clear_session with the selected config


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This PR updates the config workspace modal copy for the orphaned config bundle cleanup flow so the labels better match the actual action.

### What changed
- Renamed the button from “Review File Drift” to “Review Orphaned Config Bundles”
- Renamed the modal title to “Review Orphaned Config Bundles”
- Changed the dismiss button text from “Keep for now” to “Cancel”
- Added a regression test covering the updated modal copy

### Why
The previous wording implied a different workflow than the one being performed. These changes make the UI clearer and more consistent with the underlying behavior.

### Verification
- Ran:
  - `python -m pytest -o addopts='' tests/e2e/test_wizard_e2e.py::test_config_workspace_modal_uses_clear_orphaned_bundle_labels -vv`
- Result:
  - 1 test passed

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1703 #1704 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000128&installation_model_id=431096&pr_number=1755&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1755&signature=0a3d2a862c487b129a9156daa6de2e24db9a975733b1b036812a27ab34ea4ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->