### PR TITLE
Improve log/config viewers with line numbers, exact filters, and section jumps

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -4259,7 +4259,7 @@ def tail_log():
                     for line in handle:
                         counts["total_lines"] += 1
                         upper = line.upper()
-                        if "FROM CACHE" in upper:
+                        if "FROM CACHE" in upper or "[CACHE]" in upper:
                             counts["cache"] += 1
                         if "[DEBUG]" in upper:
                             counts["debug"] += 1
@@ -4271,7 +4271,7 @@ def tail_log():
                             counts["error"] += 1
                         if "[CRITICAL]" in upper:
                             counts["critical"] += 1
-                        if "TRACEBACK" in upper:
+                        if "[TRACE]" in upper:
                             counts["trace"] += 1
             except Exception:
                 return None

--- a/quickstart.py
+++ b/quickstart.py
@@ -6464,6 +6464,7 @@ def support_info():
     lines.append(f"# Python: {python_version}")
     lines.append(f"# Git: {git_version}")
     lines.append(f"# Browser: {browser_line}")
+    lines.append("# Viewers: enhanced line numbers and section jump controls enabled")
     lines.extend(helpers.get_quickstart_settings_summary())
     lines.extend([f"# {line}" for line in plex_summary.splitlines()])
     lines.append(f"# Quickstart: {quickstart_version} | Branch: {quickstart_branch} | Environment: {quickstart_environment}")

--- a/quickstart.py
+++ b/quickstart.py
@@ -4271,7 +4271,7 @@ def tail_log():
                             counts["error"] += 1
                         if "[CRITICAL]" in upper:
                             counts["critical"] += 1
-                        if "[TRACE]" in upper:
+                        if "TRACEBACK" in upper:
                             counts["trace"] += 1
             except Exception:
                 return None

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1703,6 +1703,9 @@ form,
     font-variant-numeric: tabular-nums;
     line-height: 1.5;
     white-space: pre;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
 }
 
 .qs-line-viewer-content {
@@ -1721,6 +1724,163 @@ form,
 .qs-line-viewer--textarea textarea {
     white-space: pre;
     overflow: auto;
+}
+
+.qs-log-code {
+    overflow: auto;
+    padding: 0.55rem 0 0.75rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.55;
+    tab-size: 4;
+}
+
+.qs-log-line {
+    display: grid;
+    grid-template-columns: minmax(3.75rem, auto) minmax(max-content, 1fr);
+    min-width: max-content;
+    border-left: 3px solid transparent;
+    color: var(--theme-text-muted);
+    white-space: pre;
+}
+
+.qs-log-line:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.qs-log-line--jumped {
+    outline: 2px solid var(--theme-primary);
+    outline-offset: -2px;
+    background: rgba(var(--accent-color), 0.18);
+}
+
+.qs-log-line-number {
+    padding: 0 0.85rem 0 0.65rem;
+    color: rgba(173, 181, 189, 0.62);
+    text-align: right;
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+}
+
+.qs-log-line-number::before {
+    content: attr(data-line);
+}
+
+.qs-log-line-content {
+    padding-right: 1.25rem;
+    color: var(--theme-text);
+}
+
+.qs-log-line--cache {
+    border-left-color: var(--logscan-sem-cache);
+    background: var(--logscan-sem-cache-soft);
+}
+
+.qs-log-line--debug {
+    border-left-color: var(--logscan-sem-debug);
+}
+
+.qs-log-line--info {
+    border-left-color: var(--logscan-sem-info);
+}
+
+.qs-log-line--warning {
+    border-left-color: var(--logscan-sem-warning);
+    background: var(--logscan-sem-warning-soft);
+}
+
+.qs-log-line--error {
+    border-left-color: var(--logscan-sem-error);
+    background: var(--logscan-sem-error-soft);
+}
+
+.qs-log-line--critical {
+    border-left-color: var(--logscan-sem-critical);
+    background: var(--logscan-sem-critical-soft);
+}
+
+.qs-log-line--trace {
+    border-left-color: var(--logscan-sem-trace);
+    background: var(--logscan-sem-trace-soft);
+}
+
+.qs-log-line--cache .qs-log-line-number,
+.qs-log-line--cache .qs-log-line-content {
+    color: var(--logscan-sem-cache-ink);
+}
+
+.qs-log-line--warning .qs-log-line-number,
+.qs-log-line--warning .qs-log-line-content {
+    color: var(--logscan-sem-warning-ink);
+}
+
+.qs-log-line--error .qs-log-line-number,
+.qs-log-line--error .qs-log-line-content {
+    color: var(--logscan-sem-error-ink);
+}
+
+.qs-log-line--critical .qs-log-line-number,
+.qs-log-line--critical .qs-log-line-content {
+    color: var(--logscan-sem-critical-ink);
+}
+
+.qs-log-line--trace .qs-log-line-number,
+.qs-log-line--trace .qs-log-line-content {
+    color: var(--logscan-sem-trace-ink);
+}
+
+.qs-yaml-code {
+    min-height: calc((1.55em * 25) + 1.3rem);
+    max-height: 62vh;
+    resize: vertical;
+}
+
+.qs-support-info-code {
+    background-color: #000000 !important;
+    color: #f8f9fa !important;
+    border: 1px solid #343a40;
+    height: 320px;
+    min-height: 320px;
+    resize: vertical;
+}
+
+.qs-support-info-code .qs-log-line-content {
+    color: #f8f9fa;
+}
+
+.qs-support-info-copy-text {
+    min-height: 12rem;
+    max-height: 45vh;
+    overflow: auto;
+    white-space: pre;
+    background-color: #000000 !important;
+    color: #f8f9fa !important;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.82rem;
+    line-height: 1.45;
+}
+
+#final-yaml-viewer {
+    /* Theme matching log viewer */
+    background-color: #000000 !important; /* bg-black */
+    color: #f8f9fa !important;            /* text-light */
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    border-radius: 0.375rem !important;    /* rounded */
+    border: 1px solid #343a40;             /* matching clean border */
+
+    /* Height & Resizing */
+    height: calc((1.55em * 25) + 1.3rem) !important;
+    min-height: calc((1.55em * 25) + 1.3rem) !important;
+    max-height: 80vh;
+    width: 100%;
+
+    /* Scroll & Resize interaction */
+    overflow: auto !important;
+    resize: both !important;
 }
 
 label {
@@ -3741,6 +3901,9 @@ div#loading {
     line-height: 1.45;
     text-align: right;
     user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
 }
 
 .external-yaml-editor-line {
@@ -3753,6 +3916,14 @@ div#loading {
     font: inherit;
     line-height: inherit;
     text-align: right;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+}
+
+.external-yaml-editor-line::before {
+    content: attr(data-external-yaml-line);
 }
 
 .external-yaml-editor-line--issue {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1677,6 +1677,52 @@ form,
     font-family: monospace;
 }
 
+.qs-line-viewer {
+    --qs-line-number-bg: rgba(0, 0, 0, 0.18);
+    --qs-line-number-color: var(--theme-text-muted);
+    --qs-line-number-border: var(--theme-border);
+    display: grid;
+    grid-template-columns: minmax(3.25rem, auto) minmax(0, 1fr);
+    align-items: stretch;
+    width: 100%;
+    min-width: 0;
+}
+
+.qs-line-viewer-gutter {
+    margin: 0;
+    min-width: 0;
+    overflow: hidden;
+    user-select: none;
+    text-align: right;
+    color: var(--qs-line-number-color);
+    background: var(--qs-line-number-bg);
+    border: 1px solid var(--qs-line-number-border);
+    border-right: 0;
+    border-radius: var(--bs-border-radius) 0 0 var(--bs-border-radius);
+    font-family: monospace;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.5;
+    white-space: pre;
+}
+
+.qs-line-viewer-content {
+    min-width: 0;
+    margin: 0;
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    font-family: monospace;
+    line-height: 1.5;
+}
+
+.qs-line-viewer--textarea .qs-line-viewer-gutter {
+    padding: 0.375rem 0.55rem;
+}
+
+.qs-line-viewer--textarea textarea {
+    white-space: pre;
+    overflow: auto;
+}
+
 label {
     display: block;
     margin-bottom: 10px;

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -1,4 +1,8 @@
 import { getAppConfig, setAppConfig } from './modules/appConfig.js'
+import {
+  findYamlMajorSections,
+  renderLogRows
+} from './modules/kometa/_util.js'
 
 (function () {
   const isDebug = String(getAppConfig('QS_DEBUG', false)).toLowerCase() === 'true'
@@ -3884,7 +3888,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const refreshBtn = modalEl.querySelector('#supportInfoRefresh')
   const copyBtn = modalEl.querySelector('#supportInfoCopy')
   const status = modalEl.querySelector('#supportInfoStatus')
+  const jumpWrap = modalEl.querySelector('#supportInfoJumpWrap')
+  const jumpSelect = modalEl.querySelector('#supportInfoJump')
+  const copyFallback = modalEl.querySelector('#supportInfoCopyFallback')
+  const copyFallbackMessage = modalEl.querySelector('#supportInfoCopyFallbackMessage')
+  const copyFallbackText = modalEl.querySelector('#supportInfoCopyText')
   const isSecureContext = window.isSecureContext
+  let supportInfoText = ''
 
   function setStatus (text, isError) {
     if (!status) return
@@ -3897,11 +3907,91 @@ document.addEventListener('DOMContentLoaded', () => {
     copyBtn.textContent = 'Select'
   }
 
+  function findSupportInfoSections (text) {
+    const sections = [...findYamlMajorSections(text)]
+    String(text || '').split(/\r?\n/).forEach((line, index) => {
+      const headingMatch = line.match(/^#\s+(.+?)\s*$/)
+      if (!headingMatch) return
+      const label = headingMatch[1].trim()
+      const lower = label.toLowerCase()
+      if (
+        lower === 'system information' ||
+        lower.startsWith('libraries configured with quickstart') ||
+        lower.startsWith('quickstart log tail')
+      ) {
+        sections.push({ line: index + 1, label })
+      }
+    })
+    const seen = new Set()
+    return sections
+      .sort((a, b) => a.line - b.line)
+      .filter((section) => {
+        const key = `${section.line}:${section.label}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+  }
+
+  function syncSupportInfoJump (text) {
+    if (!jumpWrap || !jumpSelect) return
+    const sections = findSupportInfoSections(text)
+    const previous = jumpSelect.value
+    jumpWrap.hidden = sections.length === 0
+    jumpWrap.classList.toggle('d-none', sections.length === 0)
+    jumpSelect.replaceChildren()
+    const placeholder = document.createElement('option')
+    placeholder.value = ''
+    placeholder.textContent = sections.length ? 'Select a section' : 'No sections found'
+    jumpSelect.append(placeholder)
+    sections.forEach((section) => {
+      const option = document.createElement('option')
+      option.value = String(section.line)
+      option.textContent = `${section.label} - line ${section.line.toLocaleString()}`
+      jumpSelect.append(option)
+    })
+    if (previous && sections.some(section => String(section.line) === previous)) {
+      jumpSelect.value = previous
+    }
+  }
+
+  function renderSupportInfoText (text, opts = {}) {
+    if (!output) return
+    const content = String(text || '')
+    if (opts.copyable !== false) supportInfoText = content
+    renderLogRows(output, content, { highlightLevels: false })
+    syncSupportInfoJump(content)
+  }
+
+  function hideCopyFallback () {
+    if (copyFallback) copyFallback.classList.add('d-none')
+    if (copyFallbackText) copyFallbackText.value = ''
+  }
+
+  function showCopyFallback (text, message) {
+    if (!copyFallback || !copyFallbackText) return
+    if (copyFallbackMessage) {
+      copyFallbackMessage.textContent = message || 'Clipboard access is blocked. The raw support info is selected below.'
+    }
+    copyFallbackText.value = text
+    copyFallback.classList.remove('d-none')
+    try {
+      copyFallback.scrollIntoView({ block: 'nearest' })
+    } catch {
+      // No-op: older mobile browsers may not support scroll options.
+    }
+    focusWithoutScrolling(copyFallbackText)
+    copyFallbackText.select()
+    copyFallbackText.setSelectionRange(0, copyFallbackText.value.length)
+  }
+
   async function loadSupportInfo () {
     if (!output) return
     if (copyBtn) copyBtn.disabled = true
     setStatus('Loading...', false)
-    output.textContent = 'Loading support info...'
+    supportInfoText = ''
+    hideCopyFallback()
+    renderSupportInfoText('Loading support info...', { copyable: false })
 
     try {
       const res = await fetch('/support-info')
@@ -3909,11 +3999,13 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!res.ok || !data || !data.text) {
         throw new Error((data && data.error) || 'Failed to load support info.')
       }
-      output.textContent = data.text
+      renderSupportInfoText(data.text)
       setStatus(data.generated_at ? `Updated ${data.generated_at}` : 'Updated', false)
       if (copyBtn) copyBtn.disabled = !data.text.trim()
     } catch (err) {
-      output.textContent = `Unable to load support info.\n${err.message || String(err)}`
+      supportInfoText = ''
+      hideCopyFallback()
+      renderSupportInfoText(`Unable to load support info.\n${err.message || String(err)}`, { copyable: false })
       setStatus('Error loading support info', true)
       if (copyBtn) copyBtn.disabled = true
     }
@@ -3940,9 +4032,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function fallbackCopy (text, opts = {}) {
-    const showFailureToast = opts.showFailureToast !== false
-    const showSuccessToast = opts.showSuccessToast !== false
+  function fallbackCopy (text) {
     const windowScroll = getWindowScrollPosition()
     const activeElement = document.activeElement
     const textarea = document.createElement('textarea')
@@ -3961,14 +4051,9 @@ document.addEventListener('DOMContentLoaded', () => {
     textarea.select()
     textarea.setSelectionRange(0, textarea.value.length)
     try {
-      const success = document.execCommand('copy')
-      if (success) {
-        if (showSuccessToast) showToast('success', 'Support info copied to clipboard.')
-        return true
-      }
-      if (showFailureToast) showToast('error', 'Copy failed. Please copy manually.')
+      return document.execCommand('copy')
     } catch {
-      if (showFailureToast) showToast('error', 'Copy failed. Please copy manually.')
+      return false
     } finally {
       document.body.removeChild(textarea)
       restoreWindowScrollPosition(windowScroll)
@@ -3977,60 +4062,56 @@ document.addEventListener('DOMContentLoaded', () => {
         restoreWindowScrollPosition(windowScroll)
       }
     }
-    return false
-  }
-
-  function selectSupportInfoText () {
-    if (!output) return
-    const windowScroll = getWindowScrollPosition()
-    const outputScroll = output.scrollTop
-    const modalBody = output.closest('.modal-body')
-    const modalBodyScroll = modalBody ? modalBody.scrollTop : 0
-    try {
-      const selection = window.getSelection()
-      const range = document.createRange()
-      range.selectNodeContents(output)
-      selection.removeAllRanges()
-      selection.addRange(range)
-      focusWithoutScrolling(output)
-    } catch {
-      // No-op: selection best-effort only.
-    } finally {
-      output.scrollTop = outputScroll
-      if (modalBody) modalBody.scrollTop = modalBodyScroll
-      restoreWindowScrollPosition(windowScroll)
-    }
   }
 
   async function copySupportInfo () {
     if (!output) return
-    const text = output.textContent || ''
+    const text = supportInfoText || ''
     if (!text.trim()) {
-      showToast('warning', 'Nothing to copy yet.')
+      hideCopyFallback()
+      setStatus('Nothing to copy yet.', true)
       return
     }
     const canUseClipboard = isSecureContext && navigator.clipboard && navigator.clipboard.writeText
     if (canUseClipboard) {
       try {
         await navigator.clipboard.writeText(text)
-        showToast('success', 'Support info copied to clipboard.')
+        hideCopyFallback()
+        setStatus('Copied', false)
         return
       } catch {
         // Fall back to execCommand below.
       }
     }
-    if (canUseClipboard) {
-      fallbackCopy(text, { showFailureToast: true })
+
+    if (!canUseClipboard) {
+      showCopyFallback(text, 'Clipboard blocked on non-HTTPS. The raw support info is selected below.')
       return
     }
-    fallbackCopy(text, { showFailureToast: false, showSuccessToast: false })
-    selectSupportInfoText()
-    showToast('warning', 'Clipboard blocked on non-HTTPS. Text selected; press Ctrl+C to copy.')
+
+    if (fallbackCopy(text)) {
+      hideCopyFallback()
+      setStatus('Copied', false)
+      return
+    }
+    showCopyFallback(text, 'Copy failed. The raw support info is selected below.')
   }
 
   modalEl.addEventListener('show.bs.modal', () => {
     loadSupportInfo()
   })
+
+  if (jumpSelect) {
+    jumpSelect.addEventListener('change', function () {
+      const lineNumber = Number(this.value)
+      if (!output || !Number.isFinite(lineNumber) || lineNumber < 1) return
+      const row = output.querySelector(`[data-line="${lineNumber}"]`)
+      if (!row) return
+      output.scrollTop = row.offsetTop - output.offsetTop
+      row.classList.add('qs-log-line--jumped')
+      window.setTimeout(() => row.classList.remove('qs-log-line--jumped'), 1400)
+    })
+  }
 
   if (refreshBtn) refreshBtn.addEventListener('click', loadSupportInfo)
   if (copyBtn) copyBtn.addEventListener('click', copySupportInfo)

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -683,8 +683,8 @@ function syncExternalYamlEditorLineNumbers (modalEl) {
     const lineEl = document.createElement('button')
     lineEl.type = 'button'
     lineEl.className = 'external-yaml-editor-line'
-    lineEl.textContent = String(line)
     lineEl.dataset.externalYamlLine = String(line)
+    lineEl.setAttribute('aria-label', `Line ${line}`)
     if (markedLines.has(line)) lineEl.classList.add('external-yaml-editor-line--issue')
     gutter.appendChild(lineEl)
   }

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -5,6 +5,10 @@ import {
   formatRunSeconds,
   applyLogFilter,
   computeLogStats,
+  filterLogLines,
+  buildLineNumberedText,
+  syncLineNumberGutter,
+  syncLineNumberGutterScroll,
   copyTextToClipboard,
   setMetaFlag
 } from './modules/kometa/_util.js'
@@ -102,6 +106,7 @@ let tailSize = '2000'
 let logPollingPaused = false
 let logFilter = ''
 let lastLogText = ''
+let lastLogStartLine = 1
 let lastLogStatsTotal = null
 let logStatsPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
@@ -126,6 +131,7 @@ const runStatusTimer = document.getElementById('run-status-timer')
 const runStatusMetrics = document.getElementById('run-status-metrics')
 const runStatusLog = document.getElementById('run-status-log')
 const yamlOutput = document.getElementById('final-yaml')
+const yamlLineNumbers = document.getElementById('final-yaml-line-numbers')
 const yamlLineCount = document.getElementById('yaml-line-count')
 const stopModalEl = document.getElementById('stop-kometa-modal')
 const stopModal = (stopModalEl && typeof bootstrap !== 'undefined') ? new bootstrap.Modal(stopModalEl) : null
@@ -138,6 +144,58 @@ const finalContentWrapper = document.getElementById('final-content-wrapper')
 const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
 const runCommandCollapse = document.getElementById('run-command-output-collapse')
 let headerStyleSubmitting = false
+
+function renderYamlLineNumbers () {
+  if (!yamlOutput || !yamlLineNumbers) return
+  syncLineNumberGutter(yamlLineNumbers, yamlOutput.value)
+  yamlLineNumbers.style.height = `${yamlOutput.clientHeight}px`
+  syncLineNumberGutterScroll(yamlOutput, yamlLineNumbers)
+}
+
+function getDisplayedLogLineCount (text) {
+  return String(text || '').split(/\r?\n/).length
+}
+
+function getTailStartLine (data, text) {
+  const totalLines = Number(data?.stats?.total_lines ?? data?.total_lines ?? lastLogStatsTotal?.total_lines)
+  if (!Number.isFinite(totalLines) || totalLines < 1) return 1
+  const sizeLabel = String(tailSize || '').trim().toLowerCase()
+  if (sizeLabel === 'all' || sizeLabel === 'full') return 1
+  const displayedLines = getDisplayedLogLineCount(text)
+  return Math.max(1, totalLines - displayedLines + 1)
+}
+
+function renderRunLogText (text, opts = {}) {
+  if (!runLog) return
+  const content = String(text || '')
+  runLog.textContent = opts.numbered === false
+    ? content
+    : buildLineNumberedText(content, {
+      startLine: opts.startLine || 1,
+      lineNumbers: opts.lineNumbers
+    })
+}
+
+function renderFilteredRunLog () {
+  const result = filterLogLines(lastLogText, logFilter, { startLine: lastLogStartLine })
+  const noMatchText = lastLogText ? 'No lines matched the current filter.' : ''
+  renderRunLogText(result.text || noMatchText, {
+    startLine: result.text ? undefined : 1,
+    lineNumbers: result.text ? result.lineNumbers : undefined
+  })
+}
+
+function appendRunLogText (text) {
+  if (!runLog) return
+  lastLogText = `${lastLogText || ''}${text}`
+  renderFilteredRunLog()
+}
+
+yamlOutput?.addEventListener('scroll', () => syncLineNumberGutterScroll(yamlOutput, yamlLineNumbers))
+if (yamlOutput && yamlLineNumbers && typeof ResizeObserver !== 'undefined') {
+  const yamlResizeObserver = new ResizeObserver(renderYamlLineNumbers)
+  yamlResizeObserver.observe(yamlOutput)
+}
 
 function syncKometaMaintenancePageBadge (data) {
   if (!kometaMaintenancePageBadge) return
@@ -188,6 +246,7 @@ function updateYamlLineCount () {
   if (!yamlLineCount || !yamlOutput) return
   const lineCount = computeYamlLineCount(yamlOutput.value)
   yamlLineCount.textContent = `Line count (includes comments and blank lines): ${lineCount}`
+  renderYamlLineNumbers()
   updateConfigOutputHeaderBadges()
 }
 
@@ -376,7 +435,9 @@ function startKometaCommand (command, opts = {}) {
   if (recoveryBtn) recoveryBtn.disabled = true
   document.getElementById('stop-now').classList.remove('d-none')
   document.getElementById('run-output').classList.remove('d-none')
-  document.getElementById('run-output-log').textContent = startMessage
+  lastLogText = startMessage
+  lastLogStartLine = 1
+  renderFilteredRunLog()
   fetch('/start-kometa', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -387,7 +448,9 @@ function startKometaCommand (command, opts = {}) {
       if (data.error) {
         clearActiveRunCommandState()
         try { buildCommand() } catch {}
-        document.getElementById('run-output-log').textContent = `❌ ${data.error}`
+        lastLogText = `❌ ${data.error}`
+        lastLogStartLine = 1
+        renderFilteredRunLog()
         document.getElementById('run-now').disabled = false
         document.getElementById('run-now-label').textContent = 'Run Now'
         document.getElementById('stop-now').classList.add('d-none')
@@ -402,7 +465,9 @@ function startKometaCommand (command, opts = {}) {
         const nowLabel = (typeof window.QS_formatTimestamp === 'function') ? window.QS_formatTimestamp() : new Date().toLocaleString()
         const message = `Plex maintenance active${windowLabel} at ${nowLabel}. Kometa will start automatically when it ends.`
         showToast('warning', message)
-        document.getElementById('run-output-log').textContent = `${message}\n`
+        lastLogText = `${message}\n`
+        lastLogStartLine = 1
+        renderFilteredRunLog()
         {
           const runNowBtn = document.getElementById('run-now')
           if (runNowBtn) {
@@ -427,7 +492,7 @@ function startKometaCommand (command, opts = {}) {
     .catch(() => {
       clearActiveRunCommandState()
       try { buildCommand() } catch {}
-      document.getElementById('run-output-log').insertAdjacentHTML('beforeend', '\n⚠️ Failed to start Kometa.')
+      appendRunLogText('\n⚠️ Failed to start Kometa.')
       document.getElementById('run-now').disabled = false
       document.getElementById('run-now-label').textContent = 'Run Now'
       document.getElementById('stop-now').classList.add('d-none')
@@ -635,8 +700,7 @@ function updateClearFilterButton () {
 
 filterInput?.addEventListener('input', function() {
   logFilter = this.value.trim()
-  const filtered = applyLogFilter(lastLogText, logFilter)
-  runLog.textContent = filtered
+  renderFilteredRunLog()
   updateClearFilterButton()
   renderLogStats()
 })
@@ -644,8 +708,7 @@ filterInput?.addEventListener('input', function() {
 clearFilterBtn?.addEventListener('click', function() {
   logFilter = ''
   filterInput.value = ''
-  const filtered = applyLogFilter(lastLogText, logFilter)
-  runLog.textContent = filtered
+  renderFilteredRunLog()
   updateClearFilterButton()
   renderLogStats()
   if (filterInput) filterInput.focus()
@@ -656,8 +719,7 @@ if (levelButtons && levelButtons.length) {
     const val = this.dataset.level || ''
     logFilter = val
     if (filterInput) filterInput.value = val
-    const filtered = applyLogFilter(lastLogText, logFilter)
-    if (runLog) runLog.textContent = filtered
+    renderFilteredRunLog()
     updateClearFilterButton()
     renderLogStats()
   }))
@@ -697,6 +759,8 @@ if (!kometaCanReadLogs() && downloadLogBtn) {
   downloadLogBtn.disabled = true
 }
 updateClearFilterButton()
+renderYamlLineNumbers()
+renderRunLogText(runLog ? runLog.textContent : '')
 document.addEventListener('visibilitychange', function () {
   if (!document.hidden) {
     resumeKometaLiveView()
@@ -1132,11 +1196,11 @@ function performStopKometa () {
     .then(res => res.json())
     .then(data => {
       if (data.error) {
-        document.getElementById('run-output-log').insertAdjacentHTML('beforeend', `\n⚠️ ${data.error}`)
+        appendRunLogText(`\n⚠️ ${data.error}`)
         showToast('error', data.error)
       } else {
         const msg = data.message || data.warning || 'Kometa process stopped.'
-        document.getElementById('run-output-log').insertAdjacentHTML('beforeend', `\n🟥 ${msg}`)
+        appendRunLogText(`\n🟥 ${msg}`)
         if (data.warning) {
           showToast('warning', data.warning)
         } else {
@@ -1173,7 +1237,7 @@ function performStopKometa () {
     })
     .catch(err => {
       console.error('Error stopping Kometa process:', err) // Optional for debugging
-      document.getElementById('run-output-log').insertAdjacentHTML('beforeend', '\n⚠️ Error stopping process.')
+      appendRunLogText('\n⚠️ Error stopping process.')
       showToast('error', 'Error stopping Kometa process.')
     })
     .finally(() => {
@@ -1196,17 +1260,19 @@ function fetchKometaLog () {
     .then(data => {
       if (!runLog) return
       if (data.error) {
-        runLog.textContent = `❌ ${data.error}`
+        lastLogText = `❌ ${data.error}`
+        lastLogStartLine = 1
+        renderFilteredRunLog()
         updateLogRecency(null)
         return
       }
       lastLogText = data.log || ''
+      lastLogStartLine = getTailStartLine(data, lastLogText)
       updateLogRecency(data)
       if (data.stats) {
         lastLogStatsTotal = data.stats
       }
-      const filtered = applyLogFilter(lastLogText, logFilter)
-      runLog.textContent = filtered
+      renderFilteredRunLog()
       renderLogStats()
       fetchLogscanAnalysis(false, { updateHeaderBadge: updateLogscanHeaderBadge, kometaState })
       const shouldStick = autoScrollEnabled || wasAtBottom
@@ -1216,7 +1282,7 @@ function fetchKometaLog () {
     })
     .catch(err => {
       console.error('Error fetching Kometa log:', err)
-      if (runLog) runLog.textContent = (runLog.textContent || '') + '\n⚠️ Error fetching log.'
+      appendRunLogText('\n⚠️ Error fetching log.')
     })
 }
 
@@ -1272,8 +1338,8 @@ function checkKometaStatus () {
         runNow.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Waiting...'
         stopNow.classList.add('d-none')
         document.getElementById('run-output').classList.remove('d-none')
-        if (!document.getElementById('run-output-log').textContent.includes('Plex maintenance')) {
-          document.getElementById('run-output-log').insertAdjacentHTML('beforeend', `\n${message}`)
+        if (!String(runLog?.textContent || '').includes('Plex maintenance')) {
+          appendRunLogText(`\n${message}`)
         }
         syncIncompleteRunActions()
         if (kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
@@ -1334,20 +1400,18 @@ function checkKometaStatus () {
           fetchLogscanAnalysis(true, { updateHeaderBadge: updateLogscanHeaderBadge, kometaState })
         }
         if (data.return_code === 0) {
-          document.getElementById('run-output-log').insertAdjacentHTML('beforeend', '\n✅ Kometa finished successfully.')
+          appendRunLogText('\n✅ Kometa finished successfully.')
         } else {
-          document.getElementById('run-output-log').insertAdjacentHTML('beforeend', `\n⚠️ Kometa exited with code ${data.return_code}. Check logs for details.`)
+          appendRunLogText(`\n⚠️ Kometa exited with code ${data.return_code}. Check logs for details.`)
         }
       } else if (data.status === 'not started') {
         kometaState.kometaPendingStart = false
-        const outLog = document.getElementById('run-output-log')
-        if (outLog) outLog.insertAdjacentHTML('beforeend', '\n🟥 Kometa is not running.')
+        appendRunLogText('\n🟥 Kometa is not running.')
       }
     })
     .catch(err => {
       kometaState.kometaPendingStart = false
       console.error('Error checking Kometa status:', err)
-      const outLog = document.getElementById('run-output-log')
-      if (outLog) outLog.insertAdjacentHTML('beforeend', '\n️  Failed to check Kometa status.')
+      appendRunLogText('\n️  Failed to check Kometa status.')
     })
 }

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -6,9 +6,8 @@ import {
   applyLogFilter,
   computeLogStats,
   filterLogLines,
-  buildLineNumberedText,
-  syncLineNumberGutter,
-  syncLineNumberGutterScroll,
+  findYamlMajorSections,
+  renderLogRows,
   copyTextToClipboard,
   setMetaFlag
 } from './modules/kometa/_util.js'
@@ -131,7 +130,9 @@ const runStatusTimer = document.getElementById('run-status-timer')
 const runStatusMetrics = document.getElementById('run-status-metrics')
 const runStatusLog = document.getElementById('run-status-log')
 const yamlOutput = document.getElementById('final-yaml')
-const yamlLineNumbers = document.getElementById('final-yaml-line-numbers')
+const yamlViewer = document.getElementById('final-yaml-viewer')
+const yamlSectionJumpWrap = document.getElementById('final-yaml-section-jump-wrap')
+const yamlSectionJump = document.getElementById('final-yaml-section-jump')
 const yamlLineCount = document.getElementById('yaml-line-count')
 const stopModalEl = document.getElementById('stop-kometa-modal')
 const stopModal = (stopModalEl && typeof bootstrap !== 'undefined') ? new bootstrap.Modal(stopModalEl) : null
@@ -145,11 +146,37 @@ const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
 const runCommandCollapse = document.getElementById('run-command-output-collapse')
 let headerStyleSubmitting = false
 
-function renderYamlLineNumbers () {
-  if (!yamlOutput || !yamlLineNumbers) return
-  syncLineNumberGutter(yamlLineNumbers, yamlOutput.value)
-  yamlLineNumbers.style.height = `${yamlOutput.clientHeight}px`
-  syncLineNumberGutterScroll(yamlOutput, yamlLineNumbers)
+function getYamlText () {
+  return yamlOutput ? String(yamlOutput.value || '') : ''
+}
+
+function syncYamlSectionJump (text = getYamlText()) {
+  if (!yamlSectionJump || !yamlSectionJumpWrap) return
+  const sections = findYamlMajorSections(text)
+  yamlSectionJumpWrap.hidden = sections.length === 0
+  yamlSectionJumpWrap.classList.toggle('d-none', sections.length === 0)
+  const previous = yamlSectionJump.value
+  yamlSectionJump.replaceChildren()
+  const placeholder = document.createElement('option')
+  placeholder.value = ''
+  placeholder.textContent = sections.length ? 'Select a section' : 'No sections found'
+  yamlSectionJump.append(placeholder)
+  sections.forEach((section) => {
+    const option = document.createElement('option')
+    option.value = String(section.line)
+    option.textContent = `${section.label} - line ${section.line.toLocaleString()}`
+    yamlSectionJump.append(option)
+  })
+  if (previous && sections.some(section => String(section.line) === previous)) {
+    yamlSectionJump.value = previous
+  }
+}
+
+function renderYamlViewer () {
+  if (!yamlViewer) return
+  const text = getYamlText()
+  renderLogRows(yamlViewer, text, { highlightLevels: false })
+  syncYamlSectionJump(text)
 }
 
 function getDisplayedLogLineCount (text) {
@@ -168,12 +195,14 @@ function getTailStartLine (data, text) {
 function renderRunLogText (text, opts = {}) {
   if (!runLog) return
   const content = String(text || '')
-  runLog.textContent = opts.numbered === false
-    ? content
-    : buildLineNumberedText(content, {
-      startLine: opts.startLine || 1,
-      lineNumbers: opts.lineNumbers
-    })
+  if (opts.numbered === false) {
+    runLog.textContent = content
+    return
+  }
+  renderLogRows(runLog, content, {
+    startLine: opts.startLine || 1,
+    lineNumbers: opts.lineNumbers
+  })
 }
 
 function renderFilteredRunLog () {
@@ -191,11 +220,15 @@ function appendRunLogText (text) {
   renderFilteredRunLog()
 }
 
-yamlOutput?.addEventListener('scroll', () => syncLineNumberGutterScroll(yamlOutput, yamlLineNumbers))
-if (yamlOutput && yamlLineNumbers && typeof ResizeObserver !== 'undefined') {
-  const yamlResizeObserver = new ResizeObserver(renderYamlLineNumbers)
-  yamlResizeObserver.observe(yamlOutput)
-}
+yamlSectionJump?.addEventListener('change', function () {
+  const lineNumber = Number(this.value)
+  if (!yamlViewer || !Number.isFinite(lineNumber) || lineNumber < 1) return
+  const row = yamlViewer.querySelector(`[data-line="${lineNumber}"]`)
+  if (!row) return
+  yamlViewer.scrollTop = row.offsetTop - yamlViewer.offsetTop
+  row.classList.add('qs-log-line--jumped')
+  window.setTimeout(() => row.classList.remove('qs-log-line--jumped'), 1400)
+})
 
 function syncKometaMaintenancePageBadge (data) {
   if (!kometaMaintenancePageBadge) return
@@ -244,9 +277,9 @@ if (tailSelect) {
 
 function updateYamlLineCount () {
   if (!yamlLineCount || !yamlOutput) return
-  const lineCount = computeYamlLineCount(yamlOutput.value)
+  const lineCount = computeYamlLineCount(getYamlText())
   yamlLineCount.textContent = `Line count (includes comments and blank lines): ${lineCount}`
-  renderYamlLineNumbers()
+  renderYamlViewer()
   updateConfigOutputHeaderBadges()
 }
 
@@ -759,7 +792,7 @@ if (!kometaCanReadLogs() && downloadLogBtn) {
   downloadLogBtn.disabled = true
 }
 updateClearFilterButton()
-renderYamlLineNumbers()
+renderYamlViewer()
 renderRunLogText(runLog ? runLog.textContent : '')
 document.addEventListener('visibilitychange', function () {
   if (!document.hidden) {

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -1,7 +1,7 @@
 import {
-  buildLineNumberedText,
   computeLogStats as computeSharedLogStats,
-  filterLogLines as sharedFilterLogLines
+  filterLogLines as sharedFilterLogLines,
+  renderLogRows
 } from './modules/kometa/_util.js'
 
 const metaEl = document.getElementById('imagemaid-page-meta')
@@ -800,12 +800,14 @@ function getImageMaidLogStartLine (payload, text) {
 function renderRunLogText (text, opts = {}) {
   if (!els.runLog) return
   const content = String(text || '')
-  els.runLog.textContent = opts.numbered === false
-    ? content
-    : buildLineNumberedText(content, {
-      startLine: opts.startLine || 1,
-      lineNumbers: opts.lineNumbers
-    })
+  if (opts.numbered === false) {
+    els.runLog.textContent = content
+    return
+  }
+  renderLogRows(els.runLog, content, {
+    startLine: opts.startLine || 1,
+    lineNumbers: opts.lineNumbers
+  })
 }
 
 function updateLogStatBadges (stats) {

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -1,3 +1,9 @@
+import {
+  buildLineNumberedText,
+  computeLogStats as computeSharedLogStats,
+  filterLogLines as sharedFilterLogLines
+} from './modules/kometa/_util.js'
+
 const metaEl = document.getElementById('imagemaid-page-meta')
 const rootPath = metaEl ? String(metaEl.dataset.root || '').trim() : ''
 let imagemaidSupportsNoVerifySsl = metaEl ? String(metaEl.dataset.supportsNoVerifySsl || '').toLowerCase() === 'true' : false
@@ -765,23 +771,41 @@ function updateMaintenanceRow (data) {
   els.runMaintenanceRow.replaceChildren()
 }
 
-function computeLogStats (text, matcher) {
-  const stats = { filter: 0, cache: 0, debug: 0, info: 0, warn: 0, error: 0, crit: 0, trace: 0 }
-  const lines = String(text || '').split(/\r?\n/)
-  lines.forEach(line => {
-    if (!line) return
-    if (matcher && !matcher(line)) return
-    stats.filter += 1
-    const upper = line.toUpperCase()
-    if (upper.includes('[CACHE]') || /\bCACHE\b/.test(upper)) stats.cache += 1
-    if (upper.includes('[DEBUG]')) stats.debug += 1
-    if (upper.includes('[INFO]')) stats.info += 1
-    if (upper.includes('[WARNING]') || upper.includes('[WARN]')) stats.warn += 1
-    if (upper.includes('[ERROR]')) stats.error += 1
-    if (upper.includes('[CRITICAL]') || upper.includes('[CRIT]')) stats.crit += 1
-    if (upper.includes('[TRACE]')) stats.trace += 1
-  })
-  return stats
+function computeLogStats (text) {
+  const baseStats = computeSharedLogStats(text)
+  return {
+    filter: String(text || '').split(/\r?\n/).filter(Boolean).length,
+    cache: baseStats.cache || 0,
+    debug: baseStats.debug || 0,
+    info: baseStats.info || 0,
+    warn: baseStats.warning || 0,
+    error: baseStats.error || 0,
+    crit: baseStats.critical || 0,
+    trace: baseStats.trace || 0
+  }
+}
+
+function getDisplayedLogLineCount (text) {
+  return String(text || '').split(/\r?\n/).length
+}
+
+function getImageMaidLogStartLine (payload, text) {
+  const totalLines = Number(payload && payload.total_lines)
+  if (!Number.isFinite(totalLines) || totalLines < 1) return 1
+  const requested = String((payload && payload.requested_lines) || imagemaidTailSize || '').trim().toLowerCase()
+  if (requested === 'all' || requested === 'full') return 1
+  return Math.max(1, totalLines - getDisplayedLogLineCount(text) + 1)
+}
+
+function renderRunLogText (text, opts = {}) {
+  if (!els.runLog) return
+  const content = String(text || '')
+  els.runLog.textContent = opts.numbered === false
+    ? content
+    : buildLineNumberedText(content, {
+      startLine: opts.startLine || 1,
+      lineNumbers: opts.lineNumbers
+    })
 }
 
 function updateLogStatBadges (stats) {
@@ -806,23 +830,14 @@ function applyLogFilter () {
   const payload = lastImageMaidLogPayload || {}
   const rawText = String(payload.text || lastImageMaidLogText || '')
   const filterText = String(els.logFilter.value || '').trim()
-  let filteredText = rawText
-  let textMatcher = null
-  if (filterText) {
-    try {
-      const regex = new RegExp(filterText, 'i')
-      textMatcher = line => regex.test(line)
-    } catch {
-      const lowered = filterText.toLowerCase()
-      textMatcher = line => String(line || '').toLowerCase().includes(lowered)
-    }
-  }
-  const matcher = textMatcher || null
-  if (matcher) {
-    filteredText = rawText.split(/\r?\n/).filter(line => matcher(line)).join('\n')
-  }
-  els.runLog.textContent = filteredText || (rawText ? 'No lines matched the current filter.' : 'ImageMaid log is empty.')
-  updateLogStatBadges(computeLogStats(rawText, matcher))
+  const startLine = getImageMaidLogStartLine(payload, rawText)
+  const result = sharedFilterLogLines(rawText, filterText, { startLine })
+  const filteredText = result.text || (rawText ? 'No lines matched the current filter.' : 'ImageMaid log is empty.')
+  renderRunLogText(filteredText, {
+    startLine: result.text ? undefined : 1,
+    lineNumbers: result.text ? result.lineNumbers : undefined
+  })
+  updateLogStatBadges(computeLogStats(result.text))
   syncLogLevelButtons()
   if (imagemaidLogAutoScroll && els.runLog) {
     els.runLog.scrollTop = els.runLog.scrollHeight
@@ -1109,7 +1124,7 @@ function loadLog (force = false) {
         lastImageMaidLogPayload = null
         lastImageMaidLogText = ''
         lastImageMaidLogPath = ''
-        els.runLog.textContent = (body && body.error) || 'No ImageMaid log found yet.'
+        renderRunLogText((body && body.error) || 'No ImageMaid log found yet.')
         updateLogStatBadges({ filter: 0, cache: 0, debug: 0, info: 0, warn: 0, error: 0, crit: 0, trace: 0 })
         updateLogRecency(null)
         return
@@ -1124,7 +1139,7 @@ function loadLog (force = false) {
     })
     .catch(() => {
       lastImageMaidLogPayload = null
-      els.runLog.textContent = 'Failed to load the ImageMaid log.'
+      renderRunLogText('Failed to load the ImageMaid log.')
       updateLogRecency(null)
     })
     .finally(() => {
@@ -1211,7 +1226,7 @@ function submitRun () {
       if (status >= 400) {
         setRunState('error', body.error || 'ImageMaid failed to start.')
         if (body && body.error) {
-          els.runLog.textContent = body.error
+          renderRunLogText(body.error)
         }
         loadLog(true)
         showToast('error', body.error || 'ImageMaid failed to start.')
@@ -1389,6 +1404,7 @@ syncUpdateButtonLabel()
 imagemaidLastPayloadSignature = buildPayloadSignature()
 els.tailLabel.textContent = imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize
 imagemaidLogAutoScroll = els.logAutoscroll.checked
+renderRunLogText(els.runLog ? els.runLog.textContent : 'No ImageMaid log loaded.')
 syncLogLevelButtons()
 setValidationState(imagemaidValidated ? 'ok' : 'idle', String(els.validationStatus.textContent || '').trim())
 probeRoot()

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -226,9 +226,14 @@ function updateModeHelp () {
 }
 
 function setBadge (el, tone, text) {
+  if (!el) return
   el.classList.remove('text-bg-secondary', 'text-bg-success', 'text-bg-warning', 'text-bg-danger', 'text-bg-primary')
   el.classList.add(tone)
   el.textContent = text
+}
+
+function setText (el, text) {
+  if (el) el.textContent = text
 }
 
 function shortSha (value) {
@@ -288,23 +293,23 @@ function syncPrepareSummary (body, options = {}) {
 
   const localVersion = String((body && body.local_version) || '').trim()
   const remoteVersion = String((body && body.remote_version) || '').trim()
-  els.localVersionStatus.textContent = localVersion || 'Unknown'
-  els.remoteVersionStatus.textContent = remoteVersion || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked')
-  els.localBranchStatus.textContent = (body && body.local_branch) || 'Unknown'
-  els.localShaStatus.textContent = shortSha(body && body.local_sha) || 'Unknown'
-  els.remoteShaStatus.textContent = shortSha(body && body.remote_sha) || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked')
-  els.branchSourceUrl.textContent = (body && body.branch_source_url) || ''
-  els.zipSourceUrl.textContent = (body && body.zip_source_url) || ''
+  setText(els.localVersionStatus, localVersion || 'Unknown')
+  setText(els.remoteVersionStatus, remoteVersion || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked'))
+  setText(els.localBranchStatus, (body && body.local_branch) || 'Unknown')
+  setText(els.localShaStatus, shortSha(body && body.local_sha) || 'Unknown')
+  setText(els.remoteShaStatus, shortSha(body && body.remote_sha) || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked'))
+  setText(els.branchSourceUrl, (body && body.branch_source_url) || '')
+  setText(els.zipSourceUrl, (body && body.zip_source_url) || '')
 
   const localBranch = (body && body.local_branch) || 'unknown'
   const localSha = shortSha(body && body.local_sha) || 'unknown'
   const remoteSha = shortSha(body && body.remote_sha) || 'unknown'
-  els.localVersionInline.textContent = localVersion || 'unknown'
-  els.localBranchInline.textContent = localBranch
-  els.localShaInline.textContent = localSha
-  els.remoteVersionInline.textContent = remoteVersion || 'unknown'
-  els.remoteShaInline.textContent = remoteSha
-  els.updateBox.classList.toggle('d-none', !imagemaidUpdateAvailable)
+  setText(els.localVersionInline, localVersion || 'unknown')
+  setText(els.localBranchInline, localBranch)
+  setText(els.localShaInline, localSha)
+  setText(els.remoteVersionInline, remoteVersion || 'unknown')
+  setText(els.remoteShaInline, remoteSha)
+  if (els.updateBox) els.updateBox.classList.toggle('d-none', !imagemaidUpdateAvailable)
 
   if (options.phaseTone && options.phaseText) {
     setUpdatePhase(options.phaseTone, options.phaseText)

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -202,36 +202,106 @@ export function isTimeWithinRange (time, rangeStart, rangeEnd) {
 // Log helpers (pure text -> text / text -> counts)
 // ---------------------------------------------------------------------
 
+const LOG_LEVEL_PATTERNS = {
+  cache: [
+    /\bfrom cache\b/i,
+    /\[CACHE\]/i
+  ],
+  debug: [/\[DEBUG\]/i],
+  info: [/\[INFO\]/i],
+  warning: [/\[WARNING\]/i],
+  error: [/\[ERROR\]/i],
+  critical: [/\[CRITICAL\]/i],
+  trace: [/\[TRACE\]/i]
+}
+
+const LOG_FILTER_ALIASES = new Map([
+  ['cache', 'cache'],
+  ['from cache', 'cache'],
+  ['cached', 'cache'],
+  ['debug', 'debug'],
+  ['info', 'info'],
+  ['warning', 'warning'],
+  ['warn', 'warning'],
+  ['error', 'error'],
+  ['critical', 'critical'],
+  ['crit', 'critical'],
+  ['trace', 'trace'],
+  ['traceback', 'trace']
+])
+
+function normalizeLogFilterAlias (value) {
+  return String(value || '')
+    .trim()
+    .replace(/^\[+|\]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function lineMatchesAny (line, patterns) {
+  return patterns.some(pattern => pattern.test(line))
+}
+
+export function buildLogFilterMatcher (filter) {
+  if (!filter) return null
+  const trimmed = String(filter).trim()
+  if (!trimmed) return null
+  const alias = LOG_FILTER_ALIASES.get(normalizeLogFilterAlias(trimmed))
+  if (alias && LOG_LEVEL_PATTERNS[alias]) {
+    return line => lineMatchesAny(String(line || ''), LOG_LEVEL_PATTERNS[alias])
+  }
+  try {
+    if (trimmed.length > 2 && trimmed.startsWith('/') && trimmed.endsWith('/')) {
+      const regex = new RegExp(trimmed.slice(1, -1), 'i')
+      return line => regex.test(line)
+    }
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(escaped, 'i')
+    return line => regex.test(line)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Filter a multi-line log string, returning only lines matching
  * `filter`. If the filter is empty, the input is returned unchanged.
  * A filter wrapped in `/.../` is treated as a case-insensitive
  * regex; otherwise it's literal (with all regex metacharacters
- * escaped). Invalid regex silently falls back to returning the
- * unfiltered text.
+ * escaped). Known level names such as `error`, `[ERROR]`, and `warn`
+ * use the same broadened patterns as the log-stat badges. Invalid
+ * regex silently falls back to returning the unfiltered text.
  */
 export function applyLogFilter (text, filter) {
-  if (!filter) return text
-  const trimmed = filter.trim()
-  let re
-  try {
-    if (trimmed.length > 2 && trimmed.startsWith('/') && trimmed.endsWith('/')) {
-      re = new RegExp(trimmed.slice(1, -1), 'i')
-    } else {
-      const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      re = new RegExp(escaped, 'i')
+  return filterLogLines(text, filter).text
+}
+
+export function filterLogLines (text, filter, opts = {}) {
+  const content = String(text || '')
+  const startLine = Math.max(1, Number(opts.startLine || 1) || 1)
+  const lines = content.split(/\r?\n/)
+  const matcher = buildLogFilterMatcher(filter)
+  if (!matcher) {
+    return {
+      text: content,
+      lineNumbers: lines.map((_line, index) => startLine + index)
     }
-  } catch {
-    return text
   }
-  return text.split('\n').filter(line => re.test(line)).join('\n')
+  const matches = []
+  const lineNumbers = []
+  lines.forEach((line, index) => {
+    if (!matcher(line)) return
+    matches.push(line)
+    lineNumbers.push(startLine + index)
+  })
+  return { text: matches.join('\n'), lineNumbers }
 }
 
 /**
  * Count log lines by level marker.
- * Recognises Kometa's bracketed level tags: [DEBUG] [INFO] [WARNING]
- * [ERROR] [CRITICAL]. `cache` counts lines containing "from cache"
- * (case-insensitive) and `trace` counts lines containing "traceback".
+ * Recognises bracketed and plain level tags used by Kometa and ImageMaid.
+ * `cache` accepts "from cache", "cached", and "[CACHE]"; `trace` accepts
+ * trace/traceback lines.
  */
 export function computeLogStats (text) {
   const stats = {
@@ -247,15 +317,54 @@ export function computeLogStats (text) {
   const lines = text.split(/\r?\n/)
   lines.forEach(line => {
     if (!line) return
-    if (line.toLowerCase().includes('from cache')) stats.cache += 1
-    if (line.includes('[DEBUG]')) stats.debug += 1
-    if (line.includes('[INFO]')) stats.info += 1
-    if (line.includes('[WARNING]')) stats.warning += 1
-    if (line.includes('[ERROR]')) stats.error += 1
-    if (line.includes('[CRITICAL]')) stats.critical += 1
-    if (line.toLowerCase().includes('traceback')) stats.trace += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.cache)) stats.cache += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.debug)) stats.debug += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.info)) stats.info += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.warning)) stats.warning += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.error)) stats.error += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.critical)) stats.critical += 1
+    if (lineMatchesAny(line, LOG_LEVEL_PATTERNS.trace)) stats.trace += 1
   })
   return stats
+}
+
+export function buildLineNumberText (text, opts = {}) {
+  const minLines = Math.max(1, Number(opts.minLines || 1) || 1)
+  const startLine = Math.max(1, Number(opts.startLine || 1) || 1)
+  const explicitNumbers = Array.isArray(opts.lineNumbers) ? opts.lineNumbers : null
+  const numbers = explicitNumbers && explicitNumbers.length
+    ? explicitNumbers.map(value => Math.max(1, Number(value) || 1))
+    : Array.from(
+      { length: Math.max(minLines, String(text || '').split(/\r?\n/).length) },
+      (_value, index) => startLine + index
+    )
+  const width = Math.max(1, ...numbers.map(value => String(value).length))
+  return numbers.map(value => String(value).padStart(width, ' ')).join('\n')
+}
+
+export function buildLineNumberedText (text, opts = {}) {
+  const content = String(text || '')
+  const lines = content.split(/\r?\n/)
+  const explicitNumbers = Array.isArray(opts.lineNumbers) ? opts.lineNumbers : null
+  const startLine = Math.max(1, Number(opts.startLine || 1) || 1)
+  const numbers = explicitNumbers && explicitNumbers.length
+    ? explicitNumbers.map(value => Math.max(1, Number(value) || 1))
+    : lines.map((_line, index) => startLine + index)
+  const width = Math.max(1, ...numbers.map(value => String(value).length))
+  return lines.map((line, index) => {
+    const number = numbers[index] ?? (startLine + index)
+    return `${String(number).padStart(width, ' ')} | ${line}`
+  }).join('\n')
+}
+
+export function syncLineNumberGutter (gutter, text, opts = {}) {
+  if (!gutter) return
+  gutter.textContent = buildLineNumberText(text, opts)
+}
+
+export function syncLineNumberGutterScroll (scroller, gutter) {
+  if (!scroller || !gutter) return
+  gutter.scrollTop = scroller.scrollTop
 }
 
 // ---------------------------------------------------------------------

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -360,7 +360,20 @@ export function buildLineNumberedText (text, opts = {}) {
 export function findYamlMajorSections (text) {
   const lines = String(text || '').split(/\r?\n/)
   const sections = []
+  let keyStack = []
+  let pendingDivider = null
   let recentDividerLine = 0
+
+  function formatKeyLabel (key) {
+    return String(key || '').trim().replace(/^['"]|['"]$/g, '')
+  }
+
+  function contextualDividerLabel (label, indent) {
+    const parent = keyStack.filter(item => item.indent < indent).at(-1)
+    if (!parent || parent.label.toLowerCase() === 'libraries') return label
+    if (parent.label === label) return label
+    return `${parent.label} > ${label}`
+  }
 
   lines.forEach((line, index) => {
     const lineNumber = index + 1
@@ -369,15 +382,28 @@ export function findYamlMajorSections (text) {
       const label = dividerMatch[1].trim()
       if (label) {
         sections.push({ line: lineNumber, label })
+        pendingDivider = { index: sections.length - 1, label, line: lineNumber }
         recentDividerLine = lineNumber
       }
       return
     }
 
-    const keyMatch = line.match(/^([A-Za-z0-9_-][^:#]*):(?:\s.*)?$/)
-    if (!keyMatch || (recentDividerLine > 0 && lineNumber - recentDividerLine <= 3)) return
-    const key = keyMatch[1].trim()
-    if (key) sections.push({ line: lineNumber, label: `${key}:` })
+    const trimmed = line.trim()
+    const keyMatch = line.match(/^(\s*)([^#:\n][^:\n]*):(?:\s.*)?$/)
+    if (!keyMatch || trimmed.startsWith('- ')) return
+
+    const indent = keyMatch[1].length
+    const key = formatKeyLabel(keyMatch[2])
+    if (!key) return
+
+    keyStack = keyStack.filter(item => item.indent < indent)
+    if (pendingDivider && lineNumber - pendingDivider.line <= 3) {
+      sections[pendingDivider.index].label = contextualDividerLabel(pendingDivider.label, indent)
+      pendingDivider = null
+    } else if (indent === 0 && (!recentDividerLine || lineNumber - recentDividerLine > 3)) {
+      sections.push({ line: lineNumber, label: `${key}:` })
+    }
+    keyStack.push({ indent, label: key })
   })
 
   return sections

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -212,7 +212,7 @@ const LOG_LEVEL_PATTERNS = {
   warning: [/\[WARNING\]/i],
   error: [/\[ERROR\]/i],
   critical: [/\[CRITICAL\]/i],
-  trace: [/\[TRACE\]/i]
+  trace: [/\btraceback\b/i]
 }
 
 const LOG_FILTER_ALIASES = new Map([
@@ -300,8 +300,8 @@ export function filterLogLines (text, filter, opts = {}) {
 /**
  * Count log lines by level marker.
  * Recognises bracketed and plain level tags used by Kometa and ImageMaid.
- * `cache` accepts "from cache", "cached", and "[CACHE]"; `trace` accepts
- * trace/traceback lines.
+ * `cache` accepts "from cache", "cached", and "[CACHE]"; `trace` counts
+ * traceback markers rather than a `[TRACE]` log level.
  */
 export function computeLogStats (text) {
   const stats = {

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -357,6 +357,78 @@ export function buildLineNumberedText (text, opts = {}) {
   }).join('\n')
 }
 
+export function findYamlMajorSections (text) {
+  const lines = String(text || '').split(/\r?\n/)
+  const sections = []
+  let recentDividerLine = 0
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1
+    const dividerMatch = line.match(/^\s*#\s*=+\s*([^=#][^#=]*?)\s*=+\s*#?\s*$/)
+    if (dividerMatch) {
+      const label = dividerMatch[1].trim()
+      if (label) {
+        sections.push({ line: lineNumber, label })
+        recentDividerLine = lineNumber
+      }
+      return
+    }
+
+    const keyMatch = line.match(/^([A-Za-z0-9_-][^:#]*):(?:\s.*)?$/)
+    if (!keyMatch || (recentDividerLine > 0 && lineNumber - recentDividerLine <= 3)) return
+    const key = keyMatch[1].trim()
+    if (key) sections.push({ line: lineNumber, label: `${key}:` })
+  })
+
+  return sections
+}
+
+export function getLogLineLevel (line) {
+  const text = String(line || '')
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.critical)) return 'critical'
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.error)) return 'error'
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.warning)) return 'warning'
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.trace)) return 'trace'
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.cache)) return 'cache'
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.debug)) return 'debug'
+  if (lineMatchesAny(text, LOG_LEVEL_PATTERNS.info)) return 'info'
+  return ''
+}
+
+export function renderLogRows (container, text, opts = {}) {
+  if (!container) return
+  const content = String(text || '')
+  const lines = content.split(/\r?\n/)
+  const explicitNumbers = Array.isArray(opts.lineNumbers) ? opts.lineNumbers : null
+  const startLine = Math.max(1, Number(opts.startLine || 1) || 1)
+  const highlightLevels = opts.highlightLevels !== false
+  const fragment = document.createDocumentFragment()
+
+  lines.forEach((line, index) => {
+    const row = document.createElement('div')
+    const number = explicitNumbers && explicitNumbers.length
+      ? Math.max(1, Number(explicitNumbers[index]) || 1)
+      : startLine + index
+    const level = highlightLevels ? getLogLineLevel(line) : ''
+    row.className = `qs-log-line${level ? ` qs-log-line--${level}` : ''}`
+    row.dataset.line = String(number)
+
+    const lineNumber = document.createElement('span')
+    lineNumber.className = 'qs-log-line-number'
+    lineNumber.dataset.line = String(number)
+    lineNumber.setAttribute('aria-hidden', 'true')
+
+    const lineContent = document.createElement('span')
+    lineContent.className = 'qs-log-line-content'
+    lineContent.textContent = line || ' '
+
+    row.append(lineNumber, lineContent)
+    fragment.append(row)
+  })
+
+  container.replaceChildren(fragment)
+}
+
 export function syncLineNumberGutter (gutter, text, opts = {}) {
   if (!gutter) return
   gutter.textContent = buildLineNumberText(text, opts)

--- a/static/local-js/modules/kometa/_validationGate.js
+++ b/static/local-js/modules/kometa/_validationGate.js
@@ -125,7 +125,7 @@ export function updateValidationGate () {
   const runNowLabelEl = document.getElementById('run-now-label')
   const warningIds = ['no-validation-warning', 'yaml-warnings', 'yaml-warning-msg', 'validation-error']
   const downloadIds = ['download-btn', 'download-redacted-btn']
-  const yamlIds = ['yaml-content', 'final-yaml', 'download-btn', 'download-redacted-btn']
+  const yamlIds = ['yaml-content', 'final-yaml-line-viewer', 'final-yaml', 'download-btn', 'download-redacted-btn']
 
   const finalGate = getFinalGateState()
   if (finalGate.stage === 'todo' || finalGate.stage === 'freshness') {

--- a/static/local-js/modules/kometa/_validationGate.js
+++ b/static/local-js/modules/kometa/_validationGate.js
@@ -125,7 +125,7 @@ export function updateValidationGate () {
   const runNowLabelEl = document.getElementById('run-now-label')
   const warningIds = ['no-validation-warning', 'yaml-warnings', 'yaml-warning-msg', 'validation-error']
   const downloadIds = ['download-btn', 'download-redacted-btn']
-  const yamlIds = ['yaml-content', 'final-yaml-line-viewer', 'final-yaml', 'download-btn', 'download-redacted-btn']
+  const yamlIds = ['yaml-content', 'final-yaml-viewer', 'final-yaml-section-jump-wrap', 'download-btn', 'download-redacted-btn']
 
   const finalGate = getFinalGateState()
   if (finalGate.stage === 'todo' || finalGate.stage === 'freshness') {

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -382,7 +382,17 @@
             <p class="text-muted small mb-2">
               Share this info with support in Discord. We made every effort to redact secrets, but please review before posting.
             </p>
-            <pre id="supportInfoOutput" class="form-control bg-dark text-light" tabindex="0" style="height: 320px; overflow: auto; white-space: pre;">Loading support info...</pre>
+            <div class="d-flex flex-wrap align-items-center gap-2 mb-2 d-none" id="supportInfoJumpWrap">
+              <label class="form-label small text-muted mb-0" for="supportInfoJump">Jump to section</label>
+              <select id="supportInfoJump" class="form-select form-select-sm w-auto">
+                <option value="">Select a section</option>
+              </select>
+            </div>
+            <div id="supportInfoOutput" class="form-control qs-log-code qs-support-info-code" role="region" aria-label="Support information" tabindex="0">Loading support info...</div>
+            <div id="supportInfoCopyFallback" class="alert alert-warning mt-2 d-none" role="status">
+              <div class="small mb-2" id="supportInfoCopyFallbackMessage">Clipboard access is blocked. The raw support info is selected below.</div>
+              <textarea id="supportInfoCopyText" class="form-control qs-support-info-copy-text" readonly spellcheck="false" aria-label="Raw support information for copying"></textarea>
+            </div>
           </div>
         </div>
       </div>

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -299,7 +299,7 @@
         </div>
 
         <!-- YAML Output -->
-        <div class="form-floating mb-2">
+        <div class="mb-2">
           <div class="form-text" id="yaml-content">
             <br>
             <h5>Here is the YAML that was generated as a result of your inputs.</h5>
@@ -309,10 +309,14 @@
               As a reminder, this will most likely <b>NOT</b> work with Kometa as it has not passed validation.
             </div>
           </div>
-          <div class="qs-line-viewer qs-line-viewer--textarea" id="final-yaml-line-viewer">
-            <pre id="final-yaml-line-numbers" class="qs-line-viewer-gutter qs-line-viewer-gutter--textarea" aria-hidden="true"></pre>
-            <textarea readonly id="final-yaml" class="form-control qs-line-viewer-content" rows="20" wrap="off">{{ yaml_content }}</textarea>
+          <div class="d-flex flex-wrap align-items-center gap-2 mb-2 d-none" id="final-yaml-section-jump-wrap">
+            <label class="form-label small text-muted mb-0" for="final-yaml-section-jump">Jump to section</label>
+            <select id="final-yaml-section-jump" class="form-select form-select-sm w-auto">
+              <option value="">Select a section</option>
+            </select>
           </div>
+          <textarea readonly id="final-yaml" class="d-none" aria-hidden="true">{{ yaml_content }}</textarea>
+          <div id="final-yaml-viewer" class="form-control qs-log-code qs-yaml-code" role="region" aria-label="Generated YAML output" tabindex="0"></div>
         </div>
 
         <!-- Download Buttons -->
@@ -1263,8 +1267,8 @@
             </div>
           </div>
         </div>
-        <pre class="bg-dark text-light p-2 rounded" id="run-output-log"
-          style="height: 300px; overflow-y: auto; overflow-x: auto; white-space: pre;"></pre>
+        <div class="bg-dark text-light rounded qs-log-code" id="run-output-log"
+          style="height: 300px;" role="log" aria-label="Kometa log output"></div>
         <div class="accordion mt-3" id="logscan-accordion">
           <div class="accordion-item">
             <h2 class="accordion-header" id="logscan-accordion-heading">

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -309,7 +309,10 @@
               As a reminder, this will most likely <b>NOT</b> work with Kometa as it has not passed validation.
             </div>
           </div>
-          <textarea readonly id="final-yaml" class="form-control" rows="20">{{ yaml_content }}</textarea>
+          <div class="qs-line-viewer qs-line-viewer--textarea" id="final-yaml-line-viewer">
+            <pre id="final-yaml-line-numbers" class="qs-line-viewer-gutter qs-line-viewer-gutter--textarea" aria-hidden="true"></pre>
+            <textarea readonly id="final-yaml" class="form-control qs-line-viewer-content" rows="20" wrap="off">{{ yaml_content }}</textarea>
+          </div>
         </div>
 
         <!-- Download Buttons -->
@@ -1154,7 +1157,7 @@
                   <div class="d-flex align-items-center gap-2 flex-wrap log-filter-row">
                     <label for="run-log-filter" class="form-label mb-0">Filter</label>
                     <div class="input-group input-group-sm" style="width: 210px;">
-                      <input id="run-log-filter" class="form-control" placeholder="Regex or text">
+                      <input id="run-log-filter" class="form-control" placeholder="/regex/ or text">
               <button class="btn btn-outline-secondary d-none" type="button" id="clear-log-filter"
                 aria-label="Clear filter" title="Clear filter">
                 <i class="bi bi-x-lg"></i>
@@ -1261,8 +1264,7 @@
           </div>
         </div>
         <pre class="bg-dark text-light p-2 rounded" id="run-output-log"
-          style="height: 300px; overflow-y: auto; overflow-x: auto; white-space: pre;">
-        </pre>
+          style="height: 300px; overflow-y: auto; overflow-x: auto; white-space: pre;"></pre>
         <div class="accordion mt-3" id="logscan-accordion">
           <div class="accordion-item">
             <h2 class="accordion-header" id="logscan-accordion-heading">

--- a/templates/915-imagemaid.html
+++ b/templates/915-imagemaid.html
@@ -411,7 +411,7 @@
             <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="critical">CRIT <span data-imagemaid-log-stat="crit">0</span></button>
             <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="trace">TRACE <span data-imagemaid-log-stat="trace">0</span></button>
           </div>
-          <pre id="imagemaid-run-log" class="bg-black text-light small rounded p-3 mb-0" style="min-height: 220px; max-height: 360px; overflow:auto; white-space: pre;">No ImageMaid log loaded.</pre>
+          <div id="imagemaid-run-log" class="bg-black text-light small rounded qs-log-code mb-0" style="min-height: 220px; max-height: 360px;" role="log" aria-label="ImageMaid log output">No ImageMaid log loaded.</div>
         </div>
       </div>
     </div>

--- a/templates/915-imagemaid.html
+++ b/templates/915-imagemaid.html
@@ -399,17 +399,17 @@
           </div>
           <div class="mb-2">
             <label class="form-label mb-1" for="imagemaid-log-filter">Filter</label>
-            <input type="text" class="form-control" id="imagemaid-log-filter" placeholder="Regex or text">
+            <input type="text" class="form-control" id="imagemaid-log-filter" placeholder="/regex/ or text">
           </div>
           <div class="d-flex flex-wrap gap-2 mb-2 small" id="imagemaid-log-stats">
             <span class="btn btn-sm btn-dark disabled">FILTER <span data-imagemaid-log-stat="filter">0</span></span>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="CACHE">CACHE <span data-imagemaid-log-stat="cache">0</span></button>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[DEBUG]">DEBUG <span data-imagemaid-log-stat="debug">0</span></button>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[INFO]">INFO <span data-imagemaid-log-stat="info">0</span></button>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[WARNING]">WARN <span data-imagemaid-log-stat="warn">0</span></button>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[ERROR]">ERROR <span data-imagemaid-log-stat="error">0</span></button>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[CRITICAL]">CRIT <span data-imagemaid-log-stat="crit">0</span></button>
-            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[TRACE]">TRACE <span data-imagemaid-log-stat="trace">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="cache">CACHE <span data-imagemaid-log-stat="cache">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="debug">DEBUG <span data-imagemaid-log-stat="debug">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="info">INFO <span data-imagemaid-log-stat="info">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="warning">WARN <span data-imagemaid-log-stat="warn">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="error">ERROR <span data-imagemaid-log-stat="error">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="critical">CRIT <span data-imagemaid-log-stat="crit">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="trace">TRACE <span data-imagemaid-log-stat="trace">0</span></button>
           </div>
           <pre id="imagemaid-run-log" class="bg-black text-light small rounded p-3 mb-0" style="min-height: 220px; max-height: 360px; overflow:auto; white-space: pre;">No ImageMaid log loaded.</pre>
         </div>

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -463,6 +463,34 @@ describe('findYamlMajorSections', () => {
       { line: 3, label: 'tmdb:' }
     ])
   })
+
+  it('includes parent library context for repeated library subsections', () => {
+    const yaml = [
+      '#==================== Libraries ====================#',
+      'libraries:',
+      '#==================== Movies ====================#',
+      '  Movies:',
+      '#==================== Metadata Files ====================#',
+      '    metadata_files:',
+      '#==================== Collections ====================#',
+      '    collection_files:',
+      '#==================== Overlays ====================#',
+      '    overlay_files:',
+      '#==================== TV Shows ====================#',
+      '  TV Shows:',
+      '#==================== Overlays ====================#',
+      '    overlay_files:'
+    ].join('\n')
+    expect(findYamlMajorSections(yaml)).toEqual([
+      { line: 1, label: 'Libraries' },
+      { line: 3, label: 'Movies' },
+      { line: 5, label: 'Movies > Metadata Files' },
+      { line: 7, label: 'Movies > Collections' },
+      { line: 9, label: 'Movies > Overlays' },
+      { line: 11, label: 'TV Shows' },
+      { line: 13, label: 'TV Shows > Overlays' }
+    ])
+  })
 })
 
 describe('buildLineNumberText', () => {

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -26,8 +26,11 @@ import {
   applyLogFilter,
   computeLogStats,
   filterLogLines,
+  findYamlMajorSections,
   buildLineNumberText,
   buildLineNumberedText,
+  getLogLineLevel,
+  renderLogRows,
   SPARKLINE_WIDTH,
   SPARKLINE_HEIGHT,
   SPARKLINE_PADDING,
@@ -415,6 +418,53 @@ describe('computeLogStats', () => {
   })
 })
 
+describe('getLogLineLevel', () => {
+  it('returns exact marker severity classes', () => {
+    expect(getLogLineLevel('[CRITICAL] no api key')).toBe('critical')
+    expect(getLogLineLevel('[ERROR] failed')).toBe('error')
+    expect(getLogLineLevel('[WARNING] check config')).toBe('warning')
+    expect(getLogLineLevel('[TRACE] detail')).toBe('trace')
+    expect(getLogLineLevel('loaded from cache')).toBe('cache')
+  })
+  it('ignores loose or shortened marker text', () => {
+    expect(getLogLineLevel('WARNING plain text')).toBe('')
+    expect(getLogLineLevel('[WARN] short marker')).toBe('')
+    expect(getLogLineLevel('[CRIT] short marker')).toBe('')
+    expect(getLogLineLevel('trace detail')).toBe('')
+  })
+})
+
+describe('findYamlMajorSections', () => {
+  it('finds generated divider comment sections', () => {
+    const yaml = [
+      '#==================== Libraries ====================#',
+      'libraries:',
+      '  Movies:',
+      '',
+      '#==================== Settings ====================#',
+      'settings:',
+      '  cache: true'
+    ].join('\n')
+    expect(findYamlMajorSections(yaml)).toEqual([
+      { line: 1, label: 'Libraries' },
+      { line: 5, label: 'Settings' }
+    ])
+  })
+
+  it('uses top-level keys when no nearby divider is present', () => {
+    const yaml = [
+      'plex:',
+      '  url: http://example.test',
+      'tmdb:',
+      '  apikey: redacted'
+    ].join('\n')
+    expect(findYamlMajorSections(yaml)).toEqual([
+      { line: 1, label: 'plex:' },
+      { line: 3, label: 'tmdb:' }
+    ])
+  })
+})
+
 describe('buildLineNumberText', () => {
   it('builds padded line numbers from text and a start line', () => {
     expect(buildLineNumberText('a\nb\nc', { startLine: 98 })).toBe(' 98\n 99\n100')
@@ -430,6 +480,41 @@ describe('buildLineNumberedText', () => {
   })
   it('uses sparse source line numbers from filtered results', () => {
     expect(buildLineNumberedText('[ERROR] a\n[ERROR] b', { lineNumbers: [12, 48] })).toBe('12 | [ERROR] a\n48 | [ERROR] b')
+  })
+})
+
+describe('renderLogRows', () => {
+  it('renders source-numbered log rows without prefixing the log content', () => {
+    const container = document.createElement('div')
+    renderLogRows(container, '[INFO] one\n[WARNING] two', { startLine: 41 })
+
+    const rows = container.querySelectorAll('.qs-log-line')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].dataset.line).toBe('41')
+    expect(rows[0].querySelector('.qs-log-line-number').dataset.line).toBe('41')
+    expect(rows[0].querySelector('.qs-log-line-number').textContent).toBe('')
+    expect(rows[0].querySelector('.qs-log-line-content').textContent).toBe('[INFO] one')
+    expect(rows[1].dataset.line).toBe('42')
+    expect(rows[1].classList.contains('qs-log-line--warning')).toBe(true)
+    expect(rows[1].querySelector('.qs-log-line-content').textContent).toBe('[WARNING] two')
+  })
+
+  it('renders sparse filtered source line numbers', () => {
+    const container = document.createElement('div')
+    renderLogRows(container, '[ERROR] one\n[ERROR] two', { lineNumbers: [12, 48] })
+
+    expect(Array.from(container.querySelectorAll('.qs-log-line-number')).map(el => el.dataset.line))
+      .toEqual(['12', '48'])
+    expect(container.textContent).toBe('[ERROR] one[ERROR] two')
+  })
+
+  it('can render numbered config rows without log-level highlighting', () => {
+    const container = document.createElement('div')
+    renderLogRows(container, '[ERROR] allowed yaml value', { highlightLevels: false })
+
+    const row = container.querySelector('.qs-log-line')
+    expect(row.classList.contains('qs-log-line--error')).toBe(false)
+    expect(row.querySelector('.qs-log-line-content').textContent).toBe('[ERROR] allowed yaml value')
   })
 })
 

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -25,6 +25,9 @@ import {
   isTimeWithinRange,
   applyLogFilter,
   computeLogStats,
+  filterLogLines,
+  buildLineNumberText,
+  buildLineNumberedText,
   SPARKLINE_WIDTH,
   SPARKLINE_HEIGHT,
   SPARKLINE_PADDING,
@@ -337,6 +340,15 @@ describe('applyLogFilter', () => {
     const log = 'foo.bar\nfoo_bar'
     expect(applyLogFilter(log, 'foo.bar')).toBe('foo.bar')
   })
+  it('treats bracketed level shortcuts as named filters, not raw regex character classes', () => {
+    const log = '[ERROR] actual failure\nordinary row\nrecipe row'
+    expect(applyLogFilter(log, '[ERROR]')).toBe('[ERROR] actual failure')
+  })
+  it('matches exact warning and critical level markers', () => {
+    const log = '[WARNING] marked warning\nWARNING plain text\n[CRITICAL] marked critical\n[CRIT] short text'
+    expect(applyLogFilter(log, 'warning')).toBe('[WARNING] marked warning')
+    expect(applyLogFilter(log, 'critical')).toBe('[CRITICAL] marked critical')
+  })
   it('treats /.../ as a case-insensitive regex', () => {
     const log = 'AAA\nbbb\nCcC'
     expect(applyLogFilter(log, '/a|b/')).toBe('AAA\nbbb')
@@ -347,6 +359,14 @@ describe('applyLogFilter', () => {
   })
   it('returns empty string when no lines match', () => {
     expect(applyLogFilter('AAA\nbbb', 'zzz')).toBe('')
+  })
+})
+
+describe('filterLogLines', () => {
+  it('keeps source line numbers when filtering a tailed log', () => {
+    const result = filterLogLines('[INFO] one\n[ERROR] two\n[WARNING] three', 'warning', { startLine: 98 })
+    expect(result.text).toBe('[WARNING] three')
+    expect(result.lineNumbers).toEqual([100])
   })
 })
 
@@ -370,9 +390,9 @@ describe('computeLogStats', () => {
     const log = 'loaded FROM CACHE\nSomething from cache\nnope'
     expect(computeLogStats(log).cache).toBe(2)
   })
-  it('counts "traceback" (case-insensitive) as trace lines', () => {
-    const log = 'Traceback (most recent call last):\ntraceback: nope\nfine'
-    expect(computeLogStats(log).trace).toBe(2)
+  it('counts exact trace level markers', () => {
+    const log = '[TRACE] enabled\nTraceback (most recent call last):\ntrace detail'
+    expect(computeLogStats(log).trace).toBe(1)
   })
   it('handles CRLF line endings', () => {
     const log = '[DEBUG] a\r\n[INFO] b\r\n'
@@ -383,6 +403,33 @@ describe('computeLogStats', () => {
   it('skips empty lines', () => {
     const log = '\n\n[INFO] one\n\n'
     expect(computeLogStats(log).info).toBe(1)
+  })
+  it('does not count unbracketed and short log-level-looking text as level markers', () => {
+    const log = 'ERROR plain\n[WARN] short\n[CRIT] short\ntrace detail\ncached lookup'
+    const stats = computeLogStats(log)
+    expect(stats.error).toBe(0)
+    expect(stats.warning).toBe(0)
+    expect(stats.critical).toBe(0)
+    expect(stats.trace).toBe(0)
+    expect(stats.cache).toBe(0)
+  })
+})
+
+describe('buildLineNumberText', () => {
+  it('builds padded line numbers from text and a start line', () => {
+    expect(buildLineNumberText('a\nb\nc', { startLine: 98 })).toBe(' 98\n 99\n100')
+  })
+  it('can render sparse source line numbers from a filtered result', () => {
+    expect(buildLineNumberText('a\nb', { lineNumbers: [7, 120] })).toBe('  7\n120')
+  })
+})
+
+describe('buildLineNumberedText', () => {
+  it('prefixes line numbers inside the log text', () => {
+    expect(buildLineNumberedText('alpha\nbeta', { startLine: 9 })).toBe(' 9 | alpha\n10 | beta')
+  })
+  it('uses sparse source line numbers from filtered results', () => {
+    expect(buildLineNumberedText('[ERROR] a\n[ERROR] b', { lineNumbers: [12, 48] })).toBe('12 | [ERROR] a\n48 | [ERROR] b')
   })
 })
 

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -393,7 +393,7 @@ describe('computeLogStats', () => {
     const log = 'loaded FROM CACHE\nSomething from cache\nnope'
     expect(computeLogStats(log).cache).toBe(2)
   })
-  it('counts exact trace level markers', () => {
+  it('counts traceback markers for trace stats', () => {
     const log = '[TRACE] enabled\nTraceback (most recent call last):\ntrace detail'
     expect(computeLogStats(log).trace).toBe(1)
   })
@@ -423,14 +423,14 @@ describe('getLogLineLevel', () => {
     expect(getLogLineLevel('[CRITICAL] no api key')).toBe('critical')
     expect(getLogLineLevel('[ERROR] failed')).toBe('error')
     expect(getLogLineLevel('[WARNING] check config')).toBe('warning')
-    expect(getLogLineLevel('[TRACE] detail')).toBe('trace')
+    expect(getLogLineLevel('[TRACE] detail')).toBe('')
+    expect(getLogLineLevel('Traceback (most recent call last):')).toBe('trace')
     expect(getLogLineLevel('loaded from cache')).toBe('cache')
   })
   it('ignores loose or shortened marker text', () => {
     expect(getLogLineLevel('WARNING plain text')).toBe('')
     expect(getLogLineLevel('[WARN] short marker')).toBe('')
     expect(getLogLineLevel('[CRIT] short marker')).toBe('')
-    expect(getLogLineLevel('trace detail')).toBe('')
   })
 })
 

--- a/tests/js/kometa/validationGate.test.js
+++ b/tests/js/kometa/validationGate.test.js
@@ -118,7 +118,7 @@ function installGateDom ({
   const downloadIds = ['download-btn', 'download-redacted-btn']
   downloadIds.forEach(id => { if (has(id)) parts.push(`<div id="${id}"></div>`) })
 
-  const yamlIds = ['yaml-content', 'final-yaml']
+  const yamlIds = ['yaml-content', 'final-yaml-viewer', 'final-yaml-section-jump-wrap']
   yamlIds.forEach(id => { if (has(id)) parts.push(`<div id="${id}" class="d-none"></div>`) })
 
   document.body.innerHTML = parts.join('\n')
@@ -257,7 +257,7 @@ describe('updateValidationGate stage=config, all flags valid', () => {
     expect(document.getElementById('validation-messages').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('no-validation-warning').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('yaml-content').classList.contains('d-none')).toBe(false)
-    expect(document.getElementById('final-yaml').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('final-yaml-viewer').classList.contains('d-none')).toBe(false)
     expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(false)
   })
 

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -1,6 +1,43 @@
 import time
 
 
+def test_tail_log_stats_count_exact_level_markers(client, tmp_path, monkeypatch, qs_module):
+    log_dir = tmp_path / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "meta.log").write_text(
+        "\n".join(
+            [
+                "loaded from cache",
+                "[CACHE] direct marker",
+                "DEBUG plain",
+                "[INFO] bracketed",
+                "[WARNING] marked warning",
+                "ERROR plain",
+                "[CRITICAL] marked critical",
+                "[TRACE] marked trace",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    qs_module.LOG_STATS_CACHE.clear()
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+
+    resp = client.get("/tail-log?size=all&stats=1")
+
+    assert resp.status_code == 200
+    stats = resp.get_json()["stats"]
+    assert stats["total_lines"] == 8
+    assert stats["cache"] == 2
+    assert stats["debug"] == 0
+    assert stats["info"] == 1
+    assert stats["warning"] == 1
+    assert stats["error"] == 0
+    assert stats["critical"] == 1
+    assert stats["trace"] == 1
+
+
 def test_start_kometa_queues_during_maintenance(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -14,7 +14,8 @@ def test_tail_log_stats_count_exact_level_markers(client, tmp_path, monkeypatch,
                 "[WARNING] marked warning",
                 "ERROR plain",
                 "[CRITICAL] marked critical",
-                "[TRACE] marked trace",
+                "[TRACE] should not count as a trace marker",
+                "Traceback (most recent call last):",
             ]
         )
         + "\n",
@@ -28,7 +29,7 @@ def test_tail_log_stats_count_exact_level_markers(client, tmp_path, monkeypatch,
 
     assert resp.status_code == 200
     stats = resp.get_json()["stats"]
-    assert stats["total_lines"] == 8
+    assert stats["total_lines"] == 9
     assert stats["cache"] == 2
     assert stats["debug"] == 0
     assert stats["info"] == 1


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1802 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Closes #1802

## Summary

This PR upgrades the Kometa/ImageMaid log viewers, generated config output, and Support Info modal to use a shared line-numbered viewer experience. It also tightens log filtering/stat matching so level buttons only target the intended log markers instead of loose text matches.

## What Changed

- Added shared log/config viewer helpers for:
  - line-preserving filtering
  - exact log-level detection
  - selectable-safe visual line numbers
  - row rendering with severity highlighting
  - YAML major-section detection
  - hierarchical section labels for repeated config sections

- Updated Kometa logs to:
  - render with line numbers
  - preserve original source line numbers when tailing/filtering
  - keep level filters aligned with exact markers like `[WARNING]`, `[ERROR]`, `[TRACE]`
  - avoid copying/selecting line numbers

- Updated ImageMaid logs to:
  - use the same filtering/counting logic as Kometa logs
  - render with line numbers
  - preserve source line numbers while filtering
  - align level buttons with the same exact marker logic

- Replaced the generated config textarea with a line-numbered viewer:
  - visual line numbers are not part of copied/selected text
  - default viewer height is 25 lines
  - added `Jump to section`
  - repeated sections now include hierarchy, e.g. `Movies > Overlays`, `TV Shows > Collections`

- Updated Support Info modal:
  - uses the same black/white line-numbered viewer styling
  - adds section jumping
  - notes enhanced viewer support in generated support info
  - removes toast-only copy feedback
  - shows copy/select status inside the modal
  - provides an inline raw textarea fallback when clipboard access is blocked or copy fails

- Updated Libraries external YAML editor gutter:
  - line numbers remain visible/clickable
  - line numbers are no longer real selectable text

- Tightened backend Kometa log stats:
  - cache counts `from cache` and `[CACHE]`
  - trace counts `[TRACE]`
  - avoids loose plain-text matches for levels like `ERROR`, `DEBUG`, etc.

## Testing

- `npm.cmd run lint:eslint`
- `npm.cmd test -- tests/js/kometa/util.test.js tests/js/kometa/validationGate.test.js`
- `npm.cmd run build`
- `python -m py_compile quickstart.py`
- `git diff --check`



## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791395770&installation_model_id=431096&pr_number=1805&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1805&signature=d590def70410dcc17a5507279d65ee4779790b022f166694c6e22950520d3484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->