### PR TITLE
fixes for mass * import annotations

### DIFF
--- a/modules/importer_operations.py
+++ b/modules/importer_operations.py
@@ -427,6 +427,19 @@ def _mass_metadata_dict_keys_as_sources(value: dict, ignored_keys: set[str]) -> 
     return [str(key) for key in value if str(key) not in ignored_keys]
 
 
+def _record_mass_metadata_source_import(
+    report: ImportReport,
+    lib_name: str,
+    op_key: str,
+    path_suffix: str,
+    raw_value: Any,
+    imported: bool,
+) -> None:
+    """Record the original grouped `.source` path when it imported."""
+    if imported and isinstance(raw_value, dict) and "source" in raw_value:
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{path_suffix}.source")
+
+
 def handle_mass_image_update_operation(
     lib_id: str,
     lib_name: str,
@@ -502,6 +515,7 @@ def handle_mass_metadata_update_operation(
         )
         imported_any = imported_any or imported
         if imported:
+            _record_mass_metadata_source_import(report, lib_name, op_key, new_key, op_value[new_key], imported)
             report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{new_key}")
 
     if "genre" in op_value:
@@ -528,6 +542,7 @@ def handle_mass_metadata_update_operation(
             )
             imported_any = imported_any or imported
             if imported:
+                _record_mass_metadata_source_import(report, lib_name, op_key, "genre", genre_value, imported)
                 report.add("imported", f"libraries.{lib_name}.operations.{op_key}.genre")
 
     if "content_rating" in op_value:
@@ -554,6 +569,7 @@ def handle_mass_metadata_update_operation(
             )
             imported_any = imported_any or imported
             if imported:
+                _record_mass_metadata_source_import(report, lib_name, op_key, "content_rating", rating_value, imported)
                 report.add("imported", f"libraries.{lib_name}.operations.{op_key}.content_rating")
 
     labels = op_value.get("labels")
@@ -588,6 +604,7 @@ def handle_mass_metadata_update_operation(
             )
             imported_any = imported_any or imported
             if imported:
+                _record_mass_metadata_source_import(report, lib_name, op_key, f"ratings.{new_key}", ratings[new_key], imported)
                 report.add("imported", f"libraries.{lib_name}.operations.{op_key}.ratings.{new_key}")
     elif ratings is not None:
         report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.ratings", "Unsupported ratings format.")

--- a/tests/test_mass_metadata_update_contract.py
+++ b/tests/test_mass_metadata_update_contract.py
@@ -50,6 +50,43 @@ def test_prepare_import_payload_accepts_mass_metadata_update():
     assert any("libraries.Movies.operations.mass_metadata_update" in line for line in report.lines)
 
 
+def test_mass_metadata_update_source_lines_annotate_as_imported():
+    raw_yaml = (
+        "libraries:\n"
+        "  Movies:\n"
+        "    operations:\n"
+        "      mass_metadata_update:\n"
+        "        genre:\n"
+        "          source:\n"
+        "          - tmdb\n"
+        "          - imdb\n"
+        "          - tvdb\n"
+        "        content_rating:\n"
+        "          source:\n"
+        "          - plex_csm\n"
+        "          - mdb_commonsense\n"
+        "          - omdb\n"
+    )
+    payload, report = importer.prepare_import_payload(
+        importer.load_yaml_config(raw_yaml),
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-attribute_mass_genre_update_order"] == '["tmdb", "imdb", "tvdb"]'
+    assert libraries["mov-library_movies-attribute_mass_content_rating_update_order"] == '["plex_csm", "mdb_commonsense", "omdb"]'
+    assert "imported: libraries.Movies.operations.mass_metadata_update.genre.source" in report.lines
+    assert "imported: libraries.Movies.operations.mass_metadata_update.content_rating.source" in report.lines
+
+    annotated = importer.annotate_yaml_with_report(raw_yaml, report.lines, binary=True)
+
+    assert "source:  # imported" in annotated
+    assert "- tmdb  # imported" in annotated
+    assert "- plex_csm  # imported" in annotated
+    assert "not imported - No matching Quickstart mapping" not in annotated
+
+
 def test_prepare_import_payload_accepts_legacy_metadata_backup():
     payload, report = importer.prepare_import_payload(
         {


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1800 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes import report false negatives for grouped `mass_metadata_update` source fields.

**Summary**
- Record original `mass_metadata_update.*.source` report paths when grouped source values are successfully imported.
- Keeps the existing payload behavior unchanged; this fixes the preview/report annotation only.
- Covers `genre.source`, `content_rating.source`, direct grouped aliases, and grouped rating sources.

**Validation**
- Added regression coverage for the issue #1800 shape where source rows were imported but shown as `not imported`.
- Ran:

```powershell
python -m pytest tests\test_mass_metadata_update_contract.py tests\test_importer_edge_cases.py -q
python -m py_compile modules\importer_operations.py modules\importer_yaml_annotation.py
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791286905&installation_model_id=431096&pr_number=1801&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1801&signature=76ecd6dd0e91eaf002a9abefb525920ce9d8cbcdd9e2475021182ef98442e877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->