### PR TITLE
Fix ghost library modifications from blank values

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -356,7 +356,11 @@ def _loaded_sections_with_payload_evidence(library_id, incoming_libraries, loade
 
 
 def _has_saved_value(value):
-    return value not in [None, "", [], {}, "[]", "{}"]
+    if value in [None, "", [], {}, "[]", "{}"]:
+        return False
+    if isinstance(value, str) and value.strip().lower() in {"none", "null"}:
+        return False
+    return True
 
 
 def _coerce_bool(value):

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -4240,7 +4240,7 @@ function initScheduleBuilders (scope) {
 
     function parseSchedule (rawValue) {
       const raw = String(rawValue || '').trim()
-      if (!raw) return { mode: 'range', raw: '' }
+      if (!raw || ['none', 'null'].includes(raw.toLowerCase())) return { mode: 'range', raw: '' }
       const lower = raw.toLowerCase()
       if (['daily', 'never', 'non_existing'].includes(lower)) {
         return { mode: lower, raw }
@@ -4373,7 +4373,10 @@ function initScheduleBuilders (scope) {
       updatePreview(parsed.raw || '')
     }
 
-    const initialRaw = String(hidden.value || defaultValue || '').trim()
+    const rawHiddenValue = String(hidden.value || '').trim()
+    const initialRaw = ['none', 'null'].includes(rawHiddenValue.toLowerCase())
+      ? String(defaultValue || '').trim()
+      : (rawHiddenValue || String(defaultValue || '').trim())
     const parsed = parseSchedule(initialRaw)
     applyParsed(parsed)
     updateFromBuilder()
@@ -9162,6 +9165,10 @@ function isInternalTemplateMetadataField (field) {
     name.endsWith('__lookup_labels')
 }
 
+function isBlankSavedSentinel (value) {
+  return ['none', 'null'].includes(String(value ?? '').trim().toLowerCase())
+}
+
 function isCollectionSectionFieldConfigured (fields) {
   const enabledFields = Array.from(fields || []).filter(field => field && !field.disabled && !isInternalTemplateMetadataField(field))
   if (!enabledFields.length) return false
@@ -9205,6 +9212,7 @@ function isCollectionSectionFieldConfigured (fields) {
 
   const value = String(primaryField.value ?? '').trim()
   const defaultValue = String(primaryField.dataset.default || '').trim()
+  if (isBlankSavedSentinel(value)) return false
   if (primaryField.closest('[data-schedule-builder]')) {
     return normalizeScheduleOverrideValue(value) !== normalizeScheduleOverrideValue(defaultValue)
   }

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -821,7 +821,7 @@ select_input.key if yml_location == "top_level" else
                             <input type="text" class="form-control"
                                 id="{{ library.id }}-attribute_{{ section.prefix }}_path"
                                 name="{{ library.id }}-attribute_{{ section.prefix }}_path"
-                                value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix ~ '_path'] | default('') }}"
+                                value="{{ data.libraries[library.id ~ '-attribute_' ~ section.prefix ~ '_path'] | default('', true) if data.libraries[library.id ~ '-attribute_' ~ section.prefix ~ '_path'] | string | lower not in ['none', 'null'] else '' }}"
                                 data-default=""
                                 placeholder="{{ section.text_input.placeholder }}">
                         </div>
@@ -1830,7 +1830,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 {% endif %}
                             </span>
                             <input type="{{ 'number' if is_number_input else 'text' }}" class="form-control" id="{{ input_name }}" name="{{ input_name }}"
-                                value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}"
+                                value="{{ data['libraries'].get(input_name, item.default) | default('', true) if data['libraries'].get(input_name, item.default) | string | lower not in ['none', 'null'] else '' }}"
                                 data-default="{{ item.default | default('', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
                                 {% if item.validation_preset %}data-template-scalar-lookup="true" data-library-name="{{ library.name }}" data-media-type="{{ library.type }}"{% endif %}

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -447,6 +447,11 @@ def test_lazy_overlay_count_uses_rendered_ratings_defaults(library_routes_module
     assert library_routes_module._count_overlay_overrides_for_library(library, libraries_data, overlay_config) == 6
 
 
+def test_lazy_override_count_ignores_none_sentinels(library_routes_module):
+    assert library_routes_module._template_value_is_configured("None", "") is False
+    assert library_routes_module._template_value_is_configured(" null ", "") is False
+
+
 def test_library_fragment_section_renders_requested_heavy_section(client, monkeypatch, qs_module, library_routes_module):
     monkeypatch.setattr(
         library_routes_module,


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

- Ignore `"None"` and `"null"` sentinel values when calculating library modifications.
- Prevent blank Report Path and Metadata Backup fields from appearing configured.
- Prevent blank schedules from being interpreted as `Custom (Advanced)`.
- Render sentinel values as blank in the Libraries UI.
- Add regression coverage for sentinel values.

## Validation

- Focused backend tests passed.
- JavaScript test suite passed: 1,556 tests.
- Vite production build passed.
- Pre-commit hooks passed.
- Full CI gate was skipped locally.

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791233720&installation_model_id=431096&pr_number=1797&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1797&signature=5dd46a4eeb1301f17cedad7ac94504e4ce01f789dab4291fc7e5600775f5f4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->