### PR TITLE
Fix validation state and initialize new profile settings

### DIFF
--- a/blueprints/config_routes.py
+++ b/blueprints/config_routes.py
@@ -82,9 +82,10 @@ def activate_config():
     session["config_name"] = name
 
     if created:
+        created_at = helpers.utc_now_iso()
         seed_payload = {
             "start": {"config_name": name},
-            "validated_at": helpers.utc_now_iso(),
+            "validated_at": created_at,
         }
         database.save_section_data(
             name=name,
@@ -92,6 +93,14 @@ def activate_config():
             validated=True,
             user_entered=True,
             data=seed_payload,
+        )
+        settings_defaults = persistence.get_dummy_data("settings")
+        database.save_section_data(
+            name=name,
+            section="settings",
+            validated=True,
+            user_entered=False,
+            data={"settings": settings_defaults, "validated_at": created_at},
         )
 
     return jsonify(success=True, name=name, created=created)

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -2360,9 +2360,10 @@ function getCurrentTemplateGroup () {
 function qsCurrentValidationCalloutState (isConfigured) {
   const inputState = qsStateFromValidatedInput(getValidatedInput())
   const currentState = qsGetCurrentStepStatus()
+  if (inputState === 'ok') return 'ok'
   if (currentState === 'error' || inputState === 'error') return 'error'
   if (currentState === 'warn' || inputState === 'warn') return 'warn'
-  if (isConfigured || currentState === 'ok' || inputState === 'ok') return 'ok'
+  if (isConfigured || currentState === 'ok') return 'ok'
   if (currentState === 'unknown' || inputState === 'unknown') return 'unknown'
   return null
 }

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -14,12 +14,20 @@ Covers:
 
 
 def test_activate_config_creates_new_config_and_sets_session(client, isolated_config_dir):
+    from modules import database, persistence
+
     resp = client.post("/activate-config", json={"name": "myprofile"})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["success"] is True
     assert data["name"] == "myprofile"
     assert data["created"] is True  # brand-new config
+
+    validated, user_entered, stored = database.retrieve_section_data("myprofile", "settings")
+    assert validated is True
+    assert user_entered is False
+    assert stored["settings"] == persistence.get_dummy_data("settings")
+    assert stored["validated_at"]
 
 
 def test_activate_config_existing_config_not_flagged_as_created(client, isolated_config_dir):


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

- Make successful page validation override stale sidebar errors so validation accordions collapse and show the validated state.
- Seed new profiles with the default Settings values.
- Mark untouched default Settings as valid without marking them user-entered.
- Add regression coverage for the new profile Settings state.

## Validation

- Focused backend tests passed.
- JavaScript test suite passed: 1,556 tests.
- Vite production build passed.
- Pre-commit hooks passed.
- Full repo CI gate was skipped locally because it is long-running.

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791228724&installation_model_id=431096&pr_number=1794&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1794&signature=3cee3a39e2bea209677f2fd4fb4276f2d6b6681b6bd759c42aa3a4e61278b1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->