### PR TITLE
fix scroll issue

### DIFF
--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -3878,16 +3878,45 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function getWindowScrollPosition () {
+    return {
+      x: window.scrollX || window.pageXOffset || 0,
+      y: window.scrollY || window.pageYOffset || 0
+    }
+  }
+
+  function restoreWindowScrollPosition (position) {
+    if (!position || typeof window.scrollTo !== 'function') return
+    window.scrollTo(position.x, position.y)
+  }
+
+  function focusWithoutScrolling (element) {
+    if (!element || typeof element.focus !== 'function') return
+    try {
+      element.focus({ preventScroll: true })
+    } catch {
+      element.focus()
+    }
+  }
+
   function fallbackCopy (text, opts = {}) {
     const showFailureToast = opts.showFailureToast !== false
     const showSuccessToast = opts.showSuccessToast !== false
+    const windowScroll = getWindowScrollPosition()
+    const activeElement = document.activeElement
     const textarea = document.createElement('textarea')
     textarea.value = text
     textarea.setAttribute('readonly', '')
-    textarea.style.position = 'absolute'
-    textarea.style.left = '-9999px'
+    textarea.setAttribute('aria-hidden', 'true')
+    textarea.style.position = 'fixed'
+    textarea.style.top = '0'
+    textarea.style.left = '0'
+    textarea.style.width = '1px'
+    textarea.style.height = '1px'
+    textarea.style.opacity = '0'
+    textarea.style.pointerEvents = 'none'
     document.body.appendChild(textarea)
-    textarea.focus()
+    focusWithoutScrolling(textarea)
     textarea.select()
     textarea.setSelectionRange(0, textarea.value.length)
     try {
@@ -3901,21 +3930,34 @@ document.addEventListener('DOMContentLoaded', () => {
       if (showFailureToast) showToast('error', 'Copy failed. Please copy manually.')
     } finally {
       document.body.removeChild(textarea)
+      restoreWindowScrollPosition(windowScroll)
+      if (activeElement && document.contains(activeElement)) {
+        focusWithoutScrolling(activeElement)
+        restoreWindowScrollPosition(windowScroll)
+      }
     }
     return false
   }
 
   function selectSupportInfoText () {
     if (!output) return
+    const windowScroll = getWindowScrollPosition()
+    const outputScroll = output.scrollTop
+    const modalBody = output.closest('.modal-body')
+    const modalBodyScroll = modalBody ? modalBody.scrollTop : 0
     try {
       const selection = window.getSelection()
       const range = document.createRange()
       range.selectNodeContents(output)
       selection.removeAllRanges()
       selection.addRange(range)
-      if (typeof output.focus === 'function') output.focus()
+      focusWithoutScrolling(output)
     } catch {
       // No-op: selection best-effort only.
+    } finally {
+      output.scrollTop = outputScroll
+      if (modalBody) modalBody.scrollTop = modalBodyScroll
+      restoreWindowScrollPosition(windowScroll)
     }
   }
 


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Fixes the Support Info copy/select fallback scrolling the page behind the modal to the bottom in browsers where clipboard access is unavailable or blocked.

## What Changed

- Changed the fallback copy textarea from an absolutely positioned offscreen element to a fixed, invisible 1px control.
- Added focus handling with `preventScroll` where supported.
- Restored the window scroll position after fallback copy/select behavior.
- Preserved the Support Info output/modal scroll position when selecting text manually.

## Verification

- Ran `npm run lint:eslint -- static/local-js/000-base.js`

Fixes #1691
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1691 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789086919&installation_model_id=431096&pr_number=1761&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1761&signature=7749be25a56ab82d276050be6c0d9e77b18aef1e2660ae13841fd6d9c0c164e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->