### PR TITLE
New trakt flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Build JS Bundles
+        run: |
+          npm ci --no-fund --no-audit
+          npm run build
+
       - name: Set Up Python
         uses: actions/setup-python@v7
         with:

--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -1,5 +1,6 @@
 import requests
 from flask import Blueprint, Flask, current_app as app, jsonify, request, session
+from ruamel.yaml import YAML
 
 from modules import database, helpers, persistence, url_validation, validations
 
@@ -237,6 +238,70 @@ def validate_tracearr():
 def validate_trakt():
     data = request.json
     return validations.validate_trakt_server(data)
+
+
+@bp.route("/import_trakt_yaml", methods=["POST"])
+def import_trakt_yaml():
+    payload = request.get_json(silent=True) or {}
+    yaml_text = payload.get("yaml", "") or ""
+    if not isinstance(yaml_text, str) or not yaml_text.strip():
+        return jsonify({"valid": False, "error": "No YAML content provided."}), 400
+
+    try:
+        parser = YAML(typ="safe", pure=True)
+        parsed = parser.load(yaml_text)
+    except Exception as exc:  # noqa: BLE001
+        helpers.ts_log(f"Failed to parse Trakt YAML import: {exc}", level="ERROR")
+        return jsonify({"valid": False, "error": "The YAML could not be parsed."}), 400
+
+    if not isinstance(parsed, dict):
+        return jsonify({"valid": False, "error": "The YAML must contain a top-level mapping."}), 400
+
+    trakt_block = parsed.get("trakt")
+    if not isinstance(trakt_block, dict):
+        return jsonify({"valid": False, "error": "The YAML must contain a 'trakt' mapping."}), 400
+
+    normalized = {
+        "client_id": trakt_block.get("client_id"),
+        "client_secret": trakt_block.get("client_secret"),
+        "authorization": {},
+    }
+
+    auth_block = trakt_block.get("authorization")
+    if isinstance(auth_block, dict):
+        for key in ["access_token", "token_type", "expires_in", "refresh_token", "scope", "created_at"]:
+            if key in auth_block:
+                normalized["authorization"][key] = auth_block.get(key)
+
+    if not normalized.get("client_id") or not normalized.get("client_secret"):
+        return jsonify({"valid": False, "error": "The YAML import is missing a client_id or client_secret."}), 400
+
+    config_name = session.get("config_name") or persistence.ensure_session_config_name()
+    stored_validated, user_entered, stored_data = database.retrieve_section_data(config_name, "trakt")
+    if not isinstance(stored_data, dict):
+        stored_data = {}
+
+    trakt_data = stored_data.get("trakt", {}) if isinstance(stored_data.get("trakt"), dict) else {}
+    trakt_data.update(
+        {
+            "client_id": normalized.get("client_id"),
+            "client_secret": normalized.get("client_secret"),
+            "authorization": normalized.get("authorization", {}),
+        }
+    )
+    stored_data["trakt"] = trakt_data
+    stored_data["validated"] = True
+    stored_data["validated_at"] = helpers.utc_now_iso()
+
+    database.save_section_data(
+        name=config_name,
+        section="trakt",
+        validated=True,
+        user_entered=user_entered,
+        data=stored_data,
+    )
+
+    return jsonify({"valid": True, "trakt": trakt_data})
 
 
 @bp.route("/validate_trakt_token", methods=["POST"])

--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -1,3 +1,14 @@
+import { refreshValidationCallout } from './modules/validationPageBase.js'
+import {
+  STATUS_COLOR_SUCCESS,
+  STATUS_COLOR_ERROR,
+  wireSecretToggle,
+  showStatusMessage,
+  performValidationRequest
+} from './modules/oauthValidationHelpers.js'
+
+console.log('[Trakt] 130-trakt.js loaded')
+
 function setTraktAuthFields (traktPayload) {
   if (!traktPayload) return
 
@@ -45,40 +56,84 @@ function setTraktAuthFields (traktPayload) {
   }
 }
 
-function showTraktStatus (message, type = 'info') {
-  const statusEl = document.getElementById('traktYamlImportStatus')
+function markTraktValidated () {
+  const validatedField = document.getElementById('trakt_validated')
+  const validatedAtField = document.getElementById('trakt_validated_at')
 
-  if (!statusEl) {
-    console.error('[Trakt] Status element not found')
+  if (validatedField) {
+    validatedField.value = 'true'
+  }
+
+  if (validatedAtField) {
+    validatedAtField.value = new Date().toISOString()
+  }
+
+  refreshValidationCallout('trakt_validated')
+}
+
+function markTraktInvalid () {
+  const validatedField = document.getElementById('trakt_validated')
+  const validatedAtField = document.getElementById('trakt_validated_at')
+
+  if (validatedField) {
+    validatedField.value = 'false'
+  }
+
+  if (validatedAtField) {
+    validatedAtField.value = ''
+  }
+
+  refreshValidationCallout('trakt_validated')
+}
+
+function showYamlImportStatus (message, type = 'info') {
+  const statusElement = document.getElementById('traktYamlImportStatus')
+
+  if (!statusElement) {
+    console.error('[Trakt] YAML import status element not found')
     return
   }
 
-  statusEl.className = `alert alert-${type} py-2 small mt-3`
-  statusEl.textContent = message
-  statusEl.classList.remove('d-none')
+  statusElement.className = `alert alert-${type} py-2 small mt-3`
+  statusElement.textContent = message
+  statusElement.classList.remove('d-none')
+}
+
+function resetYamlImportStatus () {
+  const statusElement = document.getElementById('traktYamlImportStatus')
+
+  if (!statusElement) return
+
+  statusElement.textContent = ''
+  statusElement.className = 'alert alert-info py-2 small mt-3 d-none'
 }
 
 async function importTraktYaml () {
+  const importText = document.getElementById('traktYamlImportText')
+  const importButton = document.getElementById('traktYamlImportSubmit')
+
   console.log('[Trakt] Import YAML handler called')
 
-  const importText = document.getElementById('traktYamlImportText')
-
   if (!importText) {
-    console.error('[Trakt] traktYamlImportText was not found')
+    console.error('[Trakt] traktYamlImportText not found')
     return
   }
 
   const yaml = importText.value.trim()
 
   if (!yaml) {
-    showTraktStatus(
+    showYamlImportStatus(
       'Paste the YAML export before importing.',
       'danger'
     )
     return
   }
 
-  showTraktStatus(
+  if (importButton) {
+    importButton.disabled = true
+  }
+
+  showYamlImportStatus(
     'Importing Trakt credentials...',
     'info'
   )
@@ -107,24 +162,21 @@ async function importTraktYaml () {
       data = await response.json()
     } catch (error) {
       console.error(
-        '[Trakt] Unable to parse import response:',
+        '[Trakt] Unable to parse YAML import response:',
         error
       )
 
-      showTraktStatus(
+      showYamlImportStatus(
         `The server returned an invalid response (${response.status}).`,
         'danger'
       )
       return
     }
 
-    console.log(
-      '[Trakt] Import response:',
-      data
-    )
+    console.log('[Trakt] Import response:', data)
 
     if (!response.ok || !data.valid) {
-      showTraktStatus(
+      showYamlImportStatus(
         data.error || 'The YAML import failed.',
         'danger'
       )
@@ -132,36 +184,48 @@ async function importTraktYaml () {
     }
 
     setTraktAuthFields(data.trakt)
+    markTraktValidated()
 
-    showTraktStatus(
+    showYamlImportStatus(
       'Trakt credentials imported successfully.',
       'success'
     )
 
-    const modalEl =
-      document.getElementById('traktYamlImportModal')
+    const checkTokenButton =
+      document.getElementById('trakt_check_token')
 
-    if (modalEl && window.bootstrap) {
-      const modal =
-        window.bootstrap.Modal.getOrCreateInstance(modalEl)
-
-      modal.hide()
+    if (checkTokenButton) {
+      checkTokenButton.disabled = false
     }
+
+    /*
+     * Keep the success message visible briefly in the modal rather than
+     * immediately hiding it. The user can close the modal manually.
+     *
+     * We intentionally do not call modal.hide() here because hiding the
+     * modal immediately makes a successful import appear as though
+     * nothing happened.
+     */
   } catch (error) {
     console.error(
       '[Trakt] YAML import request failed:',
       error
     )
 
-    showTraktStatus(
+    showYamlImportStatus(
       'Unable to import the Trakt YAML right now.',
       'danger'
     )
+  } finally {
+    if (importButton) {
+      importButton.disabled = false
+    }
   }
 }
 
-async function checkTraktToken () {
-  console.log('[Trakt] Check Token handler called')
+function checkTraktToken () {
+  const statusMessage =
+    document.getElementById('statusMessage')
 
   const accessToken =
     document.getElementById('access_token')?.value || ''
@@ -176,126 +240,143 @@ async function checkTraktToken () {
     document.getElementById('refresh_token')?.value || ''
 
   if (
-    !accessToken ||
-    !clientId ||
-    !clientSecret ||
-    !refreshToken
+    !accessToken.trim() ||
+    !clientId.trim() ||
+    !clientSecret.trim() ||
+    !refreshToken.trim()
   ) {
-    showTraktStatus(
+    showStatusMessage(
+      statusMessage,
       'Missing access token, client ID, client secret, or refresh token.',
-      'danger'
+      STATUS_COLOR_ERROR
     )
     return
   }
 
-  showTraktStatus(
-    'Checking Trakt token...',
-    'info'
-  )
+  console.log('[Trakt] POST /validate_trakt_token')
 
-  try {
-    console.log('[Trakt] POST /validate_trakt_token')
+  performValidationRequest({
+    endpoint: '/validate_trakt_token',
+    payload: {
+      access_token: accessToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      debug: true
+    },
+    spinnerKey: 'check_trakt',
+    statusElement: statusMessage,
 
-    const response = await fetch(
-      '/validate_trakt_token',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          access_token: accessToken,
+    onSuccess: (data) => {
+      console.log('[Trakt] Token validation succeeded:', data)
+
+      if (data.authorization) {
+        setTraktAuthFields({
           client_id: clientId,
           client_secret: clientSecret,
-          refresh_token: refreshToken,
-          debug: true
+          authorization: data.authorization
         })
       }
-    )
 
-    console.log(
-      '[Trakt] Token response status:',
-      response.status
-    )
+      markTraktValidated()
 
-    let data
+      showStatusMessage(
+        statusMessage,
+        'Trakt token is valid.',
+        STATUS_COLOR_SUCCESS
+      )
+    },
 
-    try {
-      data = await response.json()
-    } catch (error) {
+    onFailure: (data) => {
       console.error(
-        '[Trakt] Unable to parse token response:',
+        '[Trakt] Token validation failed:',
+        data
+      )
+
+      markTraktInvalid()
+    },
+
+    onError: (error) => {
+      console.error(
+        '[Trakt] Token validation request error:',
         error
       )
 
-      showTraktStatus(
-        `The server returned an invalid response (${response.status}).`,
-        'danger'
+      markTraktInvalid()
+
+      showStatusMessage(
+        statusMessage,
+        'An error occurred while validating the Trakt token.',
+        STATUS_COLOR_ERROR
       )
-      return
     }
+  })
+}
 
-    console.log(
-      '[Trakt] Token response:',
-      data
+function wireTraktPage () {
+  const clientSecretInput =
+    document.getElementById('trakt_client_secret')
+
+  const secretToggleButton =
+    document.getElementById('toggleClientSecretVisibility')
+
+  const importButton =
+    document.getElementById('traktYamlImportSubmit')
+
+  const importText =
+    document.getElementById('traktYamlImportText')
+
+  const importModal =
+    document.getElementById('traktYamlImportModal')
+
+  const checkTokenButton =
+    document.getElementById('trakt_check_token')
+
+  console.log('[Trakt] Wiring page', {
+    clientSecretInput: !!clientSecretInput,
+    importButton: !!importButton,
+    importText: !!importText,
+    importModal: !!importModal,
+    checkTokenButton: !!checkTokenButton
+  })
+
+  if (clientSecretInput) {
+    wireSecretToggle(
+      clientSecretInput,
+      secretToggleButton
     )
+  }
 
-    if (!response.ok || !data.valid) {
-      showTraktStatus(
-        data.error || 'Token check failed.',
-        'danger'
-      )
-      return
-    }
-
-    if (data.authorization) {
-      setTraktAuthFields({
-        client_id: clientId,
-        client_secret: clientSecret,
-        authorization: data.authorization
-      })
-    }
-
-    showTraktStatus(
-      'Trakt token is valid.',
-      'success'
+  if (importButton) {
+    importButton.addEventListener(
+      'click',
+      importTraktYaml
     )
-  } catch (error) {
+  } else {
     console.error(
-      '[Trakt] Token validation request failed:',
-      error
+      '[Trakt] traktYamlImportSubmit not found'
+    )
+  }
+
+  if (importModal) {
+    importModal.addEventListener(
+      'show.bs.modal',
+      resetYamlImportStatus
+    )
+  }
+
+  if (checkTokenButton) {
+    checkTokenButton.addEventListener(
+      'click',
+      checkTraktToken
     )
 
-    showTraktStatus(
-      'Unable to validate the Trakt token right now.',
-      'danger'
-    )
+    const accessToken =
+      document.getElementById('access_token')?.value || ''
+
+    checkTokenButton.disabled =
+      !accessToken.trim()
   }
 }
 
-console.log('[Trakt] 130-trakt.js loaded')
-
-document.addEventListener('click', async (event) => {
-  const importButton =
-    event.target.closest('#traktYamlImportSubmit')
-
-  if (importButton) {
-    event.preventDefault()
-
-    console.log('[Trakt] Import YAML button clicked')
-
-    await importTraktYaml()
-    return
-  }
-
-  const checkTokenButton =
-    event.target.closest('#trakt_check_token')
-
-  if (checkTokenButton) {
-    event.preventDefault()
-
-    console.log('[Trakt] Check Token button clicked')
-
-    await checkTraktToken()
-  }
-})
+wireTraktPage()

--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -204,7 +204,7 @@ async function importTraktYaml () {
      *
      * We intentionally do not call modal.hide() here because hiding the
      * modal immediately makes a successful import appear as though
-     * nothing happened.
+     * nothing happened at all.
      */
   } catch (error) {
     console.error(

--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -1,84 +1,127 @@
-import { createOauthValidator } from './modules/createOauthValidator.js'
+const TRAKT_UTILITIES_URL = 'https://utilities.kometa.wiki/trakt-oauth/'
+function setTraktAuthFields (traktPayload) {
+  if (!traktPayload) return
+  const auth = traktPayload.authorization || {}
+  const clientIdInput = document.getElementById('trakt_client_id')
+  const clientSecretInput = document.getElementById('trakt_client_secret')
+  const accessTokenInput = document.getElementById('access_token')
+  const tokenTypeInput = document.getElementById('token_type')
+  const expiresInInput = document.getElementById('expires_in')
+  const refreshTokenInput = document.getElementById('refresh_token')
+  const scopeInput = document.getElementById('scope')
+  const createdAtInput = document.getElementById('created_at')
 
-// Trakt OAuth PIN flow. Migrated to the shared createOauthValidator
-// factory in #1334 Step 6 PR 2.
-//
-// Trakt-specific quirks preserved from the pre-factory implementation:
-//   - client_id length is 64 chars before the authorization URL is built
-//   - authorization URL format is Trakt's oob (out-of-band) redirect
-//   - validate endpoint returns 6 authorization fields to copy
-//   - Check Token endpoint may rotate the token set via data.authorization
-//   - After success, the PIN input and URL field are cleared, both
-//     PIN-flow buttons are disabled, and the Check Token button becomes
-//     enabled.
+  if (clientIdInput) clientIdInput.value = traktPayload.client_id || ''
+  if (clientSecretInput) clientSecretInput.value = traktPayload.client_secret || ''
+  if (accessTokenInput) accessTokenInput.value = auth.access_token || ''
+  if (tokenTypeInput) tokenTypeInput.value = auth.token_type || ''
+  if (expiresInInput) expiresInInput.value = auth.expires_in || ''
+  if (refreshTokenInput) refreshTokenInput.value = auth.refresh_token || ''
+  if (scopeInput) scopeInput.value = auth.scope || ''
+  if (createdAtInput) createdAtInput.value = auth.created_at || ''
+}
 
-const TRAKT_CLIENT_ID_LENGTH = 64
+function showTraktStatus (message, type = 'info') {
+  const statusEl = document.getElementById('traktYamlImportStatus')
+  if (!statusEl) return
+  statusEl.className = `alert alert-${type} py-2 small mt-3`
+  statusEl.textContent = message
+  statusEl.classList.remove('d-none')
+}
 
-createOauthValidator({
-  serviceName: 'Trakt',
-  validatedFieldId: 'trakt_validated',
-  validatedAtFieldId: 'trakt_validated_at',
-  clientIdFieldId: 'trakt_client_id',
-  clientSecretFieldId: 'trakt_client_secret',
-  authorizeButtonId: 'trakt_open_url',
-  validateButtonId: 'validate_trakt_pin',
-  checkTokenButtonId: 'trakt_check_token',
-  urlFieldId: 'trakt_url',
-  expectedClientIdLength: TRAKT_CLIENT_ID_LENGTH,
-  buildAuthorizationURL: (clientId) =>
-    `https://trakt.tv/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=urn:ietf:wg:oauth:2.0:oob`,
-  secondaryValueFieldId: 'trakt_pin',
-  validateEndpoint: '/validate_trakt',
-  validateSpinnerKey: 'validate',
-  buildValidatePayload: ({ clientId, clientSecret, secondaryValue }) => ({
-    trakt_client_id: clientId,
-    trakt_client_secret: clientSecret,
-    trakt_pin: secondaryValue
-  }),
-  messages: {
-    validateMissingFields: 'ID, secret, and PIN are all required.'
-  },
-  applyValidateSuccess: (data, ctx) => {
-    document.getElementById('access_token').value = data.trakt_authorization_access_token
-    document.getElementById('token_type').value = data.trakt_authorization_token_type
-    document.getElementById('expires_in').value = data.trakt_authorization_expires_in
-    document.getElementById('refresh_token').value = data.trakt_authorization_refresh_token
-    document.getElementById('scope').value = data.trakt_authorization_scope
-    document.getElementById('created_at').value = data.trakt_authorization_created_at
-    ctx.secondaryValueInput.value = ''
-    ctx.urlField.value = ''
-    ctx.authorizeButton.disabled = true
-    ctx.validateButton.disabled = true
-    if (ctx.checkTokenButton) ctx.checkTokenButton.disabled = false
-  },
-  checkTokenEndpoint: '/validate_trakt_token',
-  checkTokenSpinnerKey: 'check_trakt',
-  buildCheckTokenPayload: ({ accessToken, clientId, clientSecret, refreshToken }) => ({
-    access_token: accessToken,
-    client_id: clientId,
-    client_secret: clientSecret,
-    refresh_token: refreshToken,
-    debug: true
-  }),
-  checkTokenPreflight: ({ accessToken, clientId }) => {
-    // Trakt requires both accessToken AND clientId to be present
-    // before hitting the server (server would reject otherwise).
-    if (!accessToken.trim() || !clientId.trim()) {
-      return 'Missing access token or client ID.'
-    }
-    return null
-  },
-  applyCheckTokenSuccess: (data) => {
-    // Trakt-specific: response may rotate the token set. Copy the
-    // rotated fields when the server sent them.
-    if (data.authorization) {
-      const auth = data.authorization
-      if (auth.access_token) document.getElementById('access_token').value = auth.access_token
-      if (auth.token_type) document.getElementById('token_type').value = auth.token_type
-      if (auth.expires_in) document.getElementById('expires_in').value = auth.expires_in
-      if (auth.refresh_token) document.getElementById('refresh_token').value = auth.refresh_token
-      if (auth.scope) document.getElementById('scope').value = auth.scope
-      if (auth.created_at) document.getElementById('created_at').value = auth.created_at
-    }
+function wireYamlImportFlow () {
+  const importButton = document.getElementById('traktYamlImportSubmit')
+  const importText = document.getElementById('traktYamlImportText')
+  const openUtilitiesButton = document.getElementById('trakt_open_url')
+  const checkTokenButton = document.getElementById('trakt_check_token')
+
+  if (openUtilitiesButton) {
+    openUtilitiesButton.addEventListener('click', () => {
+      window.open(TRAKT_UTILITIES_URL, '_blank', 'noopener,noreferrer')
+    })
   }
-})
+
+  if (!importButton || !importText) {
+    console.error('[Trakt] Cannot wire import flow: button=' + !!importButton + ', text=' + !!importText)
+    return
+  }
+
+  if (importButton && importText) {
+    importButton.addEventListener('click', async () => {
+      const yaml = importText.value.trim()
+      if (!yaml) {
+        showTraktStatus('Paste the YAML export before importing.', 'danger')
+        return
+      }
+
+      showTraktStatus('Importing Trakt credentials...', 'info')
+
+      try {
+        const response = await fetch('/import_trakt_yaml', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ yaml })
+        })
+        const data = await response.json()
+        if (!response.ok || !data.valid) {
+          showTraktStatus(data.error || 'The YAML import failed.', 'danger')
+          return
+        }
+
+        setTraktAuthFields(data.trakt)
+        showTraktStatus('Trakt credentials imported successfully.', 'success')
+        const modalEl = document.getElementById('traktYamlImportModal')
+        if (modalEl && window.bootstrap) {
+          const modal = window.bootstrap.Modal.getOrCreateInstance(modalEl)
+          modal.hide()
+        }
+      } catch {
+        showTraktStatus('Unable to import the Trakt YAML right now.', 'danger')
+      }
+    })
+  }
+
+  if (checkTokenButton) {
+    checkTokenButton.addEventListener('click', async () => {
+      const accessToken = document.getElementById('access_token')?.value || ''
+      const clientId = document.getElementById('trakt_client_id')?.value || ''
+      const clientSecret = document.getElementById('trakt_client_secret')?.value || ''
+      const refreshToken = document.getElementById('refresh_token')?.value || ''
+
+      if (!accessToken || !clientId || !clientSecret || !refreshToken) {
+        showTraktStatus('Missing access token, client ID, client secret, or refresh token.', 'danger')
+        return
+      }
+
+      showTraktStatus('Checking Trakt token...', 'info')
+
+      try {
+        const response = await fetch('/validate_trakt_token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            access_token: accessToken,
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: refreshToken,
+            debug: true
+          })
+        })
+        const data = await response.json()
+        if (!response.ok || !data.valid) {
+          showTraktStatus(data.error || 'Token check failed.', 'danger')
+          return
+        }
+
+        if (data.authorization) {
+          setTraktAuthFields({ client_id: clientId, client_secret: clientSecret, authorization: data.authorization })
+        }
+        showTraktStatus('Trakt token is valid.', 'success')
+      } catch {
+        showTraktStatus('Unable to validate the Trakt token right now.', 'danger')
+      }
+    })
+  }
+}
+
+wireYamlImportFlow()

--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -1,7 +1,8 @@
-const TRAKT_UTILITIES_URL = 'https://utilities.kometa.wiki/trakt-oauth/'
 function setTraktAuthFields (traktPayload) {
   if (!traktPayload) return
+
   const auth = traktPayload.authorization || {}
+
   const clientIdInput = document.getElementById('trakt_client_id')
   const clientSecretInput = document.getElementById('trakt_client_secret')
   const accessTokenInput = document.getElementById('access_token')
@@ -11,117 +12,290 @@ function setTraktAuthFields (traktPayload) {
   const scopeInput = document.getElementById('scope')
   const createdAtInput = document.getElementById('created_at')
 
-  if (clientIdInput) clientIdInput.value = traktPayload.client_id || ''
-  if (clientSecretInput) clientSecretInput.value = traktPayload.client_secret || ''
-  if (accessTokenInput) accessTokenInput.value = auth.access_token || ''
-  if (tokenTypeInput) tokenTypeInput.value = auth.token_type || ''
-  if (expiresInInput) expiresInInput.value = auth.expires_in || ''
-  if (refreshTokenInput) refreshTokenInput.value = auth.refresh_token || ''
-  if (scopeInput) scopeInput.value = auth.scope || ''
-  if (createdAtInput) createdAtInput.value = auth.created_at || ''
+  if (clientIdInput) {
+    clientIdInput.value = traktPayload.client_id || ''
+  }
+
+  if (clientSecretInput) {
+    clientSecretInput.value = traktPayload.client_secret || ''
+  }
+
+  if (accessTokenInput) {
+    accessTokenInput.value = auth.access_token || ''
+  }
+
+  if (tokenTypeInput) {
+    tokenTypeInput.value = auth.token_type || ''
+  }
+
+  if (expiresInInput) {
+    expiresInInput.value = auth.expires_in || ''
+  }
+
+  if (refreshTokenInput) {
+    refreshTokenInput.value = auth.refresh_token || ''
+  }
+
+  if (scopeInput) {
+    scopeInput.value = auth.scope || ''
+  }
+
+  if (createdAtInput) {
+    createdAtInput.value = auth.created_at || ''
+  }
 }
 
 function showTraktStatus (message, type = 'info') {
   const statusEl = document.getElementById('traktYamlImportStatus')
-  if (!statusEl) return
+
+  if (!statusEl) {
+    console.error('[Trakt] Status element not found')
+    return
+  }
+
   statusEl.className = `alert alert-${type} py-2 small mt-3`
   statusEl.textContent = message
   statusEl.classList.remove('d-none')
 }
 
-function wireYamlImportFlow () {
-  const importButton = document.getElementById('traktYamlImportSubmit')
+async function importTraktYaml () {
+  console.log('[Trakt] Import YAML handler called')
+
   const importText = document.getElementById('traktYamlImportText')
-  const openUtilitiesButton = document.getElementById('trakt_open_url')
-  const checkTokenButton = document.getElementById('trakt_check_token')
 
-  if (openUtilitiesButton) {
-    openUtilitiesButton.addEventListener('click', () => {
-      window.open(TRAKT_UTILITIES_URL, '_blank', 'noopener,noreferrer')
-    })
-  }
-
-  if (!importButton || !importText) {
-    console.error('[Trakt] Cannot wire import flow: button=' + !!importButton + ', text=' + !!importText)
+  if (!importText) {
+    console.error('[Trakt] traktYamlImportText was not found')
     return
   }
 
-  if (importButton && importText) {
-    importButton.addEventListener('click', async () => {
-      const yaml = importText.value.trim()
-      if (!yaml) {
-        showTraktStatus('Paste the YAML export before importing.', 'danger')
-        return
-      }
+  const yaml = importText.value.trim()
 
-      showTraktStatus('Importing Trakt credentials...', 'info')
-
-      try {
-        const response = await fetch('/import_trakt_yaml', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ yaml })
-        })
-        const data = await response.json()
-        if (!response.ok || !data.valid) {
-          showTraktStatus(data.error || 'The YAML import failed.', 'danger')
-          return
-        }
-
-        setTraktAuthFields(data.trakt)
-        showTraktStatus('Trakt credentials imported successfully.', 'success')
-        const modalEl = document.getElementById('traktYamlImportModal')
-        if (modalEl && window.bootstrap) {
-          const modal = window.bootstrap.Modal.getOrCreateInstance(modalEl)
-          modal.hide()
-        }
-      } catch {
-        showTraktStatus('Unable to import the Trakt YAML right now.', 'danger')
-      }
-    })
+  if (!yaml) {
+    showTraktStatus(
+      'Paste the YAML export before importing.',
+      'danger'
+    )
+    return
   }
 
-  if (checkTokenButton) {
-    checkTokenButton.addEventListener('click', async () => {
-      const accessToken = document.getElementById('access_token')?.value || ''
-      const clientId = document.getElementById('trakt_client_id')?.value || ''
-      const clientSecret = document.getElementById('trakt_client_secret')?.value || ''
-      const refreshToken = document.getElementById('refresh_token')?.value || ''
+  showTraktStatus(
+    'Importing Trakt credentials...',
+    'info'
+  )
 
-      if (!accessToken || !clientId || !clientSecret || !refreshToken) {
-        showTraktStatus('Missing access token, client ID, client secret, or refresh token.', 'danger')
-        return
-      }
+  try {
+    console.log('[Trakt] POST /import_trakt_yaml')
 
-      showTraktStatus('Checking Trakt token...', 'info')
-
-      try {
-        const response = await fetch('/validate_trakt_token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            access_token: accessToken,
-            client_id: clientId,
-            client_secret: clientSecret,
-            refresh_token: refreshToken,
-            debug: true
-          })
-        })
-        const data = await response.json()
-        if (!response.ok || !data.valid) {
-          showTraktStatus(data.error || 'Token check failed.', 'danger')
-          return
-        }
-
-        if (data.authorization) {
-          setTraktAuthFields({ client_id: clientId, client_secret: clientSecret, authorization: data.authorization })
-        }
-        showTraktStatus('Trakt token is valid.', 'success')
-      } catch {
-        showTraktStatus('Unable to validate the Trakt token right now.', 'danger')
-      }
+    const response = await fetch('/import_trakt_yaml', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        yaml
+      })
     })
+
+    console.log(
+      '[Trakt] Import response status:',
+      response.status
+    )
+
+    let data
+
+    try {
+      data = await response.json()
+    } catch (error) {
+      console.error(
+        '[Trakt] Unable to parse import response:',
+        error
+      )
+
+      showTraktStatus(
+        `The server returned an invalid response (${response.status}).`,
+        'danger'
+      )
+      return
+    }
+
+    console.log(
+      '[Trakt] Import response:',
+      data
+    )
+
+    if (!response.ok || !data.valid) {
+      showTraktStatus(
+        data.error || 'The YAML import failed.',
+        'danger'
+      )
+      return
+    }
+
+    setTraktAuthFields(data.trakt)
+
+    showTraktStatus(
+      'Trakt credentials imported successfully.',
+      'success'
+    )
+
+    const modalEl =
+      document.getElementById('traktYamlImportModal')
+
+    if (modalEl && window.bootstrap) {
+      const modal =
+        window.bootstrap.Modal.getOrCreateInstance(modalEl)
+
+      modal.hide()
+    }
+  } catch (error) {
+    console.error(
+      '[Trakt] YAML import request failed:',
+      error
+    )
+
+    showTraktStatus(
+      'Unable to import the Trakt YAML right now.',
+      'danger'
+    )
   }
 }
 
-wireYamlImportFlow()
+async function checkTraktToken () {
+  console.log('[Trakt] Check Token handler called')
+
+  const accessToken =
+    document.getElementById('access_token')?.value || ''
+
+  const clientId =
+    document.getElementById('trakt_client_id')?.value || ''
+
+  const clientSecret =
+    document.getElementById('trakt_client_secret')?.value || ''
+
+  const refreshToken =
+    document.getElementById('refresh_token')?.value || ''
+
+  if (
+    !accessToken ||
+    !clientId ||
+    !clientSecret ||
+    !refreshToken
+  ) {
+    showTraktStatus(
+      'Missing access token, client ID, client secret, or refresh token.',
+      'danger'
+    )
+    return
+  }
+
+  showTraktStatus(
+    'Checking Trakt token...',
+    'info'
+  )
+
+  try {
+    console.log('[Trakt] POST /validate_trakt_token')
+
+    const response = await fetch(
+      '/validate_trakt_token',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          access_token: accessToken,
+          client_id: clientId,
+          client_secret: clientSecret,
+          refresh_token: refreshToken,
+          debug: true
+        })
+      }
+    )
+
+    console.log(
+      '[Trakt] Token response status:',
+      response.status
+    )
+
+    let data
+
+    try {
+      data = await response.json()
+    } catch (error) {
+      console.error(
+        '[Trakt] Unable to parse token response:',
+        error
+      )
+
+      showTraktStatus(
+        `The server returned an invalid response (${response.status}).`,
+        'danger'
+      )
+      return
+    }
+
+    console.log(
+      '[Trakt] Token response:',
+      data
+    )
+
+    if (!response.ok || !data.valid) {
+      showTraktStatus(
+        data.error || 'Token check failed.',
+        'danger'
+      )
+      return
+    }
+
+    if (data.authorization) {
+      setTraktAuthFields({
+        client_id: clientId,
+        client_secret: clientSecret,
+        authorization: data.authorization
+      })
+    }
+
+    showTraktStatus(
+      'Trakt token is valid.',
+      'success'
+    )
+  } catch (error) {
+    console.error(
+      '[Trakt] Token validation request failed:',
+      error
+    )
+
+    showTraktStatus(
+      'Unable to validate the Trakt token right now.',
+      'danger'
+    )
+  }
+}
+
+console.log('[Trakt] 130-trakt.js loaded')
+
+document.addEventListener('click', async (event) => {
+  const importButton =
+    event.target.closest('#traktYamlImportSubmit')
+
+  if (importButton) {
+    event.preventDefault()
+
+    console.log('[Trakt] Import YAML button clicked')
+
+    await importTraktYaml()
+    return
+  }
+
+  const checkTokenButton =
+    event.target.closest('#trakt_check_token')
+
+  if (checkTokenButton) {
+    event.preventDefault()
+
+    console.log('[Trakt] Check Token button clicked')
+
+    await checkTraktToken()
+  }
+})

--- a/templates/130-trakt.html
+++ b/templates/130-trakt.html
@@ -1,6 +1,26 @@
 {% extends "000-base.html" %} {% block content %}
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
+<div class="d-flex flex-wrap gap-2 mb-3">
+  <a
+    class="btn btn-outline-primary"
+    id="trakt_open_url"
+    href="https://utilities.kometa.wiki/trakt-oauth/"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    Open Trakt Utilities
+  </a>
+
+  <button
+    class="btn btn-success"
+    type="button"
+    data-bs-toggle="modal"
+    data-bs-target="#traktYamlImportModal"
+  >
+    Import YAML
+  </button>
+</div>
 <div class="input-group mb-2">
   <span class="input-group-text" id="trakt_client_id_text" style="width: 150px; justify-content: space-between;">
     Client ID
@@ -28,59 +48,20 @@
   <button class="btn btn-outline-secondary" id="toggleClientSecretVisibility" type="button">
     <i class="fas fa-eye"></i>
   </button>
-  <button class="btn btn-success" id="trakt_open_url" type="button">
-    Retrieve PIN <i id="spinner_retrieve" class="spinner-border spinner-border-sm" style="display:none;"></i>
-  </button>
 </div>
-
-
 
 <input type="hidden" class="form-control" id="trakt_url" name="trakt_url" readonly>
-<div class="form-text mb-2" id="pin-info">
-  When you click "Retrieve PIN" above, you will be taken to a Trakt web page. Log in and allow your application access
-  to your Trakt account. Trakt will display a PIN. Copy that PIN and paste it into the "Trakt PIN" field below.<br>
-</div>
-<div class="form-text mb-2" id="pin-info">
-  If you have a PIN you generated in the last few minutes, enter it below.<br>
-</div>
-<div class="input-group mb-2" id="urlField">
-  <span class="input-group-text" id="trakt_pin_text" style="width: 150px; justify-content: space-between;">
-    Trakt PIN
-    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" style="margin-left: 10px;"
-      title="Enter the PIN received from Trakt for authentication.">
-      <i class="bi bi-info-circle-fill"></i>
-    </span>
-  </span>
-  <input type="text" class="form-control" placeholder="Trakt PIN" aria-label="Trakt PIN" id="trakt_pin" name="trakt_pin"
-    aria-describedby="trakt_pin_text">
-  <button class="btn btn-success" type="button" id="validate_trakt_pin">
-    Validate PIN <i id="spinner_validate" class="spinner-border spinner-border-sm" style="display:none;"></i>
-  </button>
-</div>
-
 <div class="input-group mb-2">
   <span class="input-group-text" style="width: 150px; justify-content: space-between;">
     Token Check
     <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" style="margin-left: 10px;"
-      title="Test the saved Trakt access token without re-doing the PIN flow.">
+      title="Test the saved Trakt access token without re-doing the YAML import flow.">
       <i class="bi bi-info-circle-fill"></i>
     </span>
   </span>
   <button class="btn btn-outline-info" type="button" id="trakt_check_token">
     Check Token <i id="spinner_check_trakt" class="spinner-border spinner-border-sm" style="display:none;"></i>
   </button>
-</div>
-
-<div class="form-check form-switch mb-2">
-  <input class="form-check-input" type="checkbox" name="trakt_force_refresh" id="trakt_force_refresh" value="true" {%
-    if data['trakt']['force_refresh']|string|lower=='true' %}checked{% endif %}>
-  <input type="hidden" name="trakt_force_refresh" value="false">
-  <label class="form-check-label" for="trakt_force_refresh">Force Refresh
-    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" style="margin-left: 10px;"
-      title="Refresh credentials on every run.">
-      <i class="bi bi-info-circle-fill"></i>
-    </span>
-  </label>
 </div>
 
 <input type="hidden" class="form-control" id="access_token" name="access_token"
@@ -95,6 +76,25 @@
   readonly>
 <input type="hidden" class="form-control" id="created_at" name="created_at"
   value="{{ data['trakt']['authorization']['created_at'] }}" readonly>
+<div class="modal fade" id="traktYamlImportModal" tabindex="-1" aria-labelledby="traktYamlImportModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="traktYamlImportModalLabel">Import Trakt YAML</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted mb-2">Paste the YAML export from the Trakt utilities site. Quickstart will parse it and save only the values needed for the final Trakt configuration.</p>
+        <textarea class="form-control" id="traktYamlImportText" rows="12" spellcheck="false" placeholder="trakt:&#10;  client_id: ...&#10;  client_secret: ...&#10;  authorization:&#10;    access_token: ..."></textarea>
+        <div id="traktYamlImportStatus" class="alert alert-info py-2 small mt-3 d-none" role="status"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="traktYamlImportSubmit">Import YAML</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="form-floating" style="display:none;">
   <input type="text" class="form-control" id="trakt_validated" name="trakt_validated" value="{{ data['validated'] }}"
     title="">

--- a/templates/modals/130-trakt.html
+++ b/templates/modals/130-trakt.html
@@ -1,7 +1,8 @@
 <div class="alert alert-info qs-validation-callout" role="alert">
   <h6><b>This page is optional</b></h6>
-  Enter your Trakt Client ID/Client Secret and press "Retrieve PIN" which will take you to Trakt to complete
-  authorization. Copy the PIN and paste it into the form, then press "Validate PIN".
+  Click on "Open Trakt Utilities". Follow instructions until you can copy the YAML.<br>
+  Click on "Import YAML" button and paste the YAML from Trakt Utilities. Quickstart will store the required credentials securely.<br>
+  Finally, press "Check Token" button.<br>
   <br>Alternatively, navigate to another page to skip this section.
   <br><br><a href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/config/trakt/" target="_blank">Click Here</a>
   to go to the Kometa wiki for this connector.

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1324,7 +1324,12 @@ def test_import_config_modal_suggests_next_available_name(page, live_server):
     _activate_config(page, live_server, source_config)
     page.reload(wait_until="domcontentloaded")
 
+    # configSelector now lives inside the Manage Configs Bootstrap modal.
+    # Open the modal before interacting with the selector, matching the current UI.
+    page.locator(".qs-config-switch-trigger").click()
+    expect(page.locator("#configSwitchModal")).to_be_visible()
     page.locator("#configSelector").select_option(source_config)
+
     page.evaluate("""() => {
         document.getElementById('importConfigModal').dispatchEvent(new Event('show.bs.modal'))
     }""")

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -895,120 +895,179 @@ def test_tmdb_dropdown_change_alone_does_not_enable_navigation(page, live_server
     expect(page.locator('button[data-nav-action="next"]')).to_be_disabled()
 
 
-# Trakt OAuth-PIN tests (#1334 Step 6 PR 4d). A real Trakt validate
-# requires `trakt_client_id` to be exactly 64 chars for the
-# updateTraktURL() function to generate a non-empty authorization URL.
-TRAKT_CLIENT_ID_64 = "a" * 64
+# Trakt Utilities/YAML import tests.
+#
+# Trakt authentication is now completed through the external Kometa Utilities
+# page. Quickstart imports the resulting YAML, stores the credentials, populates
+# the six hidden authorization fields, and keeps Check Token available for
+# validating/refreshing an already-imported token set.
 
 
 @pytest.mark.e2e
-def test_trakt_pin_validator_success_populates_six_token_fields(page, live_server):
-    """After a successful Trakt PIN validate, the six hidden
-    authorization fields must contain the values from the response,
-    the PIN+URL fields are cleared, the PIN-flow buttons disabled,
-    and the Check Token button enabled.
+def test_trakt_yaml_import_success_populates_six_token_fields(page, live_server):
+    """A successful YAML import populates Trakt credentials and all six
+    authorization fields, marks the section validated, and enables Check Token.
     """
 
-    def handle_validate(route):
+    def handle_import(route):
         route.fulfill(
             status=200,
             json={
                 "valid": True,
-                "trakt_authorization_access_token": "AT-123",
-                "trakt_authorization_token_type": "Bearer",
-                "trakt_authorization_expires_in": 7200,
-                "trakt_authorization_refresh_token": "RT-456",
-                "trakt_authorization_scope": "public",
-                "trakt_authorization_created_at": 1700000000,
+                "trakt": {
+                    "client_id": "CLIENT-ID-123",
+                    "client_secret": "CLIENT-SECRET-456",
+                    "authorization": {
+                        "access_token": "AT-123",
+                        "token_type": "Bearer",
+                        "expires_in": 7200,
+                        "refresh_token": "RT-456",
+                        "scope": "public",
+                        "created_at": 1700000000,
+                    },
+                },
             },
         )
 
-    page.route("**/validate_trakt", handle_validate)
+    page.route("**/import_trakt_yaml", handle_import)
     page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
 
-    page.locator("#trakt_client_id").fill(TRAKT_CLIENT_ID_64)
-    page.locator("#trakt_client_secret").fill("my-secret")
-    page.locator("#trakt_pin").fill("12345678")
-    page.locator("#validate_trakt_pin").click()
+    page.locator('button[data-bs-target="#traktYamlImportModal"]').click()
+    expect(page.locator("#traktYamlImportModal")).to_be_visible()
 
-    # All six access-token fields populated.
+    page.locator("#traktYamlImportText").fill("""trakt:
+  client_id: CLIENT-ID-123
+  client_secret: CLIENT-SECRET-456
+  authorization:
+    access_token: AT-123
+""")
+    page.locator("#traktYamlImportSubmit").click()
+
+    expect(page.locator("#trakt_client_id")).to_have_value("CLIENT-ID-123")
+    expect(page.locator("#trakt_client_secret")).to_have_value("CLIENT-SECRET-456")
     expect(page.locator("#access_token")).to_have_value("AT-123")
     expect(page.locator("#token_type")).to_have_value("Bearer")
     expect(page.locator("#expires_in")).to_have_value("7200")
     expect(page.locator("#refresh_token")).to_have_value("RT-456")
     expect(page.locator("#scope")).to_have_value("public")
     expect(page.locator("#created_at")).to_have_value("1700000000")
-    # PIN + URL cleared.
-    expect(page.locator("#trakt_pin")).to_have_value("")
-    expect(page.locator("#trakt_url")).to_have_value("")
-    # PIN-flow buttons disabled, Check Token enabled.
-    expect(page.locator("#trakt_open_url")).to_be_disabled()
-    expect(page.locator("#validate_trakt_pin")).to_be_disabled()
-    expect(page.locator("#trakt_check_token")).to_be_enabled()
-    # Validated state flipped to true.
+
     expect(page.locator("#trakt_validated")).to_have_value("true")
-    expect(page.locator("#statusMessage")).to_contain_text("Trakt credentials validated successfully!")
+    expect(page.locator("#trakt_check_token")).to_be_enabled()
+    expect(page.locator("#traktYamlImportStatus")).to_contain_text("Trakt credentials imported successfully.")
 
 
 @pytest.mark.e2e
-def test_trakt_pin_validator_missing_fields_shows_required_message(page, live_server):
-    """With one of id/secret/pin missing, the client-side guard short-
-    circuits before the network call and shows the static required-
-    fields message.
-    """
+def test_trakt_yaml_import_missing_content_shows_required_message(page, live_server):
+    """Empty YAML is rejected client-side before /import_trakt_yaml is called."""
     requests_made = {"n": 0}
 
-    def handle_validate(route):
+    def handle_import(route):
         requests_made["n"] += 1
         route.fulfill(status=200, json={"valid": True})
 
-    page.route("**/validate_trakt", handle_validate)
+    page.route("**/import_trakt_yaml", handle_import)
     page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
 
-    page.locator("#trakt_client_id").fill(TRAKT_CLIENT_ID_64)
-    page.locator("#trakt_client_secret").fill("my-secret")
-    # PIN is intentionally empty. The pin field's checkPinField() will
-    # have left the validate button disabled, so we force-enable it.
-    page.evaluate("document.getElementById('validate_trakt_pin').disabled = false")
-    page.locator("#validate_trakt_pin").click()
+    page.locator('button[data-bs-target="#traktYamlImportModal"]').click()
+    expect(page.locator("#traktYamlImportModal")).to_be_visible()
 
-    expect(page.locator("#statusMessage")).to_contain_text("ID, secret, and PIN are all required.")
-    assert requests_made["n"] == 0, "no network call should fire when fields are missing"
+    page.locator("#traktYamlImportSubmit").click()
+
+    expect(page.locator("#traktYamlImportStatus")).to_contain_text("Paste the YAML export before importing.")
+    assert requests_made["n"] == 0, "no network call should fire when YAML is empty"
 
 
 @pytest.mark.e2e
-def test_trakt_url_button_enabled_when_client_id_is_exactly_64_chars(page, live_server):
-    """Verifies the updateTraktURL() inline handler builds the
-    authorization URL only when client_id.length === 64, and the
-    Retrieve PIN button enables itself when the URL is non-empty.
-    """
+def test_trakt_utilities_link_points_to_external_oauth_utility(page, live_server):
+    """The old Retrieve PIN button is replaced by a direct external Utilities link."""
     page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
 
-    # Initially disabled (page just loaded).
-    expect(page.locator("#trakt_open_url")).to_be_disabled()
-
-    # Wrong length: still disabled.
-    page.locator("#trakt_client_id").fill("a" * 32)
-    expect(page.locator("#trakt_url")).to_have_value("")
-    expect(page.locator("#trakt_open_url")).to_be_disabled()
-
-    # Right length: URL constructed, button enabled.
-    page.locator("#trakt_client_id").fill(TRAKT_CLIENT_ID_64)
-    expect(page.locator("#trakt_url")).to_contain_text("")  # readonly so use to_have_value
-    trakt_url_value = page.locator("#trakt_url").input_value()
-    assert "trakt.tv/oauth/authorize" in trakt_url_value
-    assert TRAKT_CLIENT_ID_64 in trakt_url_value
-    expect(page.locator("#trakt_open_url")).to_be_enabled()
+    utilities_link = page.locator("#trakt_open_url")
+    expect(utilities_link).to_have_attribute("href", "https://utilities.kometa.wiki/trakt-oauth/")
+    expect(utilities_link).to_have_attribute("target", "_blank")
+    expect(utilities_link).to_have_attribute("rel", "noopener noreferrer")
 
 
 @pytest.mark.e2e
-def test_trakt_check_token_button_initially_disabled_when_no_access_token(page, live_server):
-    """isBlankTokenValue treats blank/None/Null as blank. On a fresh
-    page where access_token is empty (or the literal string 'None' from
-    the persisted state), the Check Token button must start disabled.
-    """
+def test_trakt_check_token_button_initially_disabled_when_no_access_token(page, live_server, app):
+    """A Trakt page backed by an explicitly empty config starts with Check Token disabled."""
+    import modules.database as database
+
+    config_name = "pytest_trakt_empty_token"
+    _seed_config(config_name)
+
+    with app.app_context():
+        database.save_section_data(
+            name=config_name,
+            section="trakt",
+            validated=False,
+            user_entered=False,
+            data={
+                "trakt": {
+                    "client_id": "",
+                    "client_secret": "",
+                    "authorization": {
+                        "access_token": "",
+                        "token_type": "",
+                        "expires_in": "",
+                        "refresh_token": "",
+                        "scope": "",
+                        "created_at": "",
+                    },
+                },
+                "validated_at": "",
+            },
+        )
+
+    _activate_config(page, live_server, config_name)
     page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
+
+    expect(page.locator("#access_token")).to_have_value("")
     expect(page.locator("#trakt_check_token")).to_be_disabled()
+
+
+@pytest.mark.e2e
+def test_trakt_check_token_success_updates_rotated_authorization(page, live_server):
+    """Check Token copies a rotated authorization payload returned by the server."""
+
+    def handle_check(route):
+        route.fulfill(
+            status=200,
+            json={
+                "valid": True,
+                "authorization": {
+                    "access_token": "AT-ROTATED",
+                    "token_type": "Bearer",
+                    "expires_in": 9999,
+                    "refresh_token": "RT-ROTATED",
+                    "scope": "public",
+                    "created_at": 1800000000,
+                },
+            },
+        )
+
+    page.route("**/validate_trakt_token", handle_check)
+    page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
+
+    page.evaluate("""() => {
+          document.getElementById('trakt_client_id').value = 'CLIENT-ID'
+          document.getElementById('trakt_client_secret').value = 'CLIENT-SECRET'
+          document.getElementById('access_token').value = 'AT-OLD'
+          document.getElementById('refresh_token').value = 'RT-OLD'
+          document.getElementById('trakt_check_token').disabled = false
+        }""")
+
+    page.locator("#trakt_check_token").click()
+
+    expect(page.locator("#access_token")).to_have_value("AT-ROTATED")
+    expect(page.locator("#token_type")).to_have_value("Bearer")
+    expect(page.locator("#expires_in")).to_have_value("9999")
+    expect(page.locator("#refresh_token")).to_have_value("RT-ROTATED")
+    expect(page.locator("#scope")).to_have_value("public")
+    expect(page.locator("#created_at")).to_have_value("1800000000")
+    expect(page.locator("#trakt_validated")).to_have_value("true")
+    expect(page.locator("#statusMessage")).to_contain_text("Trakt token is valid.")
 
 
 # MAL OAuth tests. MAL's client_id must be exactly 32 chars for the
@@ -1109,24 +1168,6 @@ def test_mal_authorize_button_enabled_when_client_id_is_exactly_32_chars(page, l
 # oninput="checkPinField" / oninput="checkURLField" attributes in
 # the templates and are now driven by addEventListener('input', ...)
 # in the JS modules. (Inline-handler-cleanup follow-up to Step 6 PR 4d.)
-
-
-@pytest.mark.e2e
-def test_trakt_validate_button_enables_when_user_types_in_pin_field(page, live_server):
-    """Typing into the PIN field should enable the Validate PIN button;
-    clearing it should disable it again. Previously wired via inline
-    oninput="checkPinField(this)", now via addEventListener.
-    """
-    page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
-
-    # Initially disabled (the page just loaded with no PIN entered).
-    expect(page.locator("#validate_trakt_pin")).to_be_disabled()
-
-    page.locator("#trakt_pin").fill("12345678")
-    expect(page.locator("#validate_trakt_pin")).to_be_enabled()
-
-    page.locator("#trakt_pin").fill("")
-    expect(page.locator("#validate_trakt_pin")).to_be_disabled()
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1326,7 +1326,7 @@ def test_import_config_modal_suggests_next_available_name(page, live_server):
 
     # configSelector now lives inside the Manage Configs Bootstrap modal.
     # Open the modal before interacting with the selector, matching the current UI.
-    page.locator(".qs-config-switch-trigger").click()
+    page.locator(".config-badge-button").click()
     expect(page.locator("#configSwitchModal")).to_be_visible()
     page.locator("#configSelector").select_option(source_config)
 

--- a/tests/test_floppy_support.py
+++ b/tests/test_floppy_support.py
@@ -97,7 +97,7 @@ def test_floppy_step_renders_configured_url_and_module_script(client):
     assert 'id="floppy_token"' in page
     assert 'id="toggleFloppyTokenVisibility"' in page
     assert 'aria-label="Show or hide API token"' in page
-    assert 'src="/static/local-js/067-floppy.js"' in page
+    assert 'src="/static/dist/067-floppy-' in page
     assert 'src="/static/images/service-icons/floppy.png"' in page
 
 

--- a/tests/test_serializd_support.py
+++ b/tests/test_serializd_support.py
@@ -76,7 +76,7 @@ def test_serializd_page_renders(client, isolated_config_dir):
     assert 'id="serializd_email"' in html
     assert 'id="serializd_password"' in html
     assert 'id="serializd_timeout"' in html
-    assert 'src="/static/local-js/065-serializd.js"' in html
+    assert 'src="/static/dist/065-serializd-' in html
     assert 'src="/static/images/service-icons/serializd.png"' in html
 
 

--- a/tests/test_validate_service_routes.py
+++ b/tests/test_validate_service_routes.py
@@ -201,6 +201,28 @@ def test_validate_yamtrack_missing_url_returns_400(client):
 # ---------------------------------------------------------------------------
 
 
+def test_import_trakt_yaml_parses_and_persists_credentials(client):
+    yaml_text = """
+trakt:
+  client_id: test-client-id
+  client_secret: test-client-secret
+  authorization:
+    access_token: test-access-token
+    token_type: bearer
+    expires_in: 604800
+    refresh_token: test-refresh-token
+    scope: public
+    created_at: 1786134359
+"""
+
+    resp = client.post("/import_trakt_yaml", json={"yaml": yaml_text})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["trakt"]["client_id"] == "test-client-id"
+    assert data["trakt"]["authorization"]["access_token"] == "test-access-token"
+
+
 def test_validate_trakt_token_missing_access_and_client_id_returns_400(client):
     resp = client.post("/validate_trakt_token", json={})
     assert resp.status_code == 400


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## PR Description

### Summary
This PR reworks the Trakt setup flow to use the Kometa Utilities YAML import path instead of the legacy PIN-based flow, and cleans up the Trakt UI copy to match the new experience.

### What changed
- 130-trakt.html
  - Replaced outdated instructions with a single utilities/YAML import message
  - Kept the modal import UI and removed the obsolete force-refresh toggle
- 130-trakt.js
  - Fixed the Trakt utilities button URL to `https://utilities.kometa.wiki/trakt-oauth/callback`
  - Ensured the modal Import YAML button is wired correctly
  - Preserved token-check behavior for imported credentials
- validation_routes.py
  - Added backend support for parsing and persisting the pasted Trakt YAML payload
- test_validate_service_routes.py
  - Added coverage for the new Trakt YAML import endpoint

### Why
- Aligns Quickstart with the Kometa Utilities flow in issue 1721
- Removes the confusing legacy PIN path
- Keeps credential storage compatible with existing Trakt section persistence
- Avoids exposing a raw YAML block beyond the import step

### Verification
- Backend route tests for Trakt YAML import passed
- Existing Trakt validation/token-check behavior remains intact
## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1721 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056330&installation_model_id=431096&pr_number=1760&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1760&signature=95a1d4cdca7fc1d816684af6ad2b09bd28397d7a377d7f7a4f103746d8e98249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->