### PR TITLE
fix modals on analytics page

### DIFF
--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -2418,7 +2418,7 @@ function renderLibraryInventory (runs) {
 }
 
 function renderIngestHealth (state) {
-  if (!ingest.length) return
+  if (!ingest) return
   const invalidArchivedCount = Number.isFinite(state && state.invalid_archived_count) ? state.invalid_archived_count : 0
   const invalidArchivedSample = Array.isArray(state && state.invalid_archived_sample) ? state.invalid_archived_sample : []
 
@@ -2908,12 +2908,12 @@ function updateStatus (message) {
 }
 
 function setReingestButtonLabel (label) {
-  if (!reingest.length) return
+  if (!reingest) return
   reingest.textContent = label || defaultReingestButtonLabel
 }
 
 function setProgressVisible (visible) {
-  if (!progress.length) return
+  if (!progress) return
   if (visible) {
     progress.classList.remove('d-none')
   } else {
@@ -2922,7 +2922,7 @@ function setProgressVisible (visible) {
 }
 
 function updateProgressFromState (state) {
-  if (!state || !progressBar.length) return
+  if (!state || !progressBar) return
   lastIngestState = state
   renderIngestHealth(lastIngestState)
   const total = Number.isFinite(state.total) ? state.total : 0
@@ -2932,7 +2932,7 @@ function updateProgressFromState (state) {
   const skippedInvalid = Number.isFinite(state.skipped_invalid) ? state.skipped_invalid : 0
   const errors = Number.isFinite(state.errors) ? state.errors : 0
   const pct = total ? Math.min(100, Math.round((scanned / total) * 100)) : 0
-  progressBar.css('width', `${pct}%`)
+  progressBar.style.width = `${pct}%`
   const pieces = [
     `Scanned: ${scanned}/${total}`,
     `Ingested: ${ingested}`,
@@ -2942,7 +2942,7 @@ function updateProgressFromState (state) {
   if (state.current_file) {
     pieces.unshift(`Processing: ${formatProcessingFileLabel(state.current_file)}`)
   }
-  if (progressText.length) {
+  if (progressText) {
     progressText.textContent = pieces.join(' | ')
   }
 }
@@ -3278,10 +3278,10 @@ function buildKometaDetailsBlock (run) {
 
 function showRunDetails (runKey) {
   if (!runKey) return
-  if (runDetailsBody.length) {
+  if (runDetailsBody) {
     runDetailsBody.innerHTML = 'Loading recommendations...'
   }
-  if (runDetailsTitle.length) {
+  if (runDetailsTitle) {
     runDetailsTitle.textContent = 'Run Recommendations'
   }
   if (runDetailsModalEl) {
@@ -3291,7 +3291,7 @@ function showRunDetails (runKey) {
     .then(res => res.json().then(data => ({ ok: res.ok, data })))
     .then(({ ok, data }) => {
       if (!ok) {
-        if (runDetailsBody.length) {
+        if (runDetailsBody) {
           runDetailsBody.textContent = data && data.error ? data.error : 'Unable to load recommendations.'
         }
         return
@@ -3299,7 +3299,7 @@ function showRunDetails (runKey) {
       const detailsBlock = `${buildKometaDetailsBlock(data && data.run)}${buildImagemaidDetailsBlock(data && data.run)}`
       const recs = Array.isArray(data.recommendations) ? data.recommendations : []
       if (!recs.length) {
-        if (runDetailsBody.length) {
+        if (runDetailsBody) {
           runDetailsBody.innerHTML = detailsBlock || 'No recommendations recorded for this run.'
         }
         return
@@ -3314,12 +3314,12 @@ function showRunDetails (runKey) {
           </div>
         `
       })
-      if (runDetailsBody.length) {
+      if (runDetailsBody) {
         runDetailsBody.innerHTML = `${detailsBlock}${blocks.join('')}`
       }
     })
     .catch(() => {
-      if (runDetailsBody.length) {
+      if (runDetailsBody) {
         runDetailsBody.textContent = 'Unable to load recommendations.'
       }
     })
@@ -3426,10 +3426,10 @@ function fetchIncompleteRuns (safeLimit) {
 function showSectionDetails (runKey) {
   const payload = sectionDetailsByRunKey.get(runKey)
   if (!payload) return
-  if (runDetailsTitle.length) {
+  if (runDetailsTitle) {
     runDetailsTitle.textContent = 'Section Runtimes'
   }
-  if (runDetailsBody.length) {
+  if (runDetailsBody) {
     const summary = payload.summary || 'n/a'
     const details = Array.isArray(payload.details) ? payload.details : []
     let bodyHtml = `
@@ -3459,10 +3459,10 @@ function showQuietPeriodDetails (runKey) {
   const run = allTableRuns.find(entry => entry && entry.run_key === runKey)
   const summary = getQuietPeriodSummary(run)
   if (!run || summary.longestGapSeconds <= 0) return
-  if (runDetailsTitle.length) {
+  if (runDetailsTitle) {
     runDetailsTitle.textContent = 'Quiet Period Details'
   }
-  if (runDetailsBody.length) {
+  if (runDetailsBody) {
     const renderGapBlock = (title, gapSeconds, startedAtRaw, endedAtRaw, startLine, endLine, overlap, lastLine, firstLine) => {
       if (!(gapSeconds > 0)) {
         return `
@@ -3651,7 +3651,7 @@ function openCompressLogModal (runKeys, runLabel) {
     runLabel,
     bulk: normalizedRunKeys.length > 1
   }
-  if (compressLogBody.length) {
+  if (compressLogBody) {
     if (normalizedRunKeys.length === 1) {
       compressLogBody.innerHTML = `Compress archived log for <strong>${escapeHtml(runLabel || normalizedRunKeys[0])}</strong> as <code>.log.gz</code>?`
     } else {
@@ -3680,7 +3680,7 @@ function openDeleteLogModal (runKeys, runLabel) {
     runLabel,
     bulk: normalizedRunKeys.length > 1
   }
-  if (deleteLogBody.length) {
+  if (deleteLogBody) {
     if (normalizedRunKeys.length === 1) {
       deleteLogBody.innerHTML = `Delete log for <strong>${escapeHtml(runLabel || normalizedRunKeys[0])}</strong> from disk and remove it from Analytics?`
     } else {


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1787 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix analytics page modal content and progress rendering errors.

### Changes

- Replace stale jQuery-style `.length` checks with native DOM checks.
- Fix modal content population for:
  - Run recommendations
  - Section runtimes
  - Quiet period details
  - Delete and compress confirmations
- Replace invalid `progressBar.css()` usage with native `style.width`.

### Testing

- ESLint
- `npm run build`
- `git diff --check`

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791120272&installation_model_id=431096&pr_number=1791&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1791&signature=ecdefca15f314c9c9349d0694ada171102ab0813b8a23238b014fc4163b79307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->