### PR TITLE
progress bar for validate all

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -1331,6 +1331,8 @@ os.makedirs(flask_cache_dir, exist_ok=True)
 
 logscan_reingest_lock = threading.Lock()
 logscan_ingest_lock = threading.Lock()
+BULK_VALIDATION_PROGRESS = {}
+BULK_VALIDATION_PROGRESS_LOCK = threading.Lock()
 logscan_reingest_state = {
     "status": "idle",
     "job_id": None,
@@ -3006,8 +3008,63 @@ def lookup_template_string_value():
     return jsonify({"error": f"Unsupported lookup preset: {preset}"}), 400
 
 
+def _bulk_validation_progress_key(config_name):
+    return str(config_name or "__default__").strip() or "__default__"
+
+
+def _clone_bulk_validation_progress(progress):
+    if not isinstance(progress, dict):
+        return {}
+    snapshot = dict(progress)
+    snapshot["steps"] = [dict(step) for step in progress.get("steps", []) if isinstance(step, dict)]
+    snapshot["results"] = {str(key): dict(value) if isinstance(value, dict) else value for key, value in (progress.get("results") or {}).items()}
+    snapshot["summary"] = dict(progress.get("summary") or {})
+    return snapshot
+
+
+def _set_bulk_validation_progress(config_name, **updates):
+    progress_key = _bulk_validation_progress_key(config_name)
+    with BULK_VALIDATION_PROGRESS_LOCK:
+        progress = dict(BULK_VALIDATION_PROGRESS.get(progress_key) or {})
+        progress.update(updates)
+        progress["config_name"] = progress_key
+        progress["updated_at"] = utc_now_iso()
+        BULK_VALIDATION_PROGRESS[progress_key] = progress
+        return _clone_bulk_validation_progress(progress)
+
+
+def _get_bulk_validation_progress(config_name):
+    progress_key = _bulk_validation_progress_key(config_name)
+    with BULK_VALIDATION_PROGRESS_LOCK:
+        return _clone_bulk_validation_progress(BULK_VALIDATION_PROGRESS.get(progress_key) or {})
+
+
+@app.route("/validate_all_services/status", methods=["GET"])
+def validate_all_services_status():
+    config_name = session.get("config_name") or persistence.ensure_session_config_name()
+    requested_run_id = str(request.args.get("run_id") or "").strip()
+    progress = _get_bulk_validation_progress(config_name)
+    if requested_run_id and progress.get("run_id") != requested_run_id:
+        progress = {}
+    if not progress:
+        progress = {
+            "config_name": _bulk_validation_progress_key(config_name),
+            "run_id": requested_run_id,
+            "phase": "idle",
+            "total": 0,
+            "completed": 0,
+            "current_key": "",
+            "current_label": "",
+            "results": {},
+            "summary": {"validated": 0, "failed": 0, "skipped": 0},
+        }
+    return jsonify({"success": True, "progress": progress})
+
+
 @app.route("/validate_all_services", methods=["POST"])
 def validate_all_services():
+    request_data = request.get_json(silent=True) or {}
+    run_id = str(request_data.get("run_id") or secrets.token_urlsafe(8)).strip()
     config_name = session.get("config_name") or persistence.ensure_session_config_name()
     floppy_token_required = bool(_config_floppy_dependency_reasons(database.retrieve_config_sections(config_name)))
 
@@ -3157,10 +3214,69 @@ def validate_all_services():
         ),
     ]
 
+    label_map = {}
+    try:
+        for file, display_name in helpers.get_menu_list():
+            label_map[file.rsplit(".", 1)[0]] = display_name
+    except Exception:
+        label_map = {}
+
+    def label_for_key(key):
+        return label_map.get(key, key)
+
     results = {}
     summary = {"validated": 0, "failed": 0, "skipped": 0}
+    manual_progress_keys = ["001-start", "025-libraries", "150-settings", "100-anidb", "090-webhooks", "130-trakt", "140-mal"]
+    progress_steps = [{"key": template_key, "label": label_for_key(template_key)} for template_key, *_rest in targets]
+    progress_steps.extend({"key": key, "label": label_for_key(key)} for key in manual_progress_keys)
+    progress_completed = 0
+    _set_bulk_validation_progress(
+        config_name,
+        run_id=run_id,
+        phase="running",
+        total=len(progress_steps),
+        completed=0,
+        current_key="",
+        current_label="Preparing validation",
+        current_status="pending",
+        steps=progress_steps,
+        results={},
+        summary=summary,
+    )
+
+    def start_progress_step(template_key):
+        _set_bulk_validation_progress(
+            config_name,
+            phase="running",
+            total=len(progress_steps),
+            completed=progress_completed,
+            current_key=template_key,
+            current_label=label_for_key(template_key),
+            current_status="running",
+            steps=progress_steps,
+            results=results,
+            summary=summary,
+        )
+
+    def finish_progress_step(template_key):
+        nonlocal progress_completed
+        progress_completed += 1
+        result = results.get(template_key) or {}
+        _set_bulk_validation_progress(
+            config_name,
+            phase="running",
+            total=len(progress_steps),
+            completed=progress_completed,
+            current_key=template_key,
+            current_label=label_for_key(template_key),
+            current_status=result.get("status", "complete") if isinstance(result, dict) else "complete",
+            steps=progress_steps,
+            results=results,
+            summary=summary,
+        )
 
     for template_key, section, validator, payload_builder, required_keys in targets:
+        start_progress_step(template_key)
         settings = persistence.retrieve_settings(template_key)
         validated_at = settings.get("validated_at")
         payload = payload_builder(settings) or {}
@@ -3175,6 +3291,7 @@ def validate_all_services():
                 }
                 persist_validation_metadata(section, "skipped", reason="missing_location")
                 summary["skipped"] += 1
+                finish_progress_step(template_key)
                 continue
         if not has_required_credentials(payload, required_keys):
             results[template_key] = {
@@ -3184,6 +3301,7 @@ def validate_all_services():
             }
             persist_validation_metadata(section, "skipped", reason="missing_credentials")
             summary["skipped"] += 1
+            finish_progress_step(template_key)
             continue
         try:
             response = validator(payload)
@@ -3215,6 +3333,8 @@ def validate_all_services():
             )
             results[template_key] = {"status": "validated", "validated_at": new_validated_at}
             summary["validated"] += 1
+            finish_progress_step(template_key)
+            continue
         else:
             stored_data["validated"] = False
             if existing_validated_at:
@@ -3237,6 +3357,7 @@ def validate_all_services():
             if message:
                 results[template_key]["details"] = message
             summary["failed"] += 1
+            finish_progress_step(template_key)
 
     def update_section_validation(template_key, section, is_valid, reason=None, details=None):
         stored_validated, user_entered, stored_data = database.retrieve_section_data(config_name, section)
@@ -3300,6 +3421,7 @@ def validate_all_services():
         results[template_key] = result
         summary["skipped"] += 1
 
+    start_progress_step("001-start")
     kometa_settings, kometa_section = _get_kometa_settings_section(config_name)
     del kometa_settings
     kometa_valid, kometa_reason, kometa_details = _validate_saved_kometa_selection(kometa_section)
@@ -3310,8 +3432,10 @@ def validate_all_services():
         reason=kometa_reason,
         details=kometa_details,
     )
+    finish_progress_step("001-start")
 
     # Validate All checks for libraries
+    start_progress_step("025-libraries")
     plex_settings = persistence.retrieve_settings("010-plex") or {}
     plex_is_valid = helpers.booler(plex_settings.get("validated", False)) if isinstance(plex_settings, dict) else False
     if not plex_is_valid:
@@ -3432,8 +3556,10 @@ def validate_all_services():
                     else arr_override_errors if libraries_reason == "invalid_arr_overrides" else auto_sort_hubs_errors if libraries_reason == "invalid_library_settings" else None
                 ),
             )
+    finish_progress_step("025-libraries")
 
     # Validate All checks for settings
+    start_progress_step("150-settings")
     settings_settings = persistence.retrieve_settings("150-settings") or {}
     settings_section = settings_settings.get("settings", {}) if isinstance(settings_settings, dict) else {}
     if not isinstance(settings_section, dict) or not settings_section:
@@ -3495,8 +3621,10 @@ def validate_all_services():
             update_section_validation("150-settings", "settings", False, reason="invalid_fields")
         else:
             update_section_validation("150-settings", "settings", True)
+    finish_progress_step("150-settings")
 
     # Validate All checks for AniDB
+    start_progress_step("100-anidb")
     anidb_settings = persistence.retrieve_settings("100-anidb") or {}
     anidb_data = anidb_settings.get("anidb", {}) if isinstance(anidb_settings, dict) else {}
     anidb_enabled = helpers.booler(anidb_data.get("enable")) if isinstance(anidb_data, dict) else False
@@ -3504,8 +3632,10 @@ def validate_all_services():
         update_section_validation("100-anidb", "anidb", True)
     else:
         skip_section_validation("100-anidb", "anidb", reason="disabled")
+    finish_progress_step("100-anidb")
 
     # Validate All checks for Webhooks
+    start_progress_step("090-webhooks")
     webhooks_settings = persistence.retrieve_settings("090-webhooks") or {}
     webhooks_data = webhooks_settings.get("webhooks", {}) if isinstance(webhooks_settings, dict) else {}
     configured_webhooks = False
@@ -3519,8 +3649,10 @@ def validate_all_services():
         update_section_validation("090-webhooks", "webhooks", True)
     else:
         skip_section_validation("090-webhooks", "webhooks", reason="no_webhooks")
+    finish_progress_step("090-webhooks")
 
     # Validate All checks for Trakt (token check if present)
+    start_progress_step("130-trakt")
     trakt_settings = persistence.retrieve_settings("130-trakt") or {}
     trakt_data = trakt_settings.get("trakt", {}) if isinstance(trakt_settings, dict) else {}
     trakt_auth = trakt_data.get("authorization", {}) if isinstance(trakt_data, dict) else {}
@@ -3550,8 +3682,10 @@ def validate_all_services():
                 update_section_validation("130-trakt", "trakt", False, reason="validation_error")
         except requests.exceptions.RequestException:
             update_section_validation("130-trakt", "trakt", False, reason="validation_error")
+    finish_progress_step("130-trakt")
 
     # Validate All checks for MAL (token check if present)
+    start_progress_step("140-mal")
     mal_settings = persistence.retrieve_settings("140-mal") or {}
     mal_data = mal_settings.get("mal", {}) if isinstance(mal_settings, dict) else {}
     mal_auth = mal_data.get("authorization", {}) if isinstance(mal_data, dict) else {}
@@ -3573,6 +3707,7 @@ def validate_all_services():
                 update_section_validation("140-mal", "mal", False, reason="validation_error")
         except requests.exceptions.RequestException:
             update_section_validation("140-mal", "mal", False, reason="validation_error")
+    finish_progress_step("140-mal")
 
     reason_labels = {
         "missing_credentials": "Missing credentials",
@@ -3643,7 +3778,32 @@ def validate_all_services():
         user_entered=True,
         data=summary_payload,
     )
-    return jsonify({"success": True, "results": results, "summary": summary, "summary_text": summary_text, "summary_updated_at": summary_updated_at})
+    progress_snapshot = _set_bulk_validation_progress(
+        config_name,
+        run_id=run_id,
+        phase="complete",
+        total=len(progress_steps),
+        completed=len(progress_steps),
+        current_key="",
+        current_label="Validation complete",
+        current_status="complete",
+        steps=progress_steps,
+        results=results,
+        summary=summary,
+        summary_text=summary_text,
+        summary_updated_at=summary_updated_at,
+    )
+    return jsonify(
+        {
+            "success": True,
+            "results": results,
+            "summary": summary,
+            "summary_text": summary_text,
+            "summary_updated_at": summary_updated_at,
+            "progress": progress_snapshot,
+            "run_id": run_id,
+        }
+    )
 
 
 @app.route("/shutdown", methods=["POST"])

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4903,12 +4903,9 @@ body {
     flex: 0 0 auto;
 }
 
-.qs-sidebar-validate {
-    gap: 0.3rem;
-}
-
-.qs-sidebar-validate .bi-check2-circle {
-    flex: 0 0 auto;
+.qs-validation-row-active > td,
+.qs-validation-row-active > th {
+    box-shadow: inset 3px 0 0 var(--theme-primary);
 }
 
 .qs-sidebar-text {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -2232,10 +2232,15 @@ function qsSetBulkValidationLoading (isLoading) {
 function qsRunBulkValidation (options = {}) {
   if (qsBulkValidationRequest) return qsBulkValidationRequest
 
-  document.dispatchEvent(new CustomEvent('qs:bulk-validation-start', { detail: { source: options.source || null } }))
+  const runId = options.runId || `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  document.dispatchEvent(new CustomEvent('qs:bulk-validation-start', { detail: { source: options.source || null, runId } }))
   qsSetBulkValidationLoading(true)
 
-  qsBulkValidationRequest = fetch('/validate_all_services', { method: 'POST' })
+  qsBulkValidationRequest = fetch('/validate_all_services', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ run_id: runId })
+  })
     .then(async (res) => {
       let data = null
       try {
@@ -2254,6 +2259,7 @@ function qsRunBulkValidation (options = {}) {
 
       const results = data.results || {}
       const summary = data.summary || {}
+      data.run_id = data.run_id || runId
       qsApplyBulkValidationResults(results, summary)
       document.dispatchEvent(new CustomEvent('qs:bulk-validation-complete', { detail: data }))
 

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -804,8 +804,14 @@ const validateAllBtn = document.getElementById('validate-all-services')
 const validateAllStatus = document.getElementById('validate-all-status')
 const validateAllStatusBulk = document.getElementById('validate-all-status-bulk')
 const validateAllStatusBulkTime = document.getElementById('validate-all-status-bulk-time')
+const validateAllProgress = document.getElementById('validate-all-progress')
+const validateAllProgressLabel = document.getElementById('validate-all-progress-label')
+const validateAllProgressCount = document.getElementById('validate-all-progress-count')
+const validateAllProgressBar = document.getElementById('validate-all-progress-bar')
 let previouslyBlocked = false
 let previousStatuses = {}
+let validateAllProgressTimer = null
+let validateAllProgressRunId = ''
 
 function getValidateAllCompleteMessage (summary) {
   const counts = window.QSBulkValidation && typeof window.QSBulkValidation.getSummaryCounts === 'function'
@@ -835,8 +841,106 @@ function reloadAfterBulkValidationRefresh (data, summary) {
   setTimeout(() => window.location.reload(), 300)
 }
 
+function stopValidateAllProgressPolling () {
+  if (!validateAllProgressTimer) return
+  clearInterval(validateAllProgressTimer)
+  validateAllProgressTimer = null
+}
+
+function setValidateAllProgressVisibility (visible) {
+  if (validateAllProgress) validateAllProgress.classList.toggle('d-none', !visible)
+}
+
+function formatProgressStatus (status) {
+  const normalized = String(status || '').trim().toLowerCase()
+  if (normalized === 'validated') return 'validated'
+  if (normalized === 'failed') return 'failed'
+  if (normalized === 'skipped') return 'skipped'
+  if (normalized === 'complete') return 'complete'
+  return ''
+}
+
+function syncValidateAllProgressRows (progress) {
+  const results = (progress && progress.results && typeof progress.results === 'object') ? progress.results : {}
+  Object.keys(results).forEach(key => updateValidationRow(key, results[key]))
+
+  const currentKey = String((progress && progress.current_key) || '')
+  document.querySelectorAll('[data-validation-key]').forEach(row => {
+    row.classList.toggle('qs-validation-row-active', Boolean(currentKey && row.dataset.validationKey === currentKey && progress.phase === 'running'))
+  })
+}
+
+function renderValidateAllProgress (progress) {
+  if (!validateAllProgress) return
+  const payload = (progress && typeof progress === 'object') ? progress : {}
+  const phase = String(payload.phase || 'running')
+  const total = Number(payload.total || 0)
+  const completed = Number(payload.completed || 0)
+  const percent = total > 0 ? Math.max(0, Math.min(100, Math.round((completed / total) * 100))) : 0
+  const currentLabel = String(payload.current_label || '').trim()
+  const currentStatus = formatProgressStatus(payload.current_status)
+
+  setValidateAllProgressVisibility(phase !== 'idle')
+  if (validateAllProgressBar) {
+    validateAllProgressBar.style.width = `${percent}%`
+    validateAllProgressBar.setAttribute('aria-valuenow', String(percent))
+    validateAllProgressBar.classList.toggle('bg-danger', phase === 'error')
+    validateAllProgressBar.classList.toggle('bg-success', phase === 'complete')
+  }
+  if (validateAllProgressCount) {
+    validateAllProgressCount.textContent = total > 0 ? `${Math.min(completed, total)} / ${total}` : ''
+  }
+  if (validateAllProgressLabel) {
+    if (phase === 'complete') {
+      validateAllProgressLabel.textContent = 'Validation complete'
+    } else if (phase === 'error') {
+      validateAllProgressLabel.textContent = 'Validation failed'
+    } else if (currentLabel) {
+      const statusSuffix = currentStatus && currentStatus !== 'complete' ? ` (${currentStatus})` : ''
+      validateAllProgressLabel.textContent = `Validating ${currentLabel}${statusSuffix}...`
+    } else {
+      validateAllProgressLabel.textContent = 'Preparing validation...'
+    }
+  }
+  syncValidateAllProgressRows(payload)
+}
+
+function fetchValidateAllProgress () {
+  const query = validateAllProgressRunId ? `?run_id=${encodeURIComponent(validateAllProgressRunId)}` : ''
+  return fetch(`/validate_all_services/status${query}`, { cache: 'no-store' })
+    .then(res => res.json())
+    .then(data => {
+      if (!data || !data.success) return null
+      const progress = data.progress || {}
+      if (progress.phase === 'idle' && validateAllProgressTimer) return progress
+      renderValidateAllProgress(progress)
+      if (progress.phase === 'complete' || progress.phase === 'error') {
+        stopValidateAllProgressPolling()
+      }
+      return progress
+    })
+    .catch(() => null)
+}
+
+function startValidateAllProgressPolling () {
+  stopValidateAllProgressPolling()
+  renderValidateAllProgress({
+    phase: 'running',
+    total: 0,
+    completed: 0,
+    current_label: '',
+    current_status: 'running',
+    results: {},
+    summary: {}
+  })
+  fetchValidateAllProgress()
+  validateAllProgressTimer = setInterval(fetchValidateAllProgress, 700)
+}
+
 if (validateAllBtn) {
-  document.addEventListener('qs:bulk-validation-start', function () {
+  document.addEventListener('qs:bulk-validation-start', function (event) {
+    const detail = (event && event.detail) ? event.detail : {}
+    validateAllProgressRunId = String(detail.runId || '')
     previouslyBlocked = !kometaState.showYAML
     previousStatuses = {}
     document.querySelectorAll('[data-validation-key]').forEach(row => {
@@ -846,6 +950,7 @@ if (validateAllBtn) {
         previousStatuses[key] = pill.classList.contains('rating-mapping-option-via--validated')
       }
     })
+    startValidateAllProgressPolling()
 
     if (validateAllStatus) {
       validateAllStatus.classList.add('d-none')
@@ -859,6 +964,15 @@ if (validateAllBtn) {
     const data = (event && event.detail) ? event.detail : {}
     const finalGateState = getFinalGateState()
     const results = data.results || {}
+    stopValidateAllProgressPolling()
+    renderValidateAllProgress(data.progress || {
+      phase: 'complete',
+      total: Object.keys(results).length,
+      completed: Object.keys(results).length,
+      current_label: 'Validation complete',
+      current_status: 'complete',
+      results
+    })
     const gateTargets = {
       '010-plex': { id: 'plex_valid', datasetKey: 'plexValid', attrKey: 'plex-valid' },
       '020-tmdb': { id: 'tmdb_valid', datasetKey: 'tmdbValid', attrKey: 'tmdb-valid' },
@@ -922,6 +1036,15 @@ if (validateAllBtn) {
   document.addEventListener('qs:bulk-validation-error', function (event) {
     const detail = (event && event.detail) ? event.detail : {}
     const message = detail.message || 'Validate all failed. Please try again.'
+    stopValidateAllProgressPolling()
+    renderValidateAllProgress({
+      phase: 'error',
+      total: 0,
+      completed: 0,
+      current_label: message,
+      current_status: 'failed',
+      results: {}
+    })
     if (validateAllStatus) {
       validateAllStatus.classList.remove('d-none', 'text-success', 'text-warning')
       validateAllStatus.classList.add('text-danger')

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -168,6 +168,17 @@
           Validate All completed:
           <span id="validate-all-status-bulk-time" data-validation-iso="{{ validation_bulk_rollup_at | default('', true) }}">—</span>
         </div>
+        <div id="validate-all-progress" class="d-none mb-2" aria-live="polite">
+          <div class="d-flex flex-wrap justify-content-between gap-2 mb-1">
+            <span id="validate-all-progress-label" class="small text-info">Preparing validation...</span>
+            <span id="validate-all-progress-count" class="small text-muted">0 / 0</span>
+          </div>
+          <div class="progress" style="height: 8px;">
+            <div id="validate-all-progress-bar" class="progress-bar" role="progressbar" style="width: 0%"
+              aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+          </div>
+          <div id="validate-all-status" class="small text-info mt-1 d-none"></div>
+        </div>
         <div class="table-responsive" data-qs-sticky-first="true">
           <table class="table table-sm table-dark table-striped align-middle mb-0">
             <thead>

--- a/templates/partials/_workspace_macros.html
+++ b/templates/partials/_workspace_macros.html
@@ -193,11 +193,6 @@ Sponsor
         <i class="bi bi-folder2-open qs-sidebar-config-icon" aria-hidden="true"></i>
         <span class="qs-sidebar-text qs-sidebar-config-label">Manage Configs</span>
       </button>
-      <button type="button" class="btn nav-button qs-sidebar-validate" id="qs-sidebar-validate-all"
-        data-qs-validate-all title="Validate ALL configured services">
-        <i class="bi bi-check2-circle"></i><span class="qs-sidebar-text">Validate All</span>
-        <span class="spinner-border spinner-border-sm ms-1 d-none qs-validate-all-spinner" role="status" aria-hidden="true"></span>
-      </button>
     </div>
   </div>
 </div>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4087,6 +4087,15 @@ def test_validate_all_services_flags_invalid_library_arr_overrides(client, monke
     assert libraries_result["status"] == "failed"
     assert libraries_result["reason"] == "invalid_arr_overrides"
     assert any("/bad-root" in detail for detail in libraries_result["details"])
+    assert payload["progress"]["phase"] == "complete"
+    assert payload["progress"]["completed"] == payload["progress"]["total"]
+    assert payload["progress"]["results"]["025-libraries"]["reason"] == "invalid_arr_overrides"
+
+    status = client.get(f"/validate_all_services/status?run_id={payload['run_id']}")
+    assert status.status_code == 200
+    status_payload = status.get_json()
+    assert status_payload["progress"]["run_id"] == payload["run_id"]
+    assert status_payload["progress"]["phase"] == "complete"
 
 
 def test_validate_all_services_flags_invalid_external_kometa_paths(client, monkeypatch, qs_module, tmp_path):
@@ -4131,6 +4140,8 @@ def test_validate_all_services_flags_invalid_external_kometa_paths(client, monke
     assert start_result["status"] == "failed"
     assert start_result["reason"] == "invalid_paths"
     assert any(str(missing_external) in detail for detail in start_result["details"])
+    assert payload["progress"]["phase"] == "complete"
+    assert payload["progress"]["results"]["001-start"]["reason"] == "invalid_paths"
 
 
 def test_step_post_from_libraries_rejects_invalid_collection_files(client, isolated_config_dir, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Move Validate All ownership to the Kometa page and add visible bulk-validation progress.

## What Changed

- Removed the duplicate Validate All action from the sidebar Utilities menu.
- Kept Validate All on the Kometa page as the single manual entry point.
- Added a Kometa-page progress bar with current validation label and completed/total count.
- Added backend bulk-validation progress snapshots keyed by run/config.
- Added `/validate_all_services/status` so the Kometa page can poll progress while validation runs.
- Highlighted the currently running validation row.
- Included progress metadata in the final `/validate_all_services` response.

## Verification

- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py::test_validate_all_services_flags_invalid_library_arr_overrides tests\test_core_backend.py::test_validate_all_services_flags_invalid_external_kometa_paths`
- `npm run lint:eslint -- static/local-js/000-base.js static/local-js/900-kometa.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789101425&installation_model_id=431096&pr_number=1762&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1762&signature=9d8fd15ffbb08e507ddaef17066397b51abaf89e4746f48dbabbd3265c05686d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->