### PR TITLE
Restore validation status precedence

### DIFF
--- a/modules/workspace_step_status.py
+++ b/modules/workspace_step_status.py
@@ -245,14 +245,18 @@ def _derive_step_status(template_key, group, section_rows, config_exists):
         if group == "optional" and not _has_meaningful_optional_input(template_key, payload):
             return "unknown"
 
+        if template_key == "025-libraries" and validation_status == "skipped" and validation_reason == "no_libraries":
+            return "error"
+
+        if validated or validation_status == "validated":
+            return "ok"
+
         if validation_status == "failed":
             return "error"
 
         if validation_status == "skipped":
             if template_key == "027-playlist_files" and validation_reason == "no_libraries":
                 return "unknown"
-            if template_key == "025-libraries" and validation_reason == "no_libraries":
-                return "error"
             if validation_reason in QS_ERROR_REASONS:
                 return "error"
             if group == "optional":
@@ -262,9 +266,6 @@ def _derive_step_status(template_key, group, section_rows, config_exists):
             if validation_reason in QS_WARN_REASONS:
                 return "warn"
             return "warn" if group == "required" else ("warn" if user_entered else "ok")
-
-        if validated or validation_status == "validated":
-            return "ok"
 
         if group == "required":
             if not user_entered:

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -959,6 +959,27 @@ def test_required_no_libraries_skip_beats_stale_validated_flag(qs_module):
     assert state == "error"
 
 
+def test_validated_step_stays_ok_when_skip_metadata_is_stale(qs_module):
+    section_rows = {
+        "tautulli": {
+            "validated": True,
+            "user_entered": True,
+            "data": {
+                "validation_status": "skipped",
+                "validation_reason": "missing_credentials",
+                "validated_at": "2026-04-20T10:00:00Z",
+                "tautulli": {
+                    "url": "https://tautulli.example.com",
+                    "apikey": "secret",
+                },
+            },
+        }
+    }
+
+    state = qs_module._derive_step_status("030-tautulli", "optional", section_rows, config_exists=True)
+    assert state == "ok"
+
+
 def test_anidb_enabled_and_bulk_validated_is_ok(qs_module):
     section_rows = {
         "anidb": {


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [d] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

fix validate page logic

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791166355&installation_model_id=431096&pr_number=1793&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1793&signature=bff35ac61b0ca5c30e48b731ac58ae7698d6a4060bb082b8e4c6fe0085bc17e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->