### PR TITLE
Improve import merge

### DIFF
--- a/blueprints/import_config_helpers.py
+++ b/blueprints/import_config_helpers.py
@@ -36,6 +36,7 @@ import json
 import re
 from pathlib import Path
 
+from modules.import_redaction import clean_import_credential_value
 from modules import database
 
 
@@ -211,7 +212,7 @@ def _parse_plex_credentials_from_config(config_data):
         return "", ""
     url = plex_block.get("url") or plex_block.get("plex_url") or ""
     token = plex_block.get("token") or plex_block.get("plex_token") or ""
-    return str(url).strip(), str(token).strip()
+    return clean_import_credential_value(url), clean_import_credential_value(token)
 
 
 def _parse_plex_credentials_from_base(base_name: str):
@@ -227,13 +228,13 @@ def _parse_plex_credentials_from_base(base_name: str):
         return _parse_plex_credentials_from_config(stored)
     url = stored.get("url") or stored.get("plex_url") or ""
     token = stored.get("token") or stored.get("plex_token") or ""
-    return str(url).strip(), str(token).strip()
+    return clean_import_credential_value(url), clean_import_credential_value(token)
 
 
 def _parse_plex_credentials_from_form(form_data):
     url = form_data.get("plex_url", "") or ""
     token = form_data.get("plex_token", "") or ""
-    return str(url).strip(), str(token).strip()
+    return clean_import_credential_value(url), clean_import_credential_value(token)
 
 
 def _parse_tmdb_credentials_from_config(config_data):
@@ -241,7 +242,7 @@ def _parse_tmdb_credentials_from_config(config_data):
     if not isinstance(tmdb_block, dict):
         return ""
     api_key = tmdb_block.get("apikey") or tmdb_block.get("api_key") or tmdb_block.get("tmdb_apikey") or tmdb_block.get("token") or ""
-    return str(api_key).strip()
+    return clean_import_credential_value(api_key)
 
 
 def _parse_tmdb_credentials_from_base(base_name: str):
@@ -256,12 +257,12 @@ def _parse_tmdb_credentials_from_base(base_name: str):
     if "tmdb" in stored:
         return _parse_tmdb_credentials_from_config(stored)
     api_key = stored.get("apikey") or stored.get("api_key") or stored.get("tmdb_apikey") or stored.get("token") or ""
-    return str(api_key).strip()
+    return clean_import_credential_value(api_key)
 
 
 def _parse_tmdb_credentials_from_form(form_data):
     api_key = form_data.get("tmdb_apikey", "") or ""
-    return str(api_key).strip()
+    return clean_import_credential_value(api_key)
 
 
 def count_annotated_lines(text: str) -> dict:

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -81,6 +81,62 @@ from modules.library_file_entries import _normalize_imported_libraries_payload
 bp = Blueprint("import_config_routes", __name__)
 
 
+def _missing_import_preview_credentials(parsed: dict, form_data, *, merge_mode: bool, base_config: str, needs_plex: bool, needs_tmdb: bool) -> dict[str, bool]:
+    """Return which required import credentials have no usable source."""
+    missing = {"plex": False, "tmdb": False}
+    if needs_plex:
+        base_movie_id_map, base_show_id_map = _parse_base_plex_library_id_maps(base_config) if merge_mode else ({}, {})
+        has_base_library_cache = bool(base_movie_id_map or base_show_id_map)
+        form_plex_url, form_plex_token = _parse_plex_credentials_from_form(form_data or {})
+        imported_plex_url, imported_plex_token = _parse_plex_credentials_from_config(parsed)
+        base_plex_url, base_plex_token = _parse_plex_credentials_from_base(base_config) if merge_mode else ("", "")
+        has_plex_credentials = any(
+            bool(url and token)
+            for url, token in (
+                (form_plex_url, form_plex_token),
+                (base_plex_url, base_plex_token),
+                (imported_plex_url, imported_plex_token),
+            )
+        )
+        missing["plex"] = not has_base_library_cache and not has_plex_credentials
+    if needs_tmdb:
+        form_tmdb_key = _parse_tmdb_credentials_from_form(form_data or {})
+        imported_tmdb_key = _parse_tmdb_credentials_from_config(parsed)
+        base_tmdb_key = _parse_tmdb_credentials_from_base(base_config) if merge_mode else ""
+        missing["tmdb"] = not any((form_tmdb_key, base_tmdb_key, imported_tmdb_key))
+    return missing
+
+
+def _missing_import_preview_credentials_response(missing: dict[str, bool], extracted_dir):
+    needs_plex = bool(missing.get("plex"))
+    needs_tmdb = bool(missing.get("tmdb"))
+    if not needs_plex and not needs_tmdb:
+        return None
+    if needs_plex and needs_tmdb:
+        message = "Plex credentials and a TMDb API key are required to preview this import."
+    elif needs_plex:
+        message = "Plex credentials are required to import library settings. Enter a Plex URL and token to continue."
+    else:
+        message = "TMDb API key is required to import metadata settings. Enter a valid TMDb API key to continue."
+    if extracted_dir:
+        try:
+            shutil.rmtree(extracted_dir)
+        except OSError:
+            pass
+    return (
+        jsonify(
+            success=False,
+            needs_plex_credentials=needs_plex,
+            needs_tmdb_credentials=needs_tmdb,
+            message=message,
+            plex_url="",
+            plex_token="",
+            tmdb_apikey="",
+        ),
+        400,
+    )
+
+
 # --- routes ---------------------------------------------------------------
 
 
@@ -145,6 +201,20 @@ def import_config_preview():
     movie_id_map, show_id_map = _plex_library_id_maps(plex_data)
     movie_names, show_names = set(movie_id_map.values()), set(show_id_map.values())
     plex_libraries = _sorted_plex_libraries(movie_id_map, show_id_map)
+
+    missing_credentials = _missing_import_preview_credentials(
+        parsed,
+        request.form,
+        merge_mode=merge_mode,
+        base_config=base_config,
+        needs_plex=needs_plex,
+        needs_tmdb=needs_tmdb,
+    )
+    missing_credentials_response = None
+    if missing_credentials.get("plex") or (missing_credentials.get("tmdb") and not needs_plex):
+        missing_credentials_response = _missing_import_preview_credentials_response(missing_credentials, extracted_dir)
+    if missing_credentials_response:
+        return missing_credentials_response
 
     if needs_plex:
         plex_outcome = validate_plex_credentials(

--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -141,6 +141,33 @@ def _build_library_lists():
     return movie_libraries, show_libraries, telemetry_data
 
 
+def _normalize_library_toggle_names(libraries_data):
+    """Replace selected checkbox placeholder values with exact Plex names."""
+    if not isinstance(libraries_data, dict):
+        return {}
+
+    try:
+        library_names = persistence.get_library_names("010-plex")
+    except Exception:
+        library_names = {}
+    library_names = library_names if isinstance(library_names, dict) else {}
+
+    normalized = dict(libraries_data)
+    for key, value in list(normalized.items()):
+        if not isinstance(key, str) or not key.endswith("-library"):
+            continue
+        if not _is_truthy_setting_value(value):
+            continue
+        text = str(value).strip().lower()
+        if value is not True and text not in {"true", "yes", "on", "1"}:
+            continue
+        prefix = key[: -len("-library")]
+        library_id = prefix.split("_", 1)[1] if "_" in prefix else ""
+        if library_id in library_names:
+            normalized[key] = library_names[library_id]
+    return normalized
+
+
 def _legacy_playlist_library_names():
     settings = persistence.retrieve_settings("027-playlist_files") or {}
     playlist_payload = settings.get("playlist_files", {}) if isinstance(settings, dict) else {}
@@ -148,7 +175,7 @@ def _legacy_playlist_library_names():
         playlist_payload = playlist_payload.get("playlist_files", {})
     raw_libraries = playlist_payload.get("libraries", "") if isinstance(playlist_payload, dict) else ""
     if isinstance(raw_libraries, list):
-        return {str(item).strip() for item in raw_libraries if str(item).strip()}
+        return {str(item) for item in raw_libraries if str(item).strip()}
     return {item.strip() for item in str(raw_libraries or "").split(",") if item.strip()}
 
 
@@ -834,7 +861,7 @@ def _merge_active_library_payload_with_saved_libraries(library_id, incoming_libr
             continue
         merged[key] = value
 
-    return merged
+    return _normalize_library_toggle_names(merged)
 
 
 def _is_library_file_entry_key(library_id, key):

--- a/modules/import_redaction.py
+++ b/modules/import_redaction.py
@@ -1,0 +1,24 @@
+"""Helpers for recognizing redacted import credential placeholders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+REDACTED_CREDENTIAL_VALUES = {
+    "(redacted)",
+    "<redacted>",
+    "redacted",
+    "(saved plex token)",
+    "(saved plex url)",
+}
+
+
+def is_redacted_credential_value(value: Any) -> bool:
+    return str(value or "").strip().lower() in REDACTED_CREDENTIAL_VALUES
+
+
+def clean_import_credential_value(value: Any) -> str:
+    text = str(value or "").strip()
+    if is_redacted_credential_value(text):
+        return ""
+    return text

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -442,7 +442,7 @@ def prepare_import_payload(
 
             plex_id = _name_to_plex_id.get(name) or _name_to_plex_id.get(resolved_name)
             lib_id = f"{lib_type}-library_{plex_id}" if plex_id else f"{lib_type}-library_{helpers.normalize_id(name, existing_ids)}"
-            libraries_data[f"{lib_id}-library"] = "true"
+            libraries_data[f"{lib_id}-library"] = resolved_name
             report.add("imported", f"libraries.{lib_name}.library")
             playlist_names_for_library = {name, resolved_name}
             matched_names = playlist_libraries.intersection(playlist_names_for_library)

--- a/modules/importer_playlists.py
+++ b/modules/importer_playlists.py
@@ -98,6 +98,15 @@ class PlaylistImportState:
         return bool(self.libraries or self.file_entries)
 
 
+def _coerce_playlist_library_names(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
 def parse_playlist_config(config_data: dict, report: ImportReport) -> PlaylistImportState:
     """Read ``config_data['playlist_files']`` into a :class:`PlaylistImportState`.
 
@@ -150,7 +159,7 @@ def parse_playlist_config(config_data: dict, report: ImportReport) -> PlaylistIm
             )
             continue
         libs = tv.get("libraries")
-        entry_libs = _coerce_import_string_list(libs)
+        entry_libs = _coerce_playlist_library_names(libs)
         if not entry_libs:
             report.add(
                 "unmapped",

--- a/modules/importer_simple_sections.py
+++ b/modules/importer_simple_sections.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from modules.import_redaction import is_redacted_credential_value
+
 if TYPE_CHECKING:
     from modules.importer import ImportReport
 
@@ -172,6 +174,22 @@ def _normalize_anidb_section(section_payload: dict) -> dict:
     return updated
 
 
+def _strip_redacted_credentials(section: str, section_payload: dict, report: ImportReport) -> dict:
+    credential_keys = {
+        "plex": {"url", "plex_url", "token", "plex_token"},
+        "tmdb": {"apikey", "api_key", "tmdb_apikey", "token"},
+    }.get(section)
+    if not credential_keys:
+        return section_payload
+
+    cleaned = dict(section_payload)
+    for key in list(cleaned):
+        if str(key) in credential_keys and is_redacted_credential_value(cleaned.get(key)):
+            cleaned.pop(key, None)
+            report.add("skipped", f"{section}.{key}", "Redacted credential placeholder ignored.")
+    return cleaned
+
+
 def process_simple_sections(
     config_data: dict,
     *,
@@ -210,7 +228,9 @@ def process_simple_sections(
                 section_payload = _normalize_settings_section(section_payload)
             if section == "anidb":
                 section_payload = _normalize_anidb_section(section_payload)
-            payload[section] = {section: section_payload}
-            _flatten_dict(section, section_payload, report)
+            section_payload = _strip_redacted_credentials(section, section_payload, report)
+            if section_payload:
+                payload[section] = {section: section_payload}
+                _flatten_dict(section, section_payload, report)
         else:
             report.add("unmapped", section, "Unsupported section format.")

--- a/modules/output_libraries_data.py
+++ b/modules/output_libraries_data.py
@@ -31,6 +31,7 @@ from modules.output_grouping import group_movie_and_show_libraries
 # unset checkboxes as ``False`` while some older rows may still be
 # ``None`` or the empty string.
 _UNSELECTED_LIBRARY_VALUES = (None, "", False)
+_SELECTED_LIBRARY_PLACEHOLDERS = {"true", "yes", "on"}
 
 
 @dataclass(frozen=True)
@@ -116,6 +117,24 @@ def _select_libraries(nested_libraries_data, prefix):
     return {key: value for key, value in nested_libraries_data.items() if _is_selected_library_key(key, prefix) and value not in _UNSELECTED_LIBRARY_VALUES}
 
 
+def _resolve_library_display_names(libraries, plex_name_map):
+    resolved = {}
+    for key, value in libraries.items():
+        lib_id = helpers.extract_library_name(key)
+        if plex_name_map and lib_id in plex_name_map:
+            resolved[key] = plex_name_map[lib_id]
+            continue
+        if isinstance(value, bool):
+            resolved[key] = lib_id or str(value)
+            continue
+        text = str(value).strip()
+        if text.lower() in _SELECTED_LIBRARY_PLACEHOLDERS:
+            resolved[key] = lib_id or text
+        else:
+            resolved[key] = value
+    return resolved
+
+
 def _debug_log_extracted(bundle, debug):
     """Emit the 18-line 'Extracted X:' debug dump when *debug* is truthy."""
     if not debug:
@@ -165,9 +184,8 @@ def extract_libraries_bundle(nested_libraries_data, *, debug=False):
     from modules import persistence  # local import to avoid load-order cycle
 
     plex_name_map = persistence.get_library_names()
-    if plex_name_map:
-        movie_libraries = {k: plex_name_map.get(helpers.extract_library_name(k), v) for k, v in movie_libraries.items()}
-        show_libraries = {k: plex_name_map.get(helpers.extract_library_name(k), v) for k, v in show_libraries.items()}
+    movie_libraries = _resolve_library_display_names(movie_libraries, plex_name_map)
+    show_libraries = _resolve_library_display_names(show_libraries, plex_name_map)
 
     movie_library_names = {helpers.extract_library_name(k) for k in movie_libraries}
     show_library_names = {helpers.extract_library_name(k) for k in show_libraries}

--- a/modules/output_playlists.py
+++ b/modules/output_playlists.py
@@ -180,10 +180,11 @@ def _library_names_in_output_order(libraries_section):
     return []
 
 
-def _playlist_libraries_from_library_toggles(nested_libraries_data, ordered_library_names=None):
+def _playlist_libraries_from_library_toggles(nested_libraries_data, ordered_library_names=None, library_names_by_prefix=None):
     if not isinstance(nested_libraries_data, dict):
         return False, []
 
+    library_names_by_prefix = library_names_by_prefix or {}
     has_playlist_toggle = any(isinstance(key, str) and key.endswith("-playlist") for key in nested_libraries_data)
     playlist_libraries = []
 
@@ -196,8 +197,12 @@ def _playlist_libraries_from_library_toggles(nested_libraries_data, ordered_libr
         include_playlist = _coerce_bool(nested_libraries_data.get(f"{prefix}-playlist"))
         if include_playlist is not True:
             continue
-        library_name = str(value).strip()
-        if library_name:
+        mapped_name = library_names_by_prefix.get(prefix)
+        if mapped_name is not None:
+            library_name = str(mapped_name)
+        else:
+            library_name = str(value).strip()
+        if library_name.strip():
             playlist_libraries.append(library_name)
 
     return has_playlist_toggle, _ordered_selected_libraries(playlist_libraries, ordered_library_names)
@@ -338,7 +343,7 @@ def _collect_playlist_file_entries_from_libraries_data(nested_libraries_data):
     return _parse_playlist_file_entries_value(nested_libraries_data.get("playlist_files_entries"))
 
 
-def apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section):
+def apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section, library_names_by_prefix=None):
     """Compute ``config_data['playlist_files']`` from library-level toggles.
 
     Runs AFTER :func:`build_libraries_section` has produced the ordered
@@ -364,6 +369,7 @@ def apply_playlist_libraries_toggle(config_data, nested_libraries_data, librarie
     has_playlist_toggle, playlist_libraries = _playlist_libraries_from_library_toggles(
         nested_libraries_data,
         ordered_library_names=ordered_library_names,
+        library_names_by_prefix=library_names_by_prefix,
     )
     playlist_template_variables = _collect_playlist_template_variables_from_libraries_data(nested_libraries_data)
     playlist_file_entries = _collect_playlist_file_entries_from_libraries_data(nested_libraries_data)

--- a/modules/output_render.py
+++ b/modules/output_render.py
@@ -144,7 +144,19 @@ def process_libraries_block(config_data, *, debug=False):
     libraries_section = build_libraries_section(**bundle.to_section_kwargs())
 
     config_data["libraries"] = libraries_section.get("libraries", {}) if isinstance(libraries_section, dict) else {}
-    apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
+    library_names_by_prefix = {
+        helpers.strip_library_suffix(key): name
+        for key, name in {
+            **bundle.movie_libraries,
+            **bundle.show_libraries,
+        }.items()
+    }
+    apply_playlist_libraries_toggle(
+        config_data,
+        nested_libraries_data,
+        libraries_section,
+        library_names_by_prefix=library_names_by_prefix,
+    )
 
     if debug:
         helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -2,7 +2,6 @@ import namesgenerator
 import os
 import secrets
 import json
-import datetime
 import copy
 import re
 
@@ -410,7 +409,7 @@ def save_settings(raw_source, form_data):
             except Exception:
                 existing_validated_at = None
         if helpers.booler(data.get("validated")) and not existing_validated_at:
-            data["validated_at"] = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
+            data["validated_at"] = helpers.utc_now_iso()
         elif existing_validated_at and "validated_at" not in data:
             data["validated_at"] = existing_validated_at
 
@@ -426,7 +425,7 @@ def save_settings(raw_source, form_data):
             data["validated"] = user_entered
     validated = data.get("validated", False)
     if source_name == "anidb" and validated and not data.get("validated_at"):
-        data["validated_at"] = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
+        data["validated_at"] = helpers.utc_now_iso()
 
     # Save to DB
     database.save_section_data(

--- a/quickstart.py
+++ b/quickstart.py
@@ -219,6 +219,7 @@ from blueprints.library_routes import (
     _configured_library_ids,  # noqa: F401 (used internally + by tests)
     _legacy_playlist_library_names,  # noqa: F401
     _migrate_legacy_playlist_libraries_to_library_toggles,  # noqa: F401 (patched in tests)
+    _normalize_library_toggle_names,  # noqa: F401
     _build_merged_libraries_hint_payload,  # noqa: F401
     _libraries_dependency_hint_response,  # noqa: F401
 )
@@ -1134,7 +1135,7 @@ def _merge_libraries_payload_for_partial_step_save(incoming_libraries):
         elif shared in existing_libraries and shared not in merged_libraries:
             merged_libraries[shared] = existing_libraries[shared]
 
-    return merged_libraries
+    return _normalize_library_toggle_names(merged_libraries)
 
 
 DOTENV = os.path.relpath(os.path.join(helpers.CONFIG_DIR, ".env"))

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -1903,7 +1903,10 @@ document.addEventListener('DOMContentLoaded', function () {
       importSummary.classList.add('d-none')
     }
     if (confirmImportButton) confirmImportButton.classList.add('d-none')
-    if (importTmdbCredentials) importTmdbCredentials.classList.add('d-none')
+    if (!options.keepCredentials) {
+      if (importPlexCredentials) importPlexCredentials.classList.add('d-none')
+      if (importTmdbCredentials) importTmdbCredentials.classList.add('d-none')
+    }
     clearMergeSections()
     if (importReportFilters) {
       importReportFilters.querySelectorAll('button[data-filter]').forEach(btn => {

--- a/templates/partials/_library_playlists.html
+++ b/templates/partials/_library_playlists.html
@@ -32,8 +32,8 @@
                 <input class="form-check-input playlist-library-toggle" type="checkbox" id="{{ library.id }}-playlist"
                   name="{{ library.id }}-playlist" value="true" data-include-toggle="{{ library.id }}-include"
                   data-default="false" {% if playlist_checked %}checked{% endif %}>
-                <label class="form-check-label mb-0" for="{{ library.id }}-playlist">
-                  Include {{ library.name }}
+                <label class="form-check-label mb-0" for="{{ library.id }}-playlist" title="{{ library.name | e }}">
+                  Include [{{ library.name | nbsp_leading_spaces }}]
                 </label>
               </div>
               <div class="form-text text-muted mt-2">

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -137,6 +137,15 @@ def test_start_import_confirm_is_single_bound_and_in_flight_guarded():
     assert "importConfirmInFlight = false" in script
 
 
+def test_start_import_preview_clear_state_can_preserve_credential_panels():
+    script = START_JS_PATH.read_text(encoding="utf-8")
+    clear_fn = script.split("function clearImportPreviewState", 1)[1].split("function applyImportReportFilter", 1)[0]
+
+    assert "if (!options.keepCredentials)" in clear_fn
+    assert "if (importPlexCredentials) importPlexCredentials.classList.add('d-none')" in clear_fn
+    assert "if (importTmdbCredentials) importTmdbCredentials.classList.add('d-none')" in clear_fn
+
+
 def test_libraries_lookup_label_autosave_uses_narrow_payload():
     script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
 

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -169,6 +169,8 @@ def test_playlist_toggle_preserves_mirrored_state_when_excluded():
     partial = PLAYLIST_PARTIAL_PATH.read_text(encoding="utf-8")
 
     assert "{% if playlist_checked %}checked{% endif %}" in partial
+    assert 'title="{{ library.name | e }}"' in partial
+    assert "Include [{{ library.name | nbsp_leading_spaces }}]" in partial
     assert "playlistToggle.checked = false" not in script
     assert "payload[el.name] = el.checked ? (el.value || 'true') : 'false'" in script
 

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -331,6 +331,51 @@ def test_autosave_library_reports_normalized_flag(client, isolated_config_dir, q
     assert data["normalized"] is True
 
 
+def test_autosave_library_stores_exact_plex_name_for_checkbox_placeholder(
+    client,
+    isolated_config_dir,
+    qs_module,
+    library_routes_module,
+    monkeypatch,
+):
+    from modules import database
+
+    config_name = "pytest_library_toggle_exact_name"
+    monkeypatch.setattr(qs_module, "_selected_library_ids_from_libraries_data", lambda libs: {"mov-library_1"})
+    monkeypatch.setattr(qs_module, "_validate_library_collection_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_metadata_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_overlay_files", lambda libs, ids: [])
+    monkeypatch.setattr(qs_module, "_validate_library_auto_sort_hubs", lambda libs, ids: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_library_file_entries_payload",
+        lambda libs, config_name, **kw: (libs, [], False),
+    )
+    monkeypatch.setattr(
+        library_routes_module.persistence,
+        "get_library_names",
+        lambda *_args, **_kwargs: {"1": "  Movies "},
+    )
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/autosave_library/mov-library_1",
+        json={
+            "config_name": config_name,
+            "__loaded_sections": [],
+            "mov-library_1-library": "true",
+            "mov-library_1-playlist": "true",
+        },
+    )
+
+    assert resp.status_code == 200
+    _validated, _user_entered, saved = database.retrieve_section_data(config_name, "libraries")
+    assert saved["libraries"]["mov-library_1-library"] == "  Movies "
+    assert saved["libraries"]["mov-library_1-playlist"] is True
+
+
 def test_autosave_library_preserves_unloaded_lazy_collection_and_overlay_values(client, isolated_config_dir, qs_module, monkeypatch):
     from modules import database
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4955,6 +4955,104 @@ def test_import_config_preview_handles_tuple_validation_response(client, monkeyp
     assert "Bad Plex credentials from tuple response." in payload["message"]
 
 
+def test_import_config_preview_requests_all_missing_redacted_credentials(client, monkeypatch, qs_module):
+    import io
+
+    def _unexpected_plex_validation(_payload):
+        raise AssertionError("redacted Plex credentials should be treated as missing")
+
+    def _unexpected_tmdb_validation(_payload):
+        raise AssertionError("redacted TMDb credentials should be treated as missing")
+
+    monkeypatch.setattr(qs_module.validations, "validate_plex_server", _unexpected_plex_validation)
+    monkeypatch.setattr(qs_module.validations, "validate_tmdb_server", _unexpected_tmdb_validation)
+
+    yaml_text = (
+        "plex:\n" "  url: (redacted)\n" "  token: (redacted)\n" "tmdb:\n" "  apikey: (redacted)\n" "libraries:\n" "  Movies:\n" "    metadata_files:\n" "      - default: basic\n"
+    )
+
+    resp = client.post(
+        "/import-config/preview",
+        data={"config_name": "pytest_import_redacted_creds", "file": (io.BytesIO(yaml_text.encode("utf-8")), "config.yml")},
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["success"] is False
+    assert payload["needs_plex_credentials"] is True
+    assert payload["needs_tmdb_credentials"] is True
+    assert payload["plex_url"] == ""
+    assert payload["plex_token"] == ""
+    assert payload["tmdb_apikey"] == ""
+
+
+def test_import_config_preview_merge_uses_base_credentials_over_redacted_import(client, isolated_config_dir, monkeypatch, qs_module):
+    import io
+    import json
+
+    from modules import database
+
+    base_name = "pytest_import_base_creds"
+    database.save_section_data(
+        name=base_name,
+        section="plex",
+        validated=True,
+        user_entered=True,
+        data={
+            "plex": {
+                "url": "http://base-plex.local",
+                "token": "base-plex-token",
+                "tmp_movie_libraries": "1",
+                "tmp_show_libraries": "",
+                "tmp_library_names": json.dumps({"1": "Movies"}),
+            }
+        },
+    )
+    database.save_section_data(
+        name=base_name,
+        section="tmdb",
+        validated=True,
+        user_entered=True,
+        data={"tmdb": {"apikey": "base-tmdb-key"}},
+    )
+
+    def _unexpected_plex_validation(_payload):
+        raise AssertionError("base Plex library cache should avoid a Plex credential prompt")
+
+    tmdb_payloads = []
+
+    monkeypatch.setattr(qs_module.validations, "validate_plex_server", _unexpected_plex_validation)
+    monkeypatch.setattr(
+        qs_module.validations,
+        "validate_tmdb_server",
+        lambda payload: tmdb_payloads.append(dict(payload)) or {"valid": True},
+    )
+
+    yaml_text = (
+        "plex:\n" "  url: (redacted)\n" "  token: (redacted)\n" "tmdb:\n" "  apikey: (redacted)\n" "libraries:\n" "  Movies:\n" "    metadata_files:\n" "      - default: basic\n"
+    )
+
+    resp = client.post(
+        "/import-config/preview",
+        data={
+            "config_name": "pytest_import_merge_redacted",
+            "merge_mode": "merge",
+            "base_config": base_name,
+            "file": (io.BytesIO(yaml_text.encode("utf-8")), "config.yml"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload.get("needs_plex_credentials") is None
+    assert payload.get("needs_tmdb_credentials") is None
+    assert tmdb_payloads == [{"tmdb_apikey": "base-tmdb-key"}]
+    assert "plex" not in payload["importable_sections"]
+
+
 def test_yaml_generation_missing_sections_shows_error(client, isolated_config_dir, monkeypatch, qs_module):
     monkeypatch.setattr(
         qs_module,

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -224,6 +224,23 @@ def test_prepare_import_payload_maps_apprise_config_to_location():
     assert report.counts["imported"] >= 1
 
 
+def test_prepare_import_payload_skips_redacted_credential_placeholders():
+    payload, report = importer.prepare_import_payload(
+        {
+            "plex": {"url": "(redacted)", "token": "(redacted)"},
+            "tmdb": {"apikey": "<redacted>"},
+        },
+        set(),
+        set(),
+    )
+
+    assert "plex" not in payload
+    assert "tmdb" not in payload
+    assert "skipped: plex.url :: Redacted credential placeholder ignored." in report.lines
+    assert "skipped: plex.token :: Redacted credential placeholder ignored." in report.lines
+    assert "skipped: tmdb.apikey :: Redacted credential placeholder ignored." in report.lines
+
+
 def test_annotate_yaml_marks_apprise_config_as_imported():
     raw = "apprise:\n  config: /config/apprise.yml\n"
     _, report = importer.prepare_import_payload({"apprise": {"config": "/config/apprise.yml"}}, set(), set())

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -91,10 +91,31 @@ def test_prepare_import_payload_maps_playlist_files_to_library_toggles():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "true"
+    assert libraries["mov-library_movies-library"] == "Movies"
     assert libraries["mov-library_movies-playlist"] == "true"
     assert "playlist_files" not in payload
     assert any("libraries.Movies.playlist_files" in line for line in report.lines)
+
+
+def test_prepare_import_payload_matches_playlist_library_names_with_edge_spaces():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {"  Movies ": {}},
+            "playlist_files": [
+                {
+                    "default": "playlist",
+                    "template_variables": {"libraries": ["  Movies "]},
+                }
+            ],
+        },
+        {"  Movies "},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-library"] == "  Movies "
+    assert libraries["mov-library_movies-playlist"] == "true"
+    assert any("libraries.  Movies .playlist_files" in line for line in report.lines)
 
 
 def test_prepare_import_payload_accepts_comma_separated_playlist_libraries():
@@ -113,9 +134,9 @@ def test_prepare_import_payload_accepts_comma_separated_playlist_libraries():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "true"
+    assert libraries["mov-library_movies-library"] == "Movies"
     assert libraries["mov-library_movies-playlist"] == "true"
-    assert libraries["mov-library_tvshows-library"] == "true"
+    assert libraries["mov-library_tvshows-library"] == "TV Shows"
     assert libraries["mov-library_tvshows-playlist"] == "true"
     assert any("playlist_files[0].template_variables.libraries" in line for line in report.lines)
 
@@ -156,7 +177,7 @@ def test_prepare_import_payload_maps_playlist_template_variables_into_libraries_
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "true"
+    assert libraries["mov-library_movies-library"] == "Movies"
     assert libraries["mov-library_movies-playlist"] == "true"
     assert libraries["playlist-template_variables[sync_to_users]"] == "alice, bob"
     assert libraries["playlist-template_variables[delete_playlist]"] is True

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -20,7 +20,7 @@ def test_prepare_import_payload_maps_library_radarr_overrides():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "true"
+    assert libraries["mov-library_movies-library"] == "Movies"
     assert libraries["mov-library_movies-attribute_radarr_url"] == "http://radarr.local:7878"
     assert libraries["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
     assert libraries["mov-library_movies-attribute_radarr_search"] == "true"
@@ -45,7 +45,7 @@ libraries:
     payload, report = importer.prepare_import_payload(config_data, {"Movies"}, set())
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["mov-library_movies-library"] == "true"
+    assert libraries["mov-library_movies-library"] == "Movies"
     assert libraries["mov-library_movies-attribute_radarr_url"] == "http://radarr.local:7878"
     assert libraries["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
     assert libraries["mov-library_movies-attribute_radarr_search"] == "true"
@@ -72,7 +72,7 @@ def test_prepare_import_payload_maps_library_sonarr_overrides():
     )
 
     libraries = payload["libraries"]["libraries"]
-    assert libraries["sho-library_shows-library"] == "true"
+    assert libraries["sho-library_shows-library"] == "Shows"
     assert libraries["sho-library_shows-attribute_sonarr_url"] == "http://sonarr.local:8989"
     assert libraries["sho-library_shows-attribute_sonarr_language_profile"] == "English"
     assert libraries["sho-library_shows-attribute_sonarr_monitor"] == "future"

--- a/tests/test_ratings_yaml_contract.py
+++ b/tests/test_ratings_yaml_contract.py
@@ -233,6 +233,27 @@ def test_playlist_files_follow_library_output_order(monkeypatch, qs_module):
     assert playlist_order == library_order
 
 
+def test_playlist_files_resolve_true_library_toggle_through_plex_id_name_map(monkeypatch, qs_module):
+    payload = {
+        "validated": True,
+        "libraries": {
+            "mov-library_1-library": "true",
+            "mov-library_1-playlist": "true",
+            "mov-library_1-collection_collectionless": True,
+        },
+    }
+    monkeypatch.setattr(qs_module.output.persistence, "get_library_names", lambda *_args, **_kwargs: {"1": " Movies "})
+
+    parsed = _parsed_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    library_order = list(parsed["libraries"].keys())
+    playlist_order = parsed["playlist_files"][0]["template_variables"]["libraries"]
+
+    assert library_order == [" Movies "]
+    assert playlist_order == [" Movies "]
+    assert playlist_order != ["True"]
+
+
 def test_playlist_files_emit_shared_and_keyed_template_variables(monkeypatch, qs_module):
     payload = {
         "validated": True,


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Fixes import merge behavior so existing Plex and TMDb credentials are reused correctly, redacted imported credentials are ignored, and import preview asks for all missing required credentials in one flow. Also fixes playlist library-name handling so imported playlist libraries and generated `playlist_files` preserve exact Plex library names, including leading/trailing spaces, instead of degrading selected libraries to `true`/`True`.

Closes #1774
Closes #1795

## What Changed

### Import Merge Flow

- Added centralized redacted credential detection for imported config values.
- Prevented redacted Plex/TMDb placeholders from overwriting valid saved credentials during merge import.
- Updated import preview preflight to request both missing Plex and TMDb credentials together when both are needed.
- Preserved credential prompt UI state when preview state is cleared/re-rendered.
- Added coverage for merge imports using saved base credentials over redacted imported values.

### Playlist Import And Output

- Fixed playlist import so `playlist_files[].template_variables.libraries` maps to per-library playlist toggles without losing exact library names.
- Preserved leading/trailing spaces for playlist library names when they come from YAML list entries.
- Stopped saving imported selected libraries as `"true"` when the actual display name is available.
- Resolved older persisted `*-library: true` rows through the Plex section-ID name map when generating YAML.
- Ensured generated `playlist_files.template_variables.libraries` follows the final emitted library order and does not emit `True`.

### Libraries Page UI

- Updated the Libraries page playlist toggle label to display the selected library name in brackets using the existing whitespace-visible formatting.
- Added title text with the exact raw Plex library name so users can inspect names with prepended/appended spaces.

### Compatibility

- Replaced `datetime.UTC` usage with the existing UTC timestamp helper for compatibility with the Python runtime used by tests.

## Testing

```powershell
python -m pytest tests\test_config_and_library_routes.py tests\test_importer_edge_cases.py tests\test_importer_library_services.py -q
python -m pytest tests\test_ratings_yaml_contract.py -q
python -m pytest tests\test_collection_details_contract.py -q
python -m py_compile blueprints\library_routes.py quickstart.py modules\importer.py modules\importer_playlists.py modules\output_playlists.py modules\output_render.py modules\output_libraries_data.py modules\persistence.py

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791375170&installation_model_id=431096&pr_number=1804&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1804&signature=b3a61d8c1dddc6e547dc1da79c52c6650e2945a8e52bfe83ab5b976d88e79954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->