### PR TITLE
fix auto-scroll

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1184,7 +1184,7 @@ function performStopKometa () {
 function fetchKometaLog () {
   if (logPollingPaused) return
 
-  const logEl = runLog[0]
+  const logEl = runLog
   const wasAtBottom = logEl ? (logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 5) : true
 
   logStatsPollCounter += 1

--- a/static/local-js/modules/kometa/_updatePhase.js
+++ b/static/local-js/modules/kometa/_updatePhase.js
@@ -376,14 +376,7 @@ export function setKometaStatusLog (lines, phase = null) {
   if (!logBox) return
   const text = Array.isArray(lines) ? lines.join('\n') : String(lines || '')
   logBox.textContent = text ? `${text}\n` : ''
-  // NOTE: the original code did `if (logBox[0]) logBox[0].scrollTop = ...`
-  // which is jQuery-style indexing on a plain DOM node -- always
-  // undefined, so the scroll-to-bottom never actually happened here.
-  // Preserving that (non-)behavior verbatim to keep this refactor
-  // 100% behavior-compatible. If you WANT the scroll (which
-  // appendKometaStatusLine below does correctly), fix it in a
-  // follow-up so the diff stays clear.
-  if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
+  logBox.scrollTop = logBox.scrollHeight
   if (phase) setKometaUpdatePhaseBadge(phase)
 }
 

--- a/tests/js/kometa/updatePhase.test.js
+++ b/tests/js/kometa/updatePhase.test.js
@@ -376,6 +376,13 @@ describe('setKometaStatusLog', () => {
     expect(box.textContent).toBe('fresh line\n')
   })
 
+  it('scrolls to the bottom after replacing the log', () => {
+    const box = installLogBox()
+    Object.defineProperty(box, 'scrollHeight', { configurable: true, value: 500 })
+    setKometaStatusLog('fresh line')
+    expect(box.scrollTop).toBe(500)
+  })
+
   it('updates the phase badge when a phase is passed', () => {
     installLogBox()
     installBadge()  // add badge alongside log box


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1788 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Description

Fixes auto-scroll for Kometa logs while logs are actively generated.

### Changes

- Use the actual DOM log element during live log polling.
- Scroll the status log after replacing its contents.
- Add regression coverage for initial status-log scrolling.

### Testing

- `npm test -- --run tests/js/kometa/updatePhase.test.js`
- `npx eslint `900-kometa.js` `_updatePhase.js` tests/js/kometa/updatePhase.test.js`
- `npm run build`

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791118829&installation_model_id=431096&pr_number=1790&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1790&signature=25b538c26160767ce44f9ec3775a0fd67a14b408d3e5618e6e427767db4af7df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->