### PR TITLE
Improve people detection

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -19,6 +19,8 @@ from modules import (
 from modules.logscan_people import (  # noqa: F401
     PEOPLE_MISSING_WARNING_RE,
     PEOPLE_MISSING_WARNING_REGEX,
+    PEOPLE_POSTER_README_URLS,
+    PEOPLE_POSTER_UPDATE_RE,
     PEOPLE_README_URLS,
     PEOPLE_SECTION_END_PATTERNS,
     PEOPLE_SECTION_START_STRONG,
@@ -45,6 +47,7 @@ class LogscanAnalyzer:
         self.server_versions = []
         self.people_index_available = False
         self._people_index = None
+        self._people_poster_index = None
         self.validation_summary = {}
 
     def reset_server_versions(self):
@@ -128,6 +131,9 @@ class LogscanAnalyzer:
     def _get_people_cache_path(self, log_path):
         return logscan_people.get_people_cache_path(log_path)
 
+    def _get_people_poster_cache_path(self, log_path):
+        return logscan_people.get_people_poster_cache_path(log_path)
+
     def _load_people_cache(self, cache_path):
         return logscan_people.load_people_cache(cache_path)
 
@@ -137,13 +143,17 @@ class LogscanAnalyzer:
     def _fetch_people_readme(self, cache_path):
         return logscan_people.fetch_people_readme(cache_path)
 
+    def _fetch_people_poster_readme(self, cache_path):
+        return logscan_people.fetch_people_poster_readme(cache_path)
+
     def _build_people_index(self, readme_text):
         return logscan_people.build_people_index(readme_text)
 
     def preload_people_index(self, log_path=None):
-        cache_path = logscan_people.get_people_cache_path(log_path)
-        readme_text, _used_cache = logscan_people.fetch_people_readme(cache_path)
+        cache_path = logscan_people.get_people_poster_cache_path(log_path)
+        readme_text, _used_cache = logscan_people.fetch_people_poster_readme(cache_path)
         self._people_index = logscan_people.build_people_index(readme_text)
+        self._people_poster_index = self._people_index
         self.people_index_available = bool(self._people_index)
         return self._people_index
 

--- a/modules/logscan_people.py
+++ b/modules/logscan_people.py
@@ -1,9 +1,8 @@
 """People-poster detection helpers extracted from ``modules.logscan``.
 
-These functions scan a Kometa log for ``Collection Warning: No Poster Found
-at <people-images-url>`` lines, look up the names against a cached copy of the
-People-Images repo README, and surface the genuinely-missing people for the
-recommendation panel.
+These functions scan a Kometa log for people-poster signals, look up the names
+against a cached copy of the styled People-Images repo README, and surface the
+genuinely-missing people for the recommendation panel.
 
 The functions are pure (no analyzer state); ``LogscanAnalyzer`` retains thin
 wrapper methods that delegate here and manage the cached people index on the
@@ -31,6 +30,7 @@ _logger = logging.getLogger("logscan")
 # ---------------------------------------------------------------------------
 
 PEOPLE_README_URLS = ("https://raw.githubusercontent.com/Kometa-Team/People-Images/refs/heads/master/README.md",)
+PEOPLE_POSTER_README_URLS = ("https://raw.githubusercontent.com/Kometa-Team/People-Images-bw/master/README.md",)
 
 PEOPLE_MISSING_WARNING_REGEX = (
     r"Collection Warning: No Poster Found at "
@@ -39,6 +39,10 @@ PEOPLE_MISSING_WARNING_REGEX = (
     r"/[^\s\]]+)"
 )
 PEOPLE_MISSING_WARNING_RE = re.compile(PEOPLE_MISSING_WARNING_REGEX, re.IGNORECASE)
+PEOPLE_POSTER_UPDATE_RE = re.compile(
+    r"Metadata:\s+tmdb_person\s+updated\s+poster\s+to\s+\[URL\]\s+https?://\S+",
+    re.IGNORECASE,
+)
 
 PEOPLE_SECTION_START_STRONG = (
     r"^(.+?) Collection in .+$",
@@ -51,6 +55,7 @@ PEOPLE_SECTION_START_WEAK = (
 PEOPLE_SECTION_END_PATTERNS = (r"^Finished .+ Collection$",)
 
 _PEOPLE_README_FILENAME_RE = re.compile(r"([A-Za-z0-9_./%\-]+\.(?:jpg|jpeg|png|webp))", re.IGNORECASE)
+_PEOPLE_ROLE_SUFFIX_RE = re.compile(r"\s+\((?:Director|Producer|Writer)\)\s*$", re.IGNORECASE)
 _KEY_NAME_PATTERNS = (
     r"^Validating\s+(.+?)\s+Attributes$",
     r"^Running\s+(.+?)\s+Collection$",
@@ -69,13 +74,20 @@ def extract_filename_from_url(url: str) -> str:
     return unquote(os.path.splitext(os.path.basename(url))[0])
 
 
+def normalize_people_name(name: str | None) -> str:
+    """Normalize a person name for poster-index comparison."""
+    if not name:
+        return ""
+    return _PEOPLE_ROLE_SUFFIX_RE.sub("", str(name).strip()).strip()
+
+
 # ---------------------------------------------------------------------------
 # People cache (README mirror) management
 # ---------------------------------------------------------------------------
 
 
-def get_people_cache_path(log_path=None) -> Path:
-    """Return the on-disk path used to cache the People-Images README.
+def _get_cache_path(filename: str, log_path=None) -> Path:
+    """Return the on-disk path used to cache a people-poster README.
 
     Prefers the project-wide ``config/cache/logscan/`` directory; falls back to
     a sidecar in the log's directory, and finally to the current working
@@ -84,17 +96,25 @@ def get_people_cache_path(log_path=None) -> Path:
     cache_dir = Path(__file__).resolve().parent.parent / "config" / "cache" / "logscan"
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
-        return cache_dir / "logscan_people_readme.json"
+        return cache_dir / filename
     except Exception:
         pass
     if log_path:
         try:
             log_path = Path(log_path)
             if log_path.is_file():
-                return log_path.parent / ".logscan_people_cache.json"
+                return log_path.parent / f".{filename}"
         except Exception:
             pass
-    return Path.cwd() / ".logscan_people_cache.json"
+    return Path.cwd() / f".{filename}"
+
+
+def get_people_cache_path(log_path=None) -> Path:
+    return _get_cache_path("logscan_people_readme.json", log_path=log_path)
+
+
+def get_people_poster_cache_path(log_path=None) -> Path:
+    return _get_cache_path("logscan_people_posters_readme.json", log_path=log_path)
 
 
 def load_people_cache(cache_path) -> dict:
@@ -119,7 +139,7 @@ def save_people_cache(cache_path, payload: dict) -> None:
         return
 
 
-def fetch_people_readme(cache_path) -> tuple[str | None, bool]:
+def fetch_people_readme(cache_path, readme_urls: Iterable[str] = PEOPLE_README_URLS) -> tuple[str | None, bool]:
     """Fetch the People-Images README, honoring HTTP cache headers stored in
     ``cache_path``. Returns ``(text, used_cache)``.
 
@@ -130,7 +150,7 @@ def fetch_people_readme(cache_path) -> tuple[str | None, bool]:
     cache = load_people_cache(cache_path)
     cached_content = cache.get("content")
 
-    for url in PEOPLE_README_URLS:
+    for url in readme_urls:
         headers = {"User-Agent": "Quickstart-Logscan"}
         if cache.get("url") == url:
             if cache.get("etag"):
@@ -159,6 +179,10 @@ def fetch_people_readme(cache_path) -> tuple[str | None, bool]:
             continue
 
     return cached_content, True if cached_content else False
+
+
+def fetch_people_poster_readme(cache_path) -> tuple[str | None, bool]:
+    return fetch_people_readme(cache_path, readme_urls=PEOPLE_POSTER_README_URLS)
 
 
 def build_people_index(readme_text: str | None) -> set[str]:
@@ -330,10 +354,36 @@ def extract_missing_people_names(lines: Iterable[str], available: set[str] | Non
             name = extract_filename_from_url(url)
         if not name:
             continue
-        key = name.lower()
+        key = normalize_people_name(name).lower()
+        if not key:
+            continue
         if available and key in available:
             continue
         names.add(key)
+    return names
+
+
+def extract_people_poster_candidate_names(lines: Iterable[str], available: set[str] | None, name_hint: str | None = None) -> set[str]:
+    """Return people-poster candidates that are absent from ``available``.
+
+    Warning URLs supply their own filename-derived name. TMDB poster-update
+    lines need the surrounding collection key, so they are only considered when
+    ``name_hint`` is available.
+    """
+    names = extract_missing_people_names(lines, available, name_hint=name_hint)
+    if not name_hint:
+        return names
+
+    key = normalize_people_name(name_hint).lower()
+    if not key:
+        return names
+    if available and key in available:
+        return names
+
+    for line in lines:
+        if PEOPLE_POSTER_UPDATE_RE.search(line):
+            names.add(key)
+            break
     return names
 
 
@@ -366,7 +416,7 @@ def collect_missing_people_lines(
     seen_blocks: set[str] = set()
 
     for idx, line in enumerate(raw_lines):
-        if not PEOPLE_MISSING_WARNING_RE.search(line):
+        if not (PEOPLE_MISSING_WARNING_RE.search(line) or PEOPLE_POSTER_UPDATE_RE.search(line)):
             continue
 
         if idx < len(cleaned_lines):
@@ -379,7 +429,7 @@ def collect_missing_people_lines(
         name_hint = None
         if idx < len(cleaned_lines):
             name_hint = extract_key_name_from_block(cleaned_lines, start, end)
-        names = extract_missing_people_names(block_lines, available, name_hint=name_hint)
+        names = extract_people_poster_candidate_names(block_lines, available, name_hint=name_hint)
         if not names:
             continue
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -5478,6 +5478,150 @@ def _prune_logscan_archive(archive_dir):
     return removed
 
 
+def _extract_logscan_missing_people_header(text, max_lines=200):
+    header_lines = []
+    for line in text.splitlines():
+        header_lines.append(line)
+        if "Locating config..." in line:
+            break
+        if len(header_lines) >= max_lines:
+            break
+    return "\n".join(header_lines).rstrip()
+
+
+def _iter_logscan_missing_people_export_paths(cache_logs):
+    if not isinstance(cache_logs, dict):
+        return []
+    candidates = []
+    seen_paths = set()
+    seen_md5s = set()
+    for raw_path, entry in cache_logs.items():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("run_complete") is not True:
+            continue
+        if _normalize_logscan_tool_name(entry.get("tool_name") or _detect_logscan_tool_from_path(raw_path)) != "kometa":
+            continue
+        content_md5 = str(entry.get("content_md5") or "").strip()
+        if content_md5:
+            if content_md5 in seen_md5s:
+                continue
+            seen_md5s.add(content_md5)
+        try:
+            path = Path(raw_path)
+            resolved = path.resolve()
+        except Exception:
+            continue
+        if resolved in seen_paths:
+            continue
+        seen_paths.add(resolved)
+        try:
+            if not resolved.exists() or not resolved.is_file():
+                continue
+            stats = resolved.stat()
+        except Exception:
+            continue
+        candidates.append((stats.st_mtime, resolved))
+    candidates.sort(key=lambda item: item[0])
+    return [path for _mtime, path in candidates]
+
+
+def _rebuild_logscan_missing_people_export(cache_logs, analyzer=None):
+    cache_dir = _get_logscan_cache_dir()
+    missing_people_log = cache_dir / "meta_people_missing.log"
+    missing_people_meta = cache_dir / "meta_people_missing.json"
+    missing_people_unique = set()
+    missing_people_logs = 0
+    missing_people_blocks = []
+    missing_people_seen_blocks = set()
+    missing_people_seen_names = set()
+    missing_people_header = None
+    sample_errors = []
+
+    analyzer = analyzer or logscan.LogscanAnalyzer()
+    for path in _iter_logscan_missing_people_export_paths(cache_logs):
+        try:
+            content = _read_logscan_text(path, encoding="utf-8", errors="replace")
+            people_items = analyzer.collect_missing_people_lines(
+                content,
+                available_index=getattr(analyzer, "_people_index", None),
+                log_path=path,
+            )
+        except Exception as exc:
+            if len(sample_errors) < 5:
+                sample_errors.append(f"{path.name}: {exc}")
+            continue
+        if not people_items:
+            continue
+        log_names = set()
+        for item in people_items:
+            names = {str(name).strip().lower() for name in item.get("names", set()) if str(name).strip()}
+            if not names:
+                continue
+            log_names.update(names)
+            if names.issubset(missing_people_seen_names):
+                continue
+            block = item.get("block")
+            if block and block not in missing_people_seen_blocks:
+                missing_people_blocks.append(block)
+                missing_people_seen_blocks.add(block)
+            missing_people_seen_names.update(names)
+        if log_names:
+            missing_people_logs += 1
+            missing_people_unique.update(log_names)
+            if missing_people_header is None:
+                missing_people_header = _extract_logscan_missing_people_header(content)
+
+    missing_people_log_ready = False
+    missing_people_log_lines = 0
+    if missing_people_blocks:
+        try:
+            missing_people_log_lines = sum(len(block.splitlines()) for block in missing_people_blocks)
+            output_parts = []
+            if missing_people_header:
+                output_parts.append(missing_people_header)
+                missing_people_log_lines += len(missing_people_header.splitlines())
+            output_parts.extend(missing_people_blocks)
+            missing_people_log.write_text("\n".join(output_parts).rstrip() + "\n", encoding="utf-8")
+            missing_people_log_ready = True
+            try:
+                missing_people_meta.write_text(
+                    json.dumps(
+                        {
+                            "missing_people_unique": len(missing_people_unique),
+                            "missing_people_logs": missing_people_logs,
+                            "missing_people_log_lines": missing_people_log_lines,
+                            "updated_at": datetime.now(timezone.utc).isoformat(),
+                        },
+                        ensure_ascii=True,
+                        indent=2,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            except Exception:
+                pass
+        except Exception as exc:
+            if len(sample_errors) < 5:
+                sample_errors.append(f"{missing_people_log.name}: {exc}")
+    else:
+        try:
+            if missing_people_log.exists():
+                missing_people_log.unlink()
+            if missing_people_meta.exists():
+                missing_people_meta.unlink()
+        except Exception:
+            pass
+
+    return {
+        "missing_people_unique": len(missing_people_unique),
+        "missing_people_logs": missing_people_logs,
+        "missing_people_log_ready": missing_people_log_ready,
+        "missing_people_log_lines": missing_people_log_lines,
+        "sample_errors": sample_errors,
+    }
+
+
 def _perform_logscan_reingest(reset, job_id=None, update_state=True):
     if not logscan_ingest_lock.acquire(blocking=False):
         message = "Logscan ingest already running."
@@ -5506,16 +5650,6 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
             sample_incomplete=[],
             sample_errors=[],
         )
-
-    def _extract_fake_people_header(text, max_lines=200):
-        header_lines = []
-        for line in text.splitlines():
-            header_lines.append(line)
-            if "Locating config..." in line:
-                break
-            if len(header_lines) >= max_lines:
-                break
-        return "\n".join(header_lines).rstrip()
 
     try:
         ingest_cache = _load_logscan_ingest_cache()
@@ -5549,12 +5683,6 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
         skipped_incomplete = 0
         skipped_invalid = 0
         errors = 0
-        missing_people_unique = set()
-        missing_people_logs = 0
-        missing_people_blocks = []
-        missing_people_seen_blocks = set()
-        missing_people_seen_names = set()
-        missing_people_header = None
         sample_incomplete = []
         sample_errors = []
 
@@ -5704,25 +5832,6 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                         if archived_path:
                             cache_dirty = True
                     continue
-                missing_people = result.get("missing_people") if tool_name == "kometa" and isinstance(result, dict) else None
-                if missing_people:
-                    missing_people_logs += 1
-                    missing_people_unique.update({name.lower() for name in missing_people})
-                    if missing_people_header is None:
-                        missing_people_header = _extract_fake_people_header(content)
-                people_items = analyzer.collect_missing_people_lines(content, available_index=analyzer._people_index)
-                if people_items:
-                    for item in people_items:
-                        names = {name for name in item.get("names", set()) if name in missing_people_unique}
-                        if not names:
-                            continue
-                        if names.issubset(missing_people_seen_names):
-                            continue
-                        block = item.get("block")
-                        if block and block not in missing_people_seen_blocks:
-                            missing_people_blocks.append(block)
-                            missing_people_seen_blocks.add(block)
-                        missing_people_seen_names.update(names)
                 if skip_save_if_cached and cached_run_key == summary.get("run_key"):
                     duplicates += 1
                 else:
@@ -5779,57 +5888,17 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                     skipped_incomplete=skipped_incomplete,
                     skipped_invalid=skipped_invalid,
                     errors=errors,
-                    missing_people_unique=len(missing_people_unique),
-                    missing_people_logs=missing_people_logs,
                     sample_incomplete=sample_incomplete,
                     sample_errors=sample_errors,
                 )
             if idx % LOGSCAN_INGEST_CACHE_FLUSH_INTERVAL == 0:
                 _flush_ingest_cache_progress(force=True)
 
-        cache_dir = _get_logscan_cache_dir()
-        missing_people_log = cache_dir / "meta_people_missing.log"
-        missing_people_meta = cache_dir / "meta_people_missing.json"
-        missing_people_log_ready = False
-        missing_people_log_lines = 0
-        if missing_people_blocks:
-            try:
-                missing_people_log_lines = sum(len(block.splitlines()) for block in missing_people_blocks)
-                output_parts = []
-                if missing_people_header:
-                    output_parts.append(missing_people_header)
-                    missing_people_log_lines += len(missing_people_header.splitlines())
-                output_parts.extend(missing_people_blocks)
-                missing_people_log.write_text("\n".join(output_parts).rstrip() + "\n", encoding="utf-8")
-                missing_people_log_ready = True
-                try:
-                    missing_people_meta.write_text(
-                        json.dumps(
-                            {
-                                "missing_people_unique": len(missing_people_unique),
-                                "missing_people_logs": missing_people_logs,
-                                "updated_at": datetime.now(timezone.utc).isoformat(),
-                            },
-                            ensure_ascii=True,
-                            indent=2,
-                        )
-                        + "\n",
-                        encoding="utf-8",
-                    )
-                except Exception:
-                    pass
-            except Exception as exc:
-                errors += 1
-                if len(sample_errors) < 5:
-                    sample_errors.append(f"{missing_people_log.name}: {exc}")
-        else:
-            try:
-                if missing_people_log.exists():
-                    missing_people_log.unlink()
-                if missing_people_meta.exists():
-                    missing_people_meta.unlink()
-            except Exception:
-                pass
+        missing_people_export = _rebuild_logscan_missing_people_export(cache_logs, analyzer=analyzer)
+        missing_export_errors = missing_people_export.get("sample_errors") if isinstance(missing_people_export, dict) else []
+        if missing_export_errors:
+            errors += len(missing_export_errors)
+            sample_errors.extend(error for error in missing_export_errors if len(sample_errors) < 5)
 
         result = {
             "success": True,
@@ -5839,10 +5908,10 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
             "skipped_incomplete": skipped_incomplete,
             "skipped_invalid": skipped_invalid,
             "errors": errors,
-            "missing_people_unique": len(missing_people_unique),
-            "missing_people_logs": missing_people_logs,
-            "missing_people_log_ready": missing_people_log_ready,
-            "missing_people_log_lines": missing_people_log_lines,
+            "missing_people_unique": missing_people_export.get("missing_people_unique", 0),
+            "missing_people_logs": missing_people_export.get("missing_people_logs", 0),
+            "missing_people_log_ready": missing_people_export.get("missing_people_log_ready", False),
+            "missing_people_log_lines": missing_people_export.get("missing_people_log_lines", 0),
             "sample_incomplete": sample_incomplete,
             "sample_errors": sample_errors,
         }
@@ -6258,6 +6327,8 @@ def logscan_trends_people_missing_status():
         {
             "exists": True,
             "missing_people_unique": meta.get("missing_people_unique"),
+            "missing_people_logs": meta.get("missing_people_logs"),
+            "missing_people_log_lines": meta.get("missing_people_log_lines"),
             "updated_at": meta.get("updated_at"),
         }
     )

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -3030,9 +3030,11 @@ function setControlsDisabled (disabled) {
   tableDeleteSelected.disabled = disabled || selectedRunKeys.size === 0
 }
 
-function setMissingDownloadVisible (visible, count) {
+function setMissingDownloadVisible (visible, count, logCount) {
   if (visible) {
-    if (typeof count === 'number') {
+    if (typeof count === 'number' && typeof logCount === 'number' && logCount > 1) {
+      missingDownload.textContent = `Download missing people log (${count} from ${logCount} logs)`
+    } else if (typeof count === 'number') {
       missingDownload.textContent = `Download missing people log (${count})`
     } else {
       missingDownload.textContent = 'Download missing people log'
@@ -3051,7 +3053,10 @@ function checkMissingDownload () {
       const count = data && typeof data.missing_people_unique === 'number'
         ? data.missing_people_unique
         : undefined
-      setMissingDownloadVisible(exists, count)
+      const logCount = data && typeof data.missing_people_logs === 'number'
+        ? data.missing_people_logs
+        : undefined
+      setMissingDownloadVisible(exists, count, logCount)
     })
     .catch(() => {
       setMissingDownloadVisible(false)
@@ -3099,7 +3104,7 @@ function applyReingestSummary (data) {
   const isStartupMigration = data && data.trigger === 'startup_migration'
   updateStatus(`${isStartupMigration ? 'Startup Analytics migration complete.' : 'Reingest complete.'} ${summary}`)
   fetchRuns({ suppressStatus: true })
-  setMissingDownloadVisible(Boolean(data.missing_people_log_ready), data.missing_people_unique)
+  setMissingDownloadVisible(Boolean(data.missing_people_log_ready), data.missing_people_unique, data.missing_people_logs)
   setProgressVisible(false)
   setControlsDisabled(false)
   setReingestButtonLabel(defaultReingestButtonLabel)

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -651,10 +651,10 @@
           aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        Download the <code>meta_people_missing.log</code> file, then drop it into the Kometa Discord
+        Download the deduped <code>meta_people_missing.log</code> file, then drop it into the Kometa Discord
         <a href="https://discord.com/channels/822460010649878528/1110266071849652335" target="_blank" rel="noopener noreferrer">
           people requests channel
-        </a>.
+        </a>. When multiple ingested Kometa logs include missing people, this file combines the unique missing poster blocks from all tracked completed logs.
       </div>
       <div class="modal-footer">
         <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1355,6 +1355,113 @@ def test_logscan_reingest_ingests_day_runtime_log(client, isolated_config_dir, m
     assert runs[0]["start_mode"] == "recovery"
 
 
+def test_logscan_missing_people_export_combines_tracked_kometa_logs(client, isolated_config_dir, qs_module):
+    log_dir = isolated_config_dir / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    first_log = log_dir / "meta-people-1.log"
+    second_log = log_dir / "meta-people-2.log"
+    first_log.write_text("header\nLocating config...\nmissing alice\n", encoding="utf-8")
+    second_log.write_text("header\nLocating config...\nmissing bob\n", encoding="utf-8")
+    first_stats = first_log.stat()
+    second_stats = second_log.stat()
+
+    class FakeAnalyzer:
+        _people_index = set()
+
+        def collect_missing_people_lines(self, content, **_kwargs):
+            items = []
+            if "alice" in content:
+                items.append({"names": {"alice"}, "block": "Alice missing block"})
+            if "bob" in content:
+                items.append({"names": {"bob"}, "block": "Bob missing block"})
+            return items
+
+    cache_logs = {
+        str(first_log.resolve()): {
+            "mtime": first_stats.st_mtime,
+            "size": first_stats.st_size,
+            "run_key": "run-alice",
+            "tool_name": "kometa",
+            "run_complete": True,
+            "content_md5": "alice-md5",
+        },
+        str(second_log.resolve()): {
+            "mtime": second_stats.st_mtime,
+            "size": second_stats.st_size,
+            "run_key": "run-bob",
+            "tool_name": "kometa",
+            "run_complete": True,
+            "content_md5": "bob-md5",
+        },
+    }
+
+    result = qs_module._rebuild_logscan_missing_people_export(cache_logs, analyzer=FakeAnalyzer())
+
+    assert result["missing_people_log_ready"] is True
+    assert result["missing_people_unique"] == 2
+    assert result["missing_people_logs"] == 2
+    missing_log = isolated_config_dir / "cache" / "logscan" / "meta_people_missing.log"
+    output = missing_log.read_text(encoding="utf-8")
+    assert "Alice missing block" in output
+    assert "Bob missing block" in output
+
+    status = client.get("/logscan/trends/people-missing/status")
+    assert status.status_code == 200
+    payload = status.get_json()
+    assert payload["exists"] is True
+    assert payload["missing_people_unique"] == 2
+    assert payload["missing_people_logs"] == 2
+
+
+def test_logscan_delta_reingest_rebuilds_missing_people_export_from_cache(client, isolated_config_dir, monkeypatch, qs_module):
+    log_dir = isolated_config_dir / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archived_log = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa" / "meta-people.log"
+    archived_log.parent.mkdir(parents=True, exist_ok=True)
+    archived_log.write_text("header\nLocating config...\nmissing alice\n", encoding="utf-8")
+    stats = archived_log.stat()
+
+    class FakeAnalyzer:
+        _people_index = set()
+
+        def preload_people_index(self, *_args, **_kwargs):
+            return None
+
+        def collect_missing_people_lines(self, content, **_kwargs):
+            if "alice" not in content:
+                return []
+            return [{"names": {"alice"}, "block": "Alice missing block"}]
+
+    cache = {
+        "version": 1,
+        "logs": {
+            str(archived_log.resolve()): {
+                "mtime": stats.st_mtime,
+                "size": stats.st_size,
+                "run_key": "run-alice",
+                "tool_name": "kometa",
+                "run_complete": True,
+                "content_md5": "alice-md5",
+            }
+        },
+    }
+    monkeypatch.setattr(qs_module.logscan, "LogscanAnalyzer", FakeAnalyzer)
+    monkeypatch.setattr(qs_module, "_get_logscan_delta_files", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: copy.deepcopy(cache))
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+
+    result = qs_module._perform_logscan_reingest(reset=False, update_state=False)
+
+    assert result["success"] is True
+    assert result["scanned"] == 0
+    assert result["missing_people_log_ready"] is True
+    assert result["missing_people_unique"] == 1
+    assert result["missing_people_logs"] == 1
+    missing_log = isolated_config_dir / "cache" / "logscan" / "meta_people_missing.log"
+    assert missing_log.exists()
+    assert "Alice missing block" in missing_log.read_text(encoding="utf-8")
+
+
 def test_logscan_reingest_flushes_ingest_cache_incrementally(isolated_config_dir, monkeypatch, qs_module):
     class FakeAnalyzer:
         _people_index = {}

--- a/tests/test_logscan_people_posters.py
+++ b/tests/test_logscan_people_posters.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from modules.logscan import LogscanAnalyzer, PEOPLE_MISSING_WARNING_RE
 
 
@@ -29,3 +31,46 @@ def test_collect_missing_people_lines_with_signature_repo_warning():
     items = analyzer.collect_missing_people_lines(content, available_index=set(), max_block_lines=30)
     assert items
     assert "pamela anderson" in items[0].get("names", set())
+
+
+def test_scan_uses_styled_people_poster_index_for_signature_warnings(tmp_path):
+    readme = """
+    [Alex Rudzinski](https://raw.githubusercontent.com/Kometa-Team/People-Images-bw/master/A/Images/Alex%20Rudzinski.jpg)
+    """
+    content = "\n".join(
+        [
+            "Running Alex Rudzinski (Director) Collection",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/A/Images/Alex%20Rudzinski.jpg",
+            "Finished Alex Rudzinski (Director) Collection",
+            "Running Jon Hurwitz (Director) Collection",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/J/Images/Jon%20Hurwitz.jpg",
+            "Finished Jon Hurwitz (Director) Collection",
+            "Running Hayden Schlossberg (Director) Collection",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/H/Images/Hayden%20Schlossberg.jpg",
+            "Finished Hayden Schlossberg (Director) Collection",
+            "Running Kenny Leon (Director) Collection",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/K/Images/Kenny%20Leon.jpg",
+            "Finished Kenny Leon (Director) Collection",
+        ]
+    )
+    analyzer = LogscanAnalyzer()
+
+    with patch("modules.logscan_people.fetch_people_poster_readme", return_value=(readme, False)):
+        names = analyzer.scan_file_for_people_posters(content, log_path=tmp_path / "meta.log")
+
+    assert names == ["hayden schlossberg", "jon hurwitz", "kenny leon"]
+
+
+def test_collect_missing_people_lines_detects_tmdb_poster_update_candidates():
+    content = "\n".join(
+        [
+            "Running Missing Person (Director) Collection",
+            "Metadata: tmdb_person updated poster to [URL] https://image.tmdb.org/t/p/original/example.jpg",
+            "Finished Missing Person (Director) Collection",
+        ]
+    )
+
+    items = LogscanAnalyzer().collect_missing_people_lines(content, available_index=set(), max_block_lines=30)
+
+    assert items
+    assert items[0]["names"] == {"missing person"}


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix missing people export persistence and clarify aggregation behavior.

Summary:
- Rebuild `meta_people_missing.log` from all tracked completed Kometa logs instead of only the current reingest batch.
- Preserve the missing people export across delta reingests when no new missing people are found.
- Deduplicate missing people blocks across multiple ingested logs.
- Expose `missing_people_logs` and line count metadata from the status endpoint.
- Update Analytics UI copy/button text to show when the export spans multiple logs.
- Add regression coverage for multi-log aggregation and delta reingest persistence.

Tests:
- `venv\Scripts\python.exe -m pytest tests\test_logscan_endpoints.py`
- `npx standard static\local-js\905-analytics.js`

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789790988&installation_model_id=431096&pr_number=1775&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1775&signature=3501a031719eb2682e3465c64ca220579ff3a5efe052a081310f4a91b8bdede6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->