### PR TITLE
Ensure collectionless is the final collection entry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
         entry: python scripts/run_local_ci_gate.py
         language: system
         pass_filenames: false
+        stages: [manual]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -667,6 +667,8 @@ npm run lint:eslint    # ESLint over static/local-js/
 
 ```
 python scripts/run_local_ci_gate.py
+# or
+python -m pre_commit run repo-ci-gate --hook-stage manual
 ```
 
 This mirrors the important GitHub checks locally: full repo pre-commit validation, the project unit-test runner, and the production Vite build. If you prefer the explicit raw commands, the equivalent checks are:

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -723,4 +723,9 @@ def build_collection_files(
     if raw_collection_entries:
         collection_files.extend(raw_collection_entries)
 
+    collectionless_entries = [entry for entry in collection_files if _is_collectionless_entry(entry)]
+    if collectionless_entries:
+        collection_files = [entry for entry in collection_files if not _is_collectionless_entry(entry)]
+        collection_files.extend(collectionless_entries)
+
     return collection_files, has_collectionless

--- a/scripts/run_local_ci_gate.py
+++ b/scripts/run_local_ci_gate.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Run the repo-local checks that most closely mirror the GitHub CI gate.
 
-This is intended to be used as a local pre-commit hook so developers catch the
-same classes of issues that would fail the repo's lint and build jobs before
-pushing.
+This is intended to be run manually before pushing when developers want to catch
+the same classes of issues that would fail the repo's lint and build jobs.
 """
 
 from __future__ import annotations

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -69839,6 +69839,15 @@
         "tooltip_variant": "danger",
         "template_variables": [
           {
+            "key": "collection_section",
+            "label": "Collection Section",
+            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
+            "type": "text_input",
+            "default": "999",
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -7358,6 +7358,7 @@ function getCollectionSectionEntries (libraryId) {
     entries.push({
       collectionId,
       label,
+      isCollectionless: collectionId.toLowerCase().endsWith('collectionless'),
       inputId: input.id,
       defaultValue: String(input.dataset.default || '').trim(),
       currentValue: String(input.value || '').trim(),
@@ -7366,6 +7367,7 @@ function getCollectionSectionEntries (libraryId) {
     })
   })
   entries.sort((left, right) => {
+    if (left.isCollectionless !== right.isCollectionless) return left.isCollectionless ? 1 : -1
     const byValue = compareCollectionSectionValues(left.effectiveValue, right.effectiveValue)
     if (byValue !== 0) return byValue
     return left.domIndex - right.domIndex

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2565,12 +2565,12 @@ def test_build_libraries_section_emits_collection_files(app):
         )
 
         assert libraries_section["libraries"]["Movies"]["collection_files"] == [
-            {"default": "collectionless"},
             {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
             {"folder": "config\\metadata\\movies"},
             {"git": "bullmoose20/collections/godzilla.yml"},
             {"repo": "custom/movies_meta.yml"},
             {"url": "https://example.com/movies_refresh.yml"},
+            {"default": "collectionless"},
         ]
 
 

--- a/tests/test_output_collection_order.py
+++ b/tests/test_output_collection_order.py
@@ -1,10 +1,18 @@
 import json
+from pathlib import Path
 
 from modules.output_collections import build_collection_files
 
 
 def _defaults(entries):
     return [entry.get("default") or next(iter(entry.keys())) for entry in entries]
+
+
+def test_collectionless_default_section_is_final_value():
+    data = json.loads(Path("static/json/quickstart_collections.json").read_text(encoding="utf-8"))
+    collectionless = next(collection for group in data for collection in group.get("collections", []) if collection.get("id") == "collection_collectionless")
+    section = next(item for item in collectionless["template_variables"] if item.get("key") == "collection_section")
+    assert section["default"] == "999"
 
 
 def test_build_collection_files_uses_quickstart_json_order_not_saved_key_order():
@@ -43,6 +51,32 @@ def test_build_collection_files_uses_quickstart_json_order_not_saved_key_order()
         "basic",
         "studio",
         "folder",
-        "collectionless",
         "file",
+        "collectionless",
     ]
+
+
+def test_collectionless_is_absolute_last_entry_after_raw_collection_files():
+    collections = {
+        "movies": {
+            "mov-library_movies-collection_collectionless": True,
+            "mov-library_movies-collection_basic": True,
+        }
+    }
+    raw_collection_entries = json.dumps(
+        [
+            {"type": "file", "location": "config/advanced_custom.yml"},
+        ]
+    )
+
+    collection_files, has_collectionless = build_collection_files(
+        "mov-library_movies-library",
+        "mov",
+        collections,
+        {},
+        {"movies": {"mov-library_movies-collection_files": raw_collection_entries}},
+        {},
+    )
+
+    assert has_collectionless is True
+    assert _defaults(collection_files) == ["basic", "file", "collectionless"]


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

- Add `collection_section: 999` to the collectionless default.
- Include collectionless in the Collection Section reorder modal.
- Keep collectionless visually last in the reorder UI.
- Ensure collectionless is always the absolute final `collection_files` YAML entry.
- Place raw and advanced collection-file entries before collectionless.
- Add regression coverage for collectionless metadata and ordering.

## Validation

- Collection ordering tests passed.
- Collection contract tests passed.
- Collection JSON validation passed.
- Frontend Vite build passed.
- Pre-commit hooks passed.
- Full CI gate was skipped locally.

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791246003&installation_model_id=431096&pr_number=1798&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1798&signature=577d503ef4a25a270de5d997ffa7e66e9d6fc0bd069d9f1d3f716090fb1259b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->