### PR TITLE
Sort order of collection reorder

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -470,6 +470,75 @@ def _has_active_collection_selection_for_library(library, libraries_data, collec
     return any(_collection_group_active_states_for_library(library, libraries_data, collection_config).values())
 
 
+def _collection_section_sort_key(value):
+    value = str(value or "").strip()
+    if value.isdigit():
+        return (0, int(value), "")
+    if value:
+        return (1, 0, value)
+    return (2, 0, "")
+
+
+def _collection_section_reorder_entries(library, libraries_data, collection_config=None):
+    if not isinstance(library, dict) or not isinstance(libraries_data, dict):
+        return []
+    library_id = library.get("id")
+    library_type = library.get("type")
+    if not library_id or not library_type:
+        return []
+
+    collection_config = collection_config if isinstance(collection_config, list) else helpers.load_quickstart_config("quickstart_collections.json")
+    entries = []
+    for group_index, group in enumerate(collection_config or []):
+        collections = group.get("collections", []) if isinstance(group, dict) else []
+        for collection_index, collection in enumerate(collections):
+            if not isinstance(collection, dict):
+                continue
+            media_types = collection.get("media_types") or []
+            if media_types and library_type not in media_types:
+                continue
+            collection_id = str(collection.get("id") or "").strip()
+            if not collection_id:
+                continue
+            if not _is_truthy_setting_value(libraries_data.get(f"{library_id}-{collection_id}")):
+                continue
+
+            section_item = None
+            for item in collection.get("template_variables", []) or []:
+                if isinstance(item, dict) and item.get("key") == "collection_section":
+                    section_item = item
+                    break
+            if not section_item:
+                continue
+
+            clean_id = collection_id.replace("collection_", "")
+            input_name = f"{library_id}-template_collection_{clean_id}_collection_section"
+            current_value = str(libraries_data.get(input_name) or "").strip()
+            default_value = str(section_item.get("default") or "").strip()
+            effective_value = current_value or default_value
+            entries.append(
+                {
+                    "collectionId": collection_id,
+                    "label": collection.get("label") or collection_id,
+                    "inputId": input_name,
+                    "inputName": input_name,
+                    "defaultValue": default_value,
+                    "currentValue": current_value,
+                    "effectiveValue": effective_value,
+                    "groupIndex": group_index,
+                    "collectionIndex": collection_index,
+                }
+            )
+
+    entries.sort(key=lambda entry: (_collection_section_sort_key(entry["effectiveValue"]), entry["groupIndex"], entry["collectionIndex"]))
+    return entries
+
+
+def _library_for_id(library_id):
+    movie_libraries, show_libraries, _telemetry_data = _build_library_lists()
+    return {lib["id"]: lib for lib in movie_libraries + show_libraries}.get(library_id)
+
+
 def _iter_overlay_template_items(template_variables):
     if isinstance(template_variables, dict):
         for key, details in template_variables.items():
@@ -932,6 +1001,92 @@ def library_fragment_collection_group(library_id, group_index):
     context = dict(context)
     context["group"] = collection_config[group_index]
     return render_template("partials/_collection_group_fragment.html", **context)
+
+
+@bp.route("/library_fragment/<library_id>/collection_section_entries", methods=["GET", "POST"])
+def library_collection_section_entries(library_id):
+    """Return enabled collection-section rows without hydrating lazy accordions."""
+    library = _library_for_id(library_id)
+    if not library:
+        return jsonify({"success": False, "error": "Library not found"}), 404
+
+    if request.method == "POST":
+        payload = request.get_json(silent=True) or {}
+        source_payload = payload.get("source_payload") if isinstance(payload.get("source_payload"), dict) else {}
+        libraries_data = _build_merged_libraries_hint_payload(
+            {
+                "source_library_id": library_id,
+                "source_payload": source_payload,
+            }
+        )
+    else:
+        settings = persistence.retrieve_settings("025-libraries")
+        libraries_data = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+    entries = _collection_section_reorder_entries(library, libraries_data)
+    return jsonify({"success": True, "entries": entries})
+
+
+@bp.route("/library_fragment/<library_id>/collection_section_order", methods=["POST"])
+def save_library_collection_section_order(library_id):
+    """Persist collection_section order without requiring hidden DOM sections."""
+    library = _library_for_id(library_id)
+    if not library:
+        return jsonify({"success": False, "error": "Library not found"}), 404
+
+    payload = request.get_json(silent=True) or {}
+    reset = helpers.booler(payload.get("reset"))
+    ordered_ids = payload.get("collection_ids") or []
+    if not reset and not isinstance(ordered_ids, list):
+        return jsonify({"success": False, "error": "Invalid collection order payload."}), 400
+
+    settings = persistence.retrieve_settings("025-libraries")
+    libraries_data = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+    if not isinstance(libraries_data, dict):
+        libraries_data = {}
+
+    entries = _collection_section_reorder_entries(library, libraries_data)
+    entries_by_id = {entry["collectionId"]: entry for entry in entries}
+    if not reset:
+        ordered_ids = [str(item or "").strip() for item in ordered_ids if str(item or "").strip()]
+        missing_ids = sorted(set(entries_by_id) - set(ordered_ids))
+        unknown_ids = sorted(set(ordered_ids) - set(entries_by_id))
+        if missing_ids or unknown_ids:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "Collection order does not match the enabled collection set.",
+                        "missing": missing_ids,
+                        "unknown": unknown_ids,
+                    }
+                ),
+                400,
+            )
+
+    updated_libraries = dict(libraries_data)
+    if reset:
+        for entry in entries:
+            updated_libraries.pop(entry["inputName"], None)
+    else:
+        for index, collection_id in enumerate(ordered_ids, start=1):
+            updated_libraries[entries_by_id[collection_id]["inputName"]] = f"{index * 10:03d}"
+
+    config_name = persistence.resolve_request_config_name(payload if isinstance(payload, dict) else {})
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=helpers.booler(settings.get("validated", False)) if isinstance(settings, dict) else False,
+        user_entered=True,
+        data={
+            "libraries": updated_libraries,
+            "validated": helpers.booler(settings.get("validated", False)) if isinstance(settings, dict) else False,
+            "validated_at": settings.get("validated_at") if isinstance(settings, dict) else None,
+        },
+    )
+    refreshed_settings = persistence.retrieve_settings("025-libraries")
+    refreshed_libraries = refreshed_settings.get("libraries", {}) if isinstance(refreshed_settings, dict) else updated_libraries
+    refreshed_entries = _collection_section_reorder_entries(library, refreshed_libraries)
+    return jsonify({"success": True, "entries": refreshed_entries, "reset": reset})
 
 
 @bp.route("/autosave_library/<library_id>", methods=["POST"])

--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -1013,7 +1013,12 @@ def _build_merged_libraries_hint_payload(payload):
     if not source_payload:
         return merged
 
-    clean_payload = persistence.clean_form_data(MultiDict(source_payload))
+    source_payload_for_merge = dict(source_payload)
+    loaded_sections = _coerce_loaded_library_sections(source_payload_for_merge.pop("__loaded_sections", []))
+    loaded_collection_groups_raw = source_payload_for_merge.pop("__loaded_collection_groups", None)
+    loaded_collection_groups = _coerce_loaded_collection_groups(loaded_collection_groups_raw) if loaded_collection_groups_raw is not None else None
+
+    clean_payload = persistence.clean_form_data(MultiDict(source_payload_for_merge))
     incoming_dict = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
     incoming_dict = incoming_dict if isinstance(incoming_dict, dict) else {}
 
@@ -1027,6 +1032,15 @@ def _build_merged_libraries_hint_payload(payload):
         prefix = _library_prefix_from_key(key)
         if prefix:
             prefixes.add(prefix)
+
+    for prefix in list(prefixes):
+        prefix_loaded_sections = _loaded_sections_with_payload_evidence(prefix, incoming_dict, loaded_sections)
+        incoming_dict = _preserve_unloaded_lazy_section_values(
+            prefix,
+            incoming_dict,
+            prefix_loaded_sections,
+            loaded_collection_groups,
+        )
 
     for prefix in prefixes:
         for existing_key in list(merged.keys()):

--- a/modules/bundle_artifacts.py
+++ b/modules/bundle_artifacts.py
@@ -392,7 +392,8 @@ def iter_overlay_source_bundle_artifacts(config_data, config_name):
                     overlay_slug = safe_overlay_bundle_slug(overlay_name, "overlay")
                     template_slug = safe_overlay_bundle_slug(template_key, "image")
                     stem_slug = safe_overlay_bundle_slug(source_path.stem, "image")
-                    digest_source = f"{str(source_path).replace('\\', '/').lower()}|{library_slug}|{overlay_slug}|{template_slug}"
+                    source_key = str(source_path).replace("\\", "/").lower()
+                    digest_source = f"{source_key}|{library_slug}|{overlay_slug}|{template_slug}"
                     digest = hashlib.sha1(digest_source.encode("utf-8", errors="ignore")).hexdigest()[:10]
                     suffix = source_path.suffix or ".png"
                     archive_path = Path(

--- a/modules/validations_overlay_images.py
+++ b/modules/validations_overlay_images.py
@@ -137,7 +137,8 @@ def normalize_overlay_source_override_file_location(location, *, config_name, li
     overlay_slug = _safe_overlay_image_slug(overlay_id, "overlay")
     template_slug = _safe_overlay_image_slug(template_key, "image")
     stem_slug = _safe_overlay_image_slug(source_path.stem, "image")
-    digest_source = f"{str(source_path).replace('\\', '/').lower()}|{library_slug}|{overlay_slug}|{template_slug}"
+    source_key = str(source_path).replace("\\", "/").lower()
+    digest_source = f"{source_key}|{library_slug}|{overlay_slug}|{template_slug}"
     digest = hashlib.sha1(digest_source.encode("utf-8", errors="ignore")).hexdigest()[:10]
     suffix = source_path.suffix or ".png"
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6583,9 +6583,12 @@ function markLazyCollectionGroupLoaded (card, groupIndex) {
   marker.value = Array.from(values).sort((a, b) => Number(a) - Number(b)).join(',')
 }
 
-function loadLazyCollectionGroup (collapse, card) {
+function loadLazyCollectionGroup (collapse, card, options = {}) {
   if (!collapse || collapse.dataset?.collectionGroupLazyCollapse !== 'true') {
     return Promise.resolve(collapse?.closest('[data-collection-group-shell="true"]') || null)
+  }
+  if (collapse._collectionGroupLoadPromise) {
+    return collapse._collectionGroupLoadPromise
   }
   if (collapse.dataset.lazyState === 'loading') {
     return Promise.reject(new Error('Collection group is already loading.'))
@@ -6605,7 +6608,7 @@ function loadLazyCollectionGroup (collapse, card) {
   spinner?.classList.remove('d-none')
   if (status) status.textContent = 'Loading collection group settings...'
 
-  return fetch(`/library_fragment/${encodeURIComponent(libraryId)}/section/collections/group/${encodeURIComponent(groupIndex)}`, {
+  const loadPromise = fetch(`/library_fragment/${encodeURIComponent(libraryId)}/section/collections/group/${encodeURIComponent(groupIndex)}`, {
     credentials: 'same-origin'
   })
     .then(res => {
@@ -6623,20 +6626,44 @@ function loadLazyCollectionGroup (collapse, card) {
       replacement.dataset.collectionGroupIndex = String(groupIndex)
       const replacementCollapse = replacement.querySelector('.accordion-collapse')
       const replacementButton = replacement.querySelector('.accordion-button')
-      if (replacementCollapse) {
+      const expand = options.expand !== false
+      if (replacementCollapse && expand) {
         replacementCollapse.classList.add('show')
         replacementCollapse.dataset.collectionGroupLoaded = 'true'
         replacementCollapse.dataset.collectionGroupIndex = String(groupIndex)
       }
-      if (replacementButton) {
+      if (replacementButton && expand) {
         replacementButton.classList.remove('collapsed')
         replacementButton.setAttribute('aria-expanded', 'true')
+      }
+      if (replacementCollapse && !expand) {
+        replacementCollapse.dataset.collectionGroupLoaded = 'true'
+        replacementCollapse.dataset.collectionGroupIndex = String(groupIndex)
       }
       markLazyCollectionGroupLoaded(card, groupIndex)
       initializeLibraryCardControls(card, libraryId)
       refreshTemplateOverrideState(card)
       return replacement
     })
+    .finally(() => {
+      delete collapse._collectionGroupLoadPromise
+    })
+
+  collapse._collectionGroupLoadPromise = loadPromise
+  return loadPromise
+}
+
+async function loadAllCollectionGroupsForReorder (libraryId) {
+  const container = document.getElementById(`${libraryId}-container`)
+  const card = container?.closest('.library-settings-card') ||
+    (activeLibraryId === libraryId ? libraryContainer?.querySelector('.library-settings-card') : null)
+  if (!card) return
+
+  const collapses = Array.from(card.querySelectorAll('[data-collection-group-lazy-collapse="true"]'))
+    .filter(collapse => collapse.dataset.lazyState !== 'loaded')
+  for (const collapse of collapses) {
+    await loadLazyCollectionGroup(collapse, card, { expand: false })
+  }
 }
 
 function wireLazyCollectionGroups (card) {
@@ -7358,7 +7385,6 @@ function getCollectionSectionEntries (libraryId) {
     entries.push({
       collectionId,
       label,
-      isCollectionless: collectionId.toLowerCase().endsWith('collectionless'),
       inputId: input.id,
       defaultValue: String(input.dataset.default || '').trim(),
       currentValue: String(input.value || '').trim(),
@@ -7367,7 +7393,6 @@ function getCollectionSectionEntries (libraryId) {
     })
   })
   entries.sort((left, right) => {
-    if (left.isCollectionless !== right.isCollectionless) return left.isCollectionless ? 1 : -1
     const byValue = compareCollectionSectionValues(left.effectiveValue, right.effectiveValue)
     if (byValue !== 0) return byValue
     return left.domIndex - right.domIndex
@@ -7579,15 +7604,29 @@ function resetCollectionSectionModalOrder (modalEl) {
   }, 120)
 }
 
-document.addEventListener('click', (event) => {
+document.addEventListener('click', async (event) => {
   const trigger = event.target.closest('[data-collection-section-modal-trigger]')
   if (trigger) {
     const libraryId = trigger.dataset.libraryId
     let modalEl = libraryId ? document.getElementById(`${libraryId}-collection-section-modal`) : null
     if (!modalEl || !bootstrap || !bootstrap.Modal) return
     modalEl = prepareCollectionSectionModal(modalEl)
-    renderCollectionSectionModalList(modalEl)
-    bootstrap.Modal.getOrCreateInstance(modalEl).show()
+    const status = modalEl.querySelector('[data-collection-section-modal-status]')
+    try {
+      setCollectionSectionActionBusy(trigger, true)
+      if (status) status.textContent = 'Loading collection defaults...'
+      await loadAllCollectionGroupsForReorder(libraryId)
+      renderCollectionSectionModalList(modalEl)
+      bootstrap.Modal.getOrCreateInstance(modalEl).show()
+    } catch (error) {
+      console.error('[Libraries] Failed to load collection groups for reorder', error)
+      if (status) status.textContent = 'Unable to load all collection defaults. Try again.'
+      if (typeof showToast === 'function') {
+        showToast('error', 'Unable to load all collection defaults for reordering. Try again.')
+      }
+    } finally {
+      setCollectionSectionActionBusy(trigger, false)
+    }
     return
   }
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6653,19 +6653,6 @@ function loadLazyCollectionGroup (collapse, card, options = {}) {
   return loadPromise
 }
 
-async function loadAllCollectionGroupsForReorder (libraryId) {
-  const container = document.getElementById(`${libraryId}-container`)
-  const card = container?.closest('.library-settings-card') ||
-    (activeLibraryId === libraryId ? libraryContainer?.querySelector('.library-settings-card') : null)
-  if (!card) return
-
-  const collapses = Array.from(card.querySelectorAll('[data-collection-group-lazy-collapse="true"]'))
-    .filter(collapse => collapse.dataset.lazyState !== 'loaded')
-  for (const collapse of collapses) {
-    await loadLazyCollectionGroup(collapse, card, { expand: false })
-  }
-}
-
 function wireLazyCollectionGroups (card) {
   if (!card || card.dataset.lazyCollectionGroupsBound === 'true') return
 
@@ -7400,6 +7387,70 @@ function getCollectionSectionEntries (libraryId) {
   return entries
 }
 
+function getActiveLibraryCardForId (libraryId) {
+  const container = document.getElementById(`${libraryId}-container`)
+  return container?.closest('.library-settings-card') ||
+    (activeLibraryId === libraryId ? libraryContainer?.querySelector('.library-settings-card') : null)
+}
+
+function fetchCollectionSectionEntries (libraryId) {
+  const card = getActiveLibraryCardForId(libraryId)
+  const sourcePayload = card ? buildPayloadFromCard(card) : {}
+  return fetch(`/library_fragment/${encodeURIComponent(libraryId)}/collection_section_entries`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source_payload: sourcePayload })
+  })
+    .then(res => {
+      if (!res.ok) {
+        return res.json().catch(() => ({})).then(body => {
+          throw new Error(body?.error || `Failed to load collection order (${res.status})`)
+        })
+      }
+      return res.json()
+    })
+    .then(data => {
+      if (!data || data.success !== true || !Array.isArray(data.entries)) {
+        throw new Error(data?.error || 'Invalid collection order response.')
+      }
+      return data.entries
+    })
+}
+
+function saveCollectionSectionOrderToServer (libraryId, collectionIds, reset) {
+  return fetch(`/library_fragment/${encodeURIComponent(libraryId)}/collection_section_order`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ collection_ids: collectionIds, reset })
+  })
+    .then(res => {
+      if (!res.ok) {
+        return res.json().catch(() => ({})).then(body => {
+          throw new Error(body?.error || `Failed to save collection order (${res.status})`)
+        })
+      }
+      return res.json()
+    })
+    .then(data => {
+      if (!data || data.success !== true) {
+        throw new Error(data?.error || 'Invalid collection order save response.')
+      }
+      return Array.isArray(data.entries) ? data.entries : []
+    })
+}
+
+function syncHydratedCollectionSectionInputs (entries) {
+  ;(entries || []).forEach(entry => {
+    const input = entry.inputId ? document.getElementById(entry.inputId) : null
+    if (!input) return
+    input.value = String(entry.currentValue || '')
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+  })
+}
+
 function buildCollectionSectionListItem (entry, position) {
   const li = document.createElement('li')
   li.className = 'list-group-item sortable-item d-flex justify-content-between align-items-center gap-3'
@@ -7508,13 +7559,14 @@ function prepareCollectionSectionModal (modalEl) {
   return modalEl
 }
 
-function renderCollectionSectionModalList (modalEl) {
+function renderCollectionSectionModalList (modalEl, providedEntries = null) {
   if (!modalEl) return []
   const libraryId = modalEl.dataset.libraryId
   const list = modalEl.querySelector('[data-collection-section-sortable]')
   const status = modalEl.querySelector('[data-collection-section-modal-status]')
   const saveButton = modalEl.querySelector('[data-collection-section-save]')
-  const entries = getCollectionSectionEntries(libraryId)
+  const entries = Array.isArray(providedEntries) ? providedEntries : getCollectionSectionEntries(libraryId)
+  modalEl._collectionSectionEntries = entries
   list.replaceChildren()
   if (!entries.length) {
     if (status) status.textContent = 'No enabled collections with a collection_section field are available to reorder in this library.'
@@ -7543,40 +7595,37 @@ function renderCollectionSectionModalList (modalEl) {
   return entries
 }
 
-function saveCollectionSectionModalOrder (modalEl) {
+async function saveCollectionSectionModalOrder (modalEl) {
   if (!modalEl) return
   modalEl = prepareCollectionSectionModal(modalEl)
+  const libraryId = modalEl.dataset.libraryId
   const saveButton = modalEl.querySelector('[data-collection-section-save]')
   setCollectionSectionActionBusy(saveButton, true)
   const list = modalEl.querySelector('[data-collection-section-sortable]')
   const items = Array.from(list ? list.children : [])
   const resetMode = modalEl.dataset.collectionSectionResetMode === 'true'
-  window.setTimeout(() => {
+  try {
     if (!items.length) {
-      setCollectionSectionActionBusy(saveButton, false)
       return
     }
-    if (!resetMode) {
-      items.forEach((item, index) => {
-        const inputId = item.dataset.inputId
-        const input = inputId ? document.getElementById(inputId) : null
-        if (!input) return
-        const nextValue = String((index + 1) * 10).padStart(3, '0')
-        input.value = nextValue
-        input.dispatchEvent(new Event('input', { bubbles: true }))
-        input.dispatchEvent(new Event('change', { bubbles: true }))
-        const current = item.querySelector('[data-collection-section-current]')
-        if (current) current.textContent = nextValue
-      })
-    }
+    const orderedIds = items.map(item => item.dataset.collectionId).filter(Boolean)
+    const savedEntries = await saveCollectionSectionOrderToServer(libraryId, orderedIds, resetMode)
+    syncHydratedCollectionSectionInputs(savedEntries)
     if (typeof showToast === 'function') {
       showToast(resetMode ? 'info' : 'success', resetMode ? 'Collection section modifications cleared. JSON defaults will be used.' : 'Collection section order updated.')
     }
-    refreshCollectionSectionPreviewNumbers(list)
     const modal = typeof bootstrap !== 'undefined' && bootstrap.Modal ? bootstrap.Modal.getOrCreateInstance(modalEl) : null
     if (modal) modal.hide()
+    refreshTemplateOverrideState(getActiveLibraryCardForId(libraryId) || document)
+    document.dispatchEvent(new CustomEvent('qs:workspace-data-changed', { detail: { source: 'collection-section-order', delayMs: 80 } }))
+  } catch (error) {
+    console.error('[Libraries] Failed to save collection section order', error)
+    if (typeof showToast === 'function') {
+      showToast('error', error.message || 'Unable to save collection section order.')
+    }
+  } finally {
     setCollectionSectionActionBusy(saveButton, false)
-  }, 120)
+  }
 }
 
 function resetCollectionSectionModalOrder (modalEl) {
@@ -7584,16 +7633,20 @@ function resetCollectionSectionModalOrder (modalEl) {
   modalEl = prepareCollectionSectionModal(modalEl)
   const resetButton = modalEl.querySelector('[data-collection-section-reset]')
   setCollectionSectionActionBusy(resetButton, true)
-  const entries = getCollectionSectionEntries(modalEl.dataset.libraryId)
   window.setTimeout(() => {
-    entries.forEach(entry => {
-      const input = entry.inputId ? document.getElementById(entry.inputId) : null
-      if (!input) return
-      input.value = ''
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      input.dispatchEvent(new Event('change', { bubbles: true }))
-    })
-    renderCollectionSectionModalList(modalEl)
+    const entries = Array.from(modalEl._collectionSectionEntries || [])
+      .map(entry => ({
+        ...entry,
+        currentValue: '',
+        effectiveValue: String(entry.defaultValue || '').trim()
+      }))
+      .sort((left, right) => {
+        const byValue = compareCollectionSectionValues(left.effectiveValue, right.effectiveValue)
+        if (byValue !== 0) return byValue
+        return (Number(left.groupIndex || 0) - Number(right.groupIndex || 0)) ||
+          (Number(left.collectionIndex || 0) - Number(right.collectionIndex || 0))
+      })
+    renderCollectionSectionModalList(modalEl, entries)
     modalEl.dataset.collectionSectionResetMode = 'true'
     const status = modalEl.querySelector('[data-collection-section-modal-status]')
     if (status) status.textContent = 'Defaults pending. Save Order will clear collection_section modifications and use JSON defaults.'
@@ -7615,14 +7668,14 @@ document.addEventListener('click', async (event) => {
     try {
       setCollectionSectionActionBusy(trigger, true)
       if (status) status.textContent = 'Loading collection defaults...'
-      await loadAllCollectionGroupsForReorder(libraryId)
-      renderCollectionSectionModalList(modalEl)
+      const entries = await fetchCollectionSectionEntries(libraryId)
+      renderCollectionSectionModalList(modalEl, entries)
       bootstrap.Modal.getOrCreateInstance(modalEl).show()
     } catch (error) {
-      console.error('[Libraries] Failed to load collection groups for reorder', error)
+      console.error('[Libraries] Failed to load collection section order', error)
       if (status) status.textContent = 'Unable to load all collection defaults. Try again.'
       if (typeof showToast === 'function') {
-        showToast('error', 'Unable to load all collection defaults for reordering. Try again.')
+        showToast('error', error.message || 'Unable to load collection defaults for reordering. Try again.')
       }
     } finally {
       setCollectionSectionActionBusy(trigger, false)

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -251,6 +251,9 @@ def test_libraries_lazy_loads_heavy_collection_and_overlay_sections():
     assert "clearLazyCollectionShellOverrideSummaries(sectionBody)" in script
     assert "await autosaveActiveLibrary({ quiet: true })" in script
     assert "await loadAllLazyCollectionGroups(sectionBody, card)" not in script
+    assert "async function loadAllCollectionGroupsForReorder (libraryId)" in script
+    assert "await loadLazyCollectionGroup(collapse, card, { expand: false })" in script
+    assert "await loadAllCollectionGroupsForReorder(libraryId)" in script
     assert "await loadLazyCollectionGroup(lazyCollapse, card)" in script
     assert "initializeLibraryCardControls(card, libraryId)" in script
     assert "wireLazyLibrarySections(card)" in script
@@ -285,6 +288,33 @@ def test_collection_section_partials_lazy_load_parent_groups():
         assert "macros.collection_group_section" not in partial
 
     assert "macros.collection_group_section(library, data, version_info, group, telemetry)" in group_fragment
+
+
+def test_collection_section_reorder_modal_sorts_by_saved_section_value():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    entries_body = script.split("function getCollectionSectionEntries (libraryId) {", 1)[1].split(
+        "function buildCollectionSectionListItem",
+        1,
+    )[0]
+    sort_body = entries_body.split("entries.sort((left, right) => {", 1)[1].split("  })\n  return entries", 1)[0]
+
+    assert "const byValue = compareCollectionSectionValues(left.effectiveValue, right.effectiveValue)" in sort_body
+    assert "if (byValue !== 0) return byValue" in sort_body
+    assert "return left.domIndex - right.domIndex" in sort_body
+    assert "isCollectionless" not in sort_body
+
+
+def test_collection_section_reorder_modal_hydrates_lazy_collection_groups_before_render():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    click_body = script.split("const trigger = event.target.closest('[data-collection-section-modal-trigger]')", 1)[1].split(
+        "const resetButton = event.target.closest('[data-collection-section-reset]')",
+        1,
+    )[0]
+
+    assert "await loadAllCollectionGroupsForReorder(libraryId)" in click_body
+    assert click_body.index("await loadAllCollectionGroupsForReorder(libraryId)") < click_body.index("renderCollectionSectionModalList(modalEl)")
+    assert "Loading collection defaults..." in click_body
+    assert "Unable to load all collection defaults for reordering. Try again." in click_body
 
 
 def test_cached_library_cards_do_not_submit_stale_form_fields():

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -251,9 +251,10 @@ def test_libraries_lazy_loads_heavy_collection_and_overlay_sections():
     assert "clearLazyCollectionShellOverrideSummaries(sectionBody)" in script
     assert "await autosaveActiveLibrary({ quiet: true })" in script
     assert "await loadAllLazyCollectionGroups(sectionBody, card)" not in script
-    assert "async function loadAllCollectionGroupsForReorder (libraryId)" in script
-    assert "await loadLazyCollectionGroup(collapse, card, { expand: false })" in script
-    assert "await loadAllCollectionGroupsForReorder(libraryId)" in script
+    assert "function fetchCollectionSectionEntries (libraryId)" in script
+    assert "collection_section_entries" in script
+    assert "collection_section_order" in script
+    assert "loadAllCollectionGroupsForReorder" not in script
     assert "await loadLazyCollectionGroup(lazyCollapse, card)" in script
     assert "initializeLibraryCardControls(card, libraryId)" in script
     assert "wireLazyLibrarySections(card)" in script
@@ -304,17 +305,30 @@ def test_collection_section_reorder_modal_sorts_by_saved_section_value():
     assert "isCollectionless" not in sort_body
 
 
-def test_collection_section_reorder_modal_hydrates_lazy_collection_groups_before_render():
+def test_collection_section_reorder_modal_fetches_server_entries_before_render():
     script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
     click_body = script.split("const trigger = event.target.closest('[data-collection-section-modal-trigger]')", 1)[1].split(
         "const resetButton = event.target.closest('[data-collection-section-reset]')",
         1,
     )[0]
 
-    assert "await loadAllCollectionGroupsForReorder(libraryId)" in click_body
-    assert click_body.index("await loadAllCollectionGroupsForReorder(libraryId)") < click_body.index("renderCollectionSectionModalList(modalEl)")
+    assert "const entries = await fetchCollectionSectionEntries(libraryId)" in click_body
+    assert click_body.index("const entries = await fetchCollectionSectionEntries(libraryId)") < click_body.index("renderCollectionSectionModalList(modalEl, entries)")
+    assert "loadAllCollectionGroupsForReorder" not in click_body
     assert "Loading collection defaults..." in click_body
-    assert "Unable to load all collection defaults for reordering. Try again." in click_body
+    assert "Unable to load collection defaults for reordering. Try again." in click_body
+
+
+def test_collection_section_reorder_modal_saves_order_server_side():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    save_body = script.split("async function saveCollectionSectionModalOrder (modalEl) {", 1)[1].split(
+        "function resetCollectionSectionModalOrder",
+        1,
+    )[0]
+
+    assert "await saveCollectionSectionOrderToServer(libraryId, orderedIds, resetMode)" in save_body
+    assert "syncHydratedCollectionSectionInputs(savedEntries)" in save_body
+    assert "document.getElementById(inputId)" not in save_body
 
 
 def test_cached_library_cards_do_not_submit_stale_form_fields():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -367,6 +367,146 @@ def test_library_fragment_lazy_overlay_count_ignores_inactive_overlay_values(cli
     assert 'data-lazy-override-count="0"' in html
 
 
+def test_collection_section_entries_endpoint_uses_server_data(client, monkeypatch, qs_module, library_routes_module):
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: ([{"id": "mov-library_movies", "name": "Movies", "type": "movie"}], [], {"plex_pass": True}),
+    )
+    monkeypatch.setattr(
+        library_routes_module.helpers,
+        "load_quickstart_config",
+        lambda _filename: [
+            {
+                "accordion": "Awards",
+                "collections": [
+                    {
+                        "id": "collection_oscars",
+                        "label": "Academy Awards",
+                        "media_types": ["movie"],
+                        "template_variables": [{"key": "collection_section", "type": "text_input", "default": "130"}],
+                    }
+                ],
+            },
+            {
+                "accordion": "Other",
+                "collections": [
+                    {
+                        "id": "collection_collectionless",
+                        "label": "Collectionless",
+                        "media_types": ["movie", "show"],
+                        "template_variables": [{"key": "collection_section", "type": "text_input", "default": "999"}],
+                    }
+                ],
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        qs_module.persistence,
+        "retrieve_settings",
+        lambda _target: {
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_collectionless": True,
+                "mov-library_movies-template_collection_collectionless_collection_section": "010",
+            }
+        },
+    )
+
+    resp = client.post(
+        "/library_fragment/mov-library_movies/collection_section_entries",
+        json={
+            "source_payload": {
+                "__loaded_sections": [],
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_oscars": "true",
+                "mov-library_movies-template_collection_oscars_collection_section": "020",
+            }
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert [entry["collectionId"] for entry in payload["entries"]] == ["collection_collectionless", "collection_oscars"]
+    assert [entry["currentValue"] for entry in payload["entries"]] == ["010", "020"]
+
+
+def test_collection_section_order_endpoint_saves_and_resets_without_dom(client, isolated_config_dir, monkeypatch, app, library_routes_module):
+    from modules import database
+
+    config_name = "pytest_collection_section_order"
+    database.save_section_data(
+        section="libraries",
+        validated=False,
+        user_entered=True,
+        name=config_name,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_collectionless": True,
+                "mov-library_movies-collection_oscars": True,
+                "mov-library_movies-template_collection_collectionless_collection_section": "010",
+            },
+            "validated": False,
+        },
+    )
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: ([{"id": "mov-library_movies", "name": "Movies", "type": "movie"}], [], {"plex_pass": True}),
+    )
+    monkeypatch.setattr(
+        library_routes_module.helpers,
+        "load_quickstart_config",
+        lambda _filename: [
+            {
+                "accordion": "Awards",
+                "collections": [
+                    {
+                        "id": "collection_oscars",
+                        "label": "Academy Awards",
+                        "media_types": ["movie"],
+                        "template_variables": [{"key": "collection_section", "type": "text_input", "default": "130"}],
+                    },
+                    {
+                        "id": "collection_collectionless",
+                        "label": "Collectionless",
+                        "media_types": ["movie", "show"],
+                        "template_variables": [{"key": "collection_section", "type": "text_input", "default": "999"}],
+                    },
+                ],
+            }
+        ],
+    )
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/library_fragment/mov-library_movies/collection_section_order",
+        json={"collection_ids": ["collection_oscars", "collection_collectionless"]},
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    _validated, _user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    libraries = stored["libraries"]
+    assert libraries["mov-library_movies-template_collection_oscars_collection_section"] == "010"
+    assert libraries["mov-library_movies-template_collection_collectionless_collection_section"] == "020"
+
+    reset_resp = client.post(
+        "/library_fragment/mov-library_movies/collection_section_order",
+        json={"collection_ids": ["collection_oscars", "collection_collectionless"], "reset": True},
+    )
+
+    assert reset_resp.status_code == 200
+    _validated, _user_entered, reset_stored = database.retrieve_section_data(config_name, "libraries")
+    reset_libraries = reset_stored["libraries"]
+    assert "mov-library_movies-template_collection_oscars_collection_section" not in reset_libraries
+    assert "mov-library_movies-template_collection_collectionless_collection_section" not in reset_libraries
+
+
 def test_lazy_overlay_count_uses_rendered_ratings_defaults(library_routes_module):
     library = {"id": "mov-library_movies", "name": "Movies", "type": "movie"}
     libraries_data = {

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -1562,6 +1562,37 @@ def test_libraries_radarr_dependency_hint_endpoint_template_collection_returns_r
     assert any("radarr_add_missing_best_picture enabled" in reason for reason in payload["reasons"])
 
 
+def test_libraries_radarr_dependency_hint_preserves_unloaded_lazy_collection_values(client, monkeypatch, qs_module):
+    monkeypatch.setattr(
+        qs_module.persistence,
+        "retrieve_settings",
+        lambda _target: {
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                RADARR_TEMPLATE_COLLECTION_KEY: "true",
+            }
+        },
+    )
+
+    resp = client.post(
+        "/libraries_radarr_dependency_hint",
+        json={
+            "source_library_id": "mov-library_movies",
+            "source_payload": {
+                "__loaded_sections": [],
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-playlist": "true",
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["required"] is True
+    assert any("radarr_add_missing_best_picture enabled" in reason for reason in payload["reasons"])
+
+
 def test_libraries_radarr_dependency_hint_endpoint_inactive_library_returns_empty(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.persistence, "retrieve_settings", lambda _target: {"libraries": {}})
 


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

- Move collection-section reorder data loading server-side so the modal no longer hydrates every lazy collection accordion.
- Save reordered `collection_section` values directly through a lightweight endpoint.
- Preserve unloaded lazy Libraries data when building dependency hints, so counts/requirements do not change just because an accordion was not expanded.
- Keep the reorder modal sorted by effective `collection_section` values, including `Collectionless`.

## Testing

- `python -m pytest tests\test_core_backend.py -k "collection_section_entries_endpoint_uses_server_data or collection_section_order_endpoint_saves_and_resets_without_dom or library_fragment_lazy_collection_and_overlay_counts"`
- `python -m pytest tests\test_collection_details_contract.py -k "collection_section_reorder_modal or libraries_lazy_loads_heavy_collection"`
- `python -m pytest tests\test_workspace_dependency_logic.py -k "radarr_dependency_hint_preserves_unloaded_lazy_collection_values or radarr_dependency_hint_endpoint_template_collection_returns_reasons"`
- `npx.cmd eslint static/local-js/025-libraries.js`
- `python -m py_compile blueprints\library_routes.py modules\validations_overlay_images.py modules\bundle_artifacts.py`
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791285443&installation_model_id=431096&pr_number=1799&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1799&signature=1cae693ebeb31946c548d20f990eb8037f6a796ba7cdfb17a61e95707041907c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->