### PR TITLE
fixed control-c everywhere minus containers

### DIFF
--- a/modules/process_control.py
+++ b/modules/process_control.py
@@ -136,6 +136,7 @@ from modules.process_lifecycle import (  # noqa: F401
     reset_imagemaid_runtime_env,
     resume_process_tree,
     stop_process_tree,
+    stop_launched_processes,
     suspend_process_tree,
 )
 

--- a/modules/process_lifecycle.py
+++ b/modules/process_lifecycle.py
@@ -40,6 +40,7 @@ import os
 import shlex
 import subprocess
 import sys
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -56,6 +57,8 @@ from modules.process_markers import (
 from modules.process_run_context import update_imagemaid_run_context
 
 _KOMETA_RUNTIME_BRANCHES = {"master", "develop", "nightly"}
+_LAUNCHED_PROCESSES = {}
+_LAUNCHED_PROCESSES_LOCK = threading.Lock()
 
 
 def _normalize_kometa_runtime_branch(value):
@@ -111,6 +114,28 @@ def stop_process_tree(proc):
     return alive
 
 
+def stop_launched_processes():
+    """Stop only Kometa/ImageMaid processes launched by this Quickstart process."""
+    with _LAUNCHED_PROCESSES_LOCK:
+        launched = list(_LAUNCHED_PROCESSES.items())
+        _LAUNCHED_PROCESSES.clear()
+
+    alive = []
+    for pid, child in launched:
+        if child.poll() is not None:
+            continue
+        try:
+            alive.extend(stop_process_tree(psutil.Process(pid)))
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return alive
+
+
+def _track_launched_process(proc):
+    with _LAUNCHED_PROCESSES_LOCK:
+        _LAUNCHED_PROCESSES[proc.pid] = proc
+
+
 def launch_kometa_command(command, config_name=None, start_mode="current"):
     if not command:
         return False, "No command provided"
@@ -161,6 +186,7 @@ def launch_kometa_command(command, config_name=None, start_mode="current"):
         start_new_session=True,
         env=runtime_env,
     )
+    _track_launched_process(proc)
 
     with open(helpers.get_kometa_pid_file(), "w", encoding="utf-8") as f:
         f.write(str(proc.pid))
@@ -225,6 +251,7 @@ def launch_imagemaid_command(command, mode=None, config_name=None):
             stderr=subprocess.STDOUT,
             start_new_session=True,
         )
+        _track_launched_process(proc)
 
         with open(helpers.get_imagemaid_pid_file(), "w", encoding="utf-8") as f:
             f.write(str(proc.pid))
@@ -232,6 +259,8 @@ def launch_imagemaid_command(command, mode=None, config_name=None):
         time.sleep(1.0)
         return_code = proc.poll()
         if return_code is not None:
+            with _LAUNCHED_PROCESSES_LOCK:
+                _LAUNCHED_PROCESSES.pop(proc.pid, None)
             launch_log.flush()
             try:
                 os.remove(helpers.get_imagemaid_pid_file())

--- a/quickstart.py
+++ b/quickstart.py
@@ -26,6 +26,7 @@ import platform
 import psutil
 import re
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -365,6 +366,7 @@ from modules.process_control import (
     find_running_imagemaid_processes as _find_running_imagemaid_processes,  # noqa: F401 (load-bearing: tests + blueprints/imagemaid_routes.py access via qs_module)
     find_running_imagemaid_process as _find_running_imagemaid_process,  # noqa: F401 (load-bearing: tests + blueprints/imagemaid_routes.py access via qs_module)
     stop_process_tree as _stop_process_tree,
+    stop_launched_processes as _stop_launched_processes,
     launch_kometa_command as _launch_kometa_command,
     launch_imagemaid_command as _launch_imagemaid_command,  # noqa: F401 (load-bearing: tests + blueprints/imagemaid_routes.py access via qs_module)
     reset_imagemaid_runtime_env as _reset_imagemaid_runtime_env,  # noqa: F401 (used directly by tests as qs_module._reset_imagemaid_runtime_env)
@@ -3846,6 +3848,9 @@ def shutdown():
 
         shutdown_event.set()
 
+        if not app.config.get("QUICKSTART_DOCKER"):
+            _stop_launched_processes()
+
         try:
             from PyQt5.QtCore import QTimer
             from PyQt5.QtWidgets import QApplication
@@ -6927,6 +6932,23 @@ if __name__ == "__main__":
     except (ModuleNotFoundError, ImportError):
         has_tray = False
 
+    def handle_sigint(signum, frame):
+        if app.config["QUICKSTART_DOCKER"]:
+            signal.default_int_handler(signum, frame)
+            return
+        helpers.ts_log("\nShutting down Quickstart...", level="INFO")
+        _stop_launched_processes()
+        shutdown_event.set()
+        if has_tray:
+            qt_app = QApplication.instance()
+            if qt_app:
+                qt_app.quit()
+            return
+        raise KeyboardInterrupt
+
+    if not app.config["QUICKSTART_DOCKER"]:
+        signal.signal(signal.SIGINT, handle_sigint)
+
     if not has_tray:
         # Headless mode: skip system tray
         helpers.ts_log("Running in headless mode — no system tray will be shown...", level="INFO")
@@ -6952,9 +6974,11 @@ if __name__ == "__main__":
                 time.sleep(1)  # Keep main thread alive
         except KeyboardInterrupt:
             helpers.ts_log("\nShutting down Quickstart...", level="INFO")
+            _stop_launched_processes()
             sys.exit(0)
 
         helpers.ts_log("Shutting down Quickstart...", level="INFO")
+        _stop_launched_processes()
         sys.exit(0)
 
     else:
@@ -7116,6 +7140,8 @@ if __name__ == "__main__":
                 global server_thread, update_thread
 
                 helpers.ts_log("Shutting down Quickstart...", level="INFO")
+                shutdown_event.set()
+                _stop_launched_processes()
 
                 # Stop tray icon
                 self.tray.hide()

--- a/scripts/run_local_ci_gate.py
+++ b/scripts/run_local_ci_gate.py
@@ -27,6 +27,7 @@ def run(command: list[str], *, env: dict[str, str] | None = None) -> int:
 def main() -> int:
     env = os.environ.copy()
     env["SKIP"] = "repo-ci-gate"
+    npm_command = "npm.cmd" if os.name == "nt" else "npm"
 
     # Mirror the repo's lint workflow exactly, but skip the current custom hook so
     # that the nested invocation does not recursively invoke itself. This keeps the
@@ -39,11 +40,11 @@ def main() -> int:
     if result != 0:
         return result
 
-    result = run(["npm", "ci", "--no-fund", "--no-audit"], env=env)
+    result = run([npm_command, "ci", "--no-fund", "--no-audit"], env=env)
     if result != 0:
         return result
 
-    result = run(["npm", "run", "build"], env=env)
+    result = run([npm_command, "run", "build"], env=env)
     if result != 0:
         return result
 


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1686 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary
- Track Kometa and ImageMaid processes launched by Quickstart.
- Stop tracked child processes during local Ctrl+C and shutdown handling.
- Preserve container behavior.
- Fix the local CI gate to invoke `npm.cmd` on Windows.

## Validation
- 1,462 unit tests passed
- Pre-commit checks passed
- Vite production build passed
- Local CI gate passed

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791158596&installation_model_id=431096&pr_number=1792&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1792&signature=3aed69d8ea05becb3808baa13b67ae416503657a0027de4d1b884ce92816f1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->