### PR TITLE
Improve Kometa progress performance and Active Work visibility

### DIFF
--- a/modules/process_control.py
+++ b/modules/process_control.py
@@ -218,6 +218,7 @@ def maintenance_guard_loop(app_in):
                     pending = quickstart._pop_pending_kometa_start()
                     if pending:
                         start_mode = quickstart._normalize_kometa_start_mode(pending.get("start_mode"))
+                        quickstart._clear_logscan_progress_snapshot()
                         quickstart._update_run_context(pending.get("command"), config_name=pending.get("config_name"), start_mode=start_mode)
                         ok, result = quickstart._launch_kometa_command(pending.get("command"), pending.get("config_name"), start_mode=start_mode)
                         if ok:

--- a/quickstart.py
+++ b/quickstart.py
@@ -454,6 +454,7 @@ ACTIVE_WORK_POLICIES = {
 LOG_STATS_CACHE = {"mtime": None, "size": None, "stats": None}
 LOGSCAN_ANALYSIS_CACHE_VERSION = 3
 LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "version": LOGSCAN_ANALYSIS_CACHE_VERSION, "data": None}
+LOGSCAN_PROGRESS_SNAPSHOT_VERSION = 1
 LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "aux_signature": None, "data": None}
 
 VALIDATION_DOC_BASE = "/step/"
@@ -3920,6 +3921,7 @@ def start_kometa():
             payload["phase"] = job.get("phase")
         return jsonify(payload), 409
 
+    _clear_logscan_progress_snapshot()
     _update_run_context(command, start_mode=start_mode)
 
     maintenance_config_name = session.get("config_name")
@@ -4200,8 +4202,6 @@ def tail_log():
         return jsonify({"error": f"Log file not found at: {log_path}"}), 404
 
     try:
-        from collections import deque
-
         size_param = request.args.get("size", "2000")
         download = request.args.get("download")
         stats_param = request.args.get("stats", "")
@@ -4220,11 +4220,9 @@ def tail_log():
             log_stats = None
 
         if max_lines:
-            with log_path.open("r", encoding="utf-8", errors="replace") as f:
-                lines = deque(f, maxlen=max_lines)
-            log_content = "".join(lines)
+            log_content = _read_text_tail(log_path, max_lines)
         else:
-            log_content = log_path.read_text(encoding="utf-8", errors="replace")
+            log_content = _read_text_tail(log_path, None)
 
         if download:
             return send_file(
@@ -4317,6 +4315,161 @@ def tail_log():
         return jsonify({"error": f"Failed to read log: {str(e)}"}), 500
 
 
+def _read_text_tail(path, max_lines, encoding="utf-8", errors="replace", block_size=64 * 1024):
+    if max_lines is None:
+        return path.read_text(encoding=encoding, errors=errors)
+
+    max_lines = max(1, int(max_lines))
+    chunks = []
+    newline_count = 0
+    with path.open("rb") as handle:
+        handle.seek(0, os.SEEK_END)
+        offset = handle.tell()
+        while offset > 0 and newline_count <= max_lines:
+            read_size = min(block_size, offset)
+            offset -= read_size
+            handle.seek(offset)
+            chunk = handle.read(read_size)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            newline_count += chunk.count(b"\n")
+
+    data = b"".join(reversed(chunks))
+    if newline_count > max_lines:
+        data = b"".join(data.splitlines(keepends=True)[-max_lines:])
+    return data.decode(encoding, errors=errors)
+
+
+def _json_safe_progress_value(value):
+    if isinstance(value, dict):
+        return {str(key): _json_safe_progress_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_progress_value(item) for item in value]
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()
+            except Exception:
+                pass
+        return str(value)
+
+
+def _normalize_progress_identity_value(value):
+    if value in (None, ""):
+        return None
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:
+            pass
+    return str(value)
+
+
+def _progress_data_matches_run(data, started_at):
+    if not isinstance(data, dict):
+        return False
+    if started_at in (None, ""):
+        return True
+    return _normalize_progress_identity_value(data.get("run_started_at")) == _normalize_progress_identity_value(started_at)
+
+
+def _get_logscan_progress_snapshot_path():
+    snapshot_dir = _get_logscan_cache_dir() / "progress"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    return snapshot_dir / "kometa-progress.json"
+
+
+def _build_logscan_progress_snapshot_metadata(log_path, log_stats=None, aux_signature=None, started_at=None, config_path=None, run_mode=None):
+    try:
+        resolved_log_path = str(Path(log_path).resolve())
+    except Exception:
+        resolved_log_path = str(log_path)
+    return {
+        "version": LOGSCAN_PROGRESS_SNAPSHOT_VERSION,
+        "log_path": resolved_log_path,
+        "log_mtime": float(log_stats.st_mtime) if log_stats else None,
+        "log_size": int(log_stats.st_size) if log_stats else None,
+        "aux_signature": _json_safe_progress_value(aux_signature or ()),
+        "run_started_at": _normalize_progress_identity_value(started_at),
+        "config_path": str(config_path or "") or None,
+        "run_mode": str(run_mode or "") or None,
+    }
+
+
+def _load_logscan_progress_snapshot(log_path, log_stats=None, started_at=None):
+    path = _get_logscan_progress_snapshot_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or payload.get("version") != LOGSCAN_PROGRESS_SNAPSHOT_VERSION:
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+    try:
+        current_log_path = str(Path(log_path).resolve())
+    except Exception:
+        current_log_path = str(log_path)
+    if metadata.get("log_path") != current_log_path:
+        return None
+    if log_stats and metadata.get("log_size") is not None:
+        try:
+            if int(metadata.get("log_size")) > int(log_stats.st_size):
+                return None
+        except Exception:
+            return None
+    snapshot_started_at = metadata.get("run_started_at") or data.get("run_started_at")
+    if started_at not in (None, "") and _normalize_progress_identity_value(snapshot_started_at) != _normalize_progress_identity_value(started_at):
+        return None
+    return data
+
+
+def _save_logscan_progress_snapshot(log_path, log_stats=None, aux_signature=None, started_at=None, config_path=None, run_mode=None, data=None):
+    if not isinstance(data, dict) or not log_stats:
+        return False
+    path = _get_logscan_progress_snapshot_path()
+    payload = {
+        "version": LOGSCAN_PROGRESS_SNAPSHOT_VERSION,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "metadata": _build_logscan_progress_snapshot_metadata(
+            log_path,
+            log_stats=log_stats,
+            aux_signature=aux_signature,
+            started_at=started_at,
+            config_path=config_path,
+            run_mode=run_mode,
+        ),
+        "data": _json_safe_progress_value(data),
+    }
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp_path.write_text(json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(tmp_path, path)
+        return True
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except Exception:
+            pass
+        return False
+
+
+def _clear_logscan_progress_snapshot():
+    LOGSCAN_PROGRESS_CACHE.update({"mtime": None, "size": None, "aux_signature": None, "data": None})
+    try:
+        _get_logscan_progress_snapshot_path().unlink()
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+
+
 @app.route("/logscan/analyze", methods=["GET"])
 def logscan_analyze():
     log_path = helpers.get_kometa_log_dir() / "meta.log"
@@ -4405,7 +4558,6 @@ def logscan_progress():
         return jsonify({"error": f"Log file not found at: {log_path}"}), 404
 
     try:
-        from collections import deque
         from copy import deepcopy
 
         size_arg = request.args.get("size")
@@ -4451,14 +4603,15 @@ def logscan_progress():
                 return False
             if cached.get("mtime") != log_stats.st_mtime or cached.get("size") != log_stats.st_size:
                 return False
-            return cached.get("aux_signature") == aux_signature
+            cached_aux_signature = cached.get("aux_signature")
+            if not aux_signature and cached_aux_signature in (None, ()):
+                return True
+            return cached_aux_signature == aux_signature
 
         def _read_progress_log_content():
             if force_full_read:
                 return _read_logscan_text(log_path)
-            with log_path.open("r", encoding="utf-8", errors="replace") as handle:
-                lines = deque(handle, maxlen=max_lines)
-            content = "".join(lines)
+            content = _read_text_tail(log_path, max_lines)
             try:
                 aux_content = []
                 for aux_path in (pending_path, sidecar_path):
@@ -4547,7 +4700,13 @@ def logscan_progress():
         run_mode = ctx.get("run_mode") or "all"
         stopped_requested = bool(ctx.get("stop_requested_at"))
         cached_data = LOGSCAN_PROGRESS_CACHE.get("data")
-        cache_matches_run = bool(cached_data and cached_data.get("run_started_at") == started_at)
+        cache_matches_run = _progress_data_matches_run(cached_data, started_at)
+        if not cache_matches_run:
+            persisted_data = _load_logscan_progress_snapshot(log_path, log_stats=log_stats, started_at=started_at)
+            if persisted_data:
+                cached_data = persisted_data
+                LOGSCAN_PROGRESS_CACHE["data"] = cached_data
+                cache_matches_run = True
 
         # Seed progress from the full log when no explicit size was requested and
         # the current run has no matching cached progress state yet. After the
@@ -4562,8 +4721,9 @@ def logscan_progress():
             data = normalize_progress_for_stopped(data, running, stopped_requested)
             return jsonify(data)
 
-        if cached_data and cached_data.get("run_started_at") != started_at:
+        if cached_data and not _progress_data_matches_run(cached_data, started_at):
             LOGSCAN_PROGRESS_CACHE.update({"mtime": None, "size": None, "aux_signature": None, "data": None})
+            cached_data = None
         analyzer = logscan.LogscanAnalyzer()
         config_data = _load_progress_config(config_path)
         log_content = _read_progress_log_content()
@@ -4575,7 +4735,7 @@ def logscan_progress():
                 config_data=config_data,
             ),
             selected_libraries=selected,
-            previous=LOGSCAN_PROGRESS_CACHE.get("data"),
+            previous=cached_data,
             run_started_at=started_at,
             now_ts=datetime.now(timezone.utc),
             is_running=running,
@@ -4606,6 +4766,15 @@ def logscan_progress():
                     "aux_signature": aux_signature,
                     "data": progress,
                 }
+            )
+            _save_logscan_progress_snapshot(
+                log_path,
+                log_stats=log_stats,
+                aux_signature=aux_signature,
+                started_at=started_at,
+                config_path=config_path,
+                run_mode=run_mode,
+                data=progress,
             )
         return jsonify(progress)
     except Exception as e:

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1736,6 +1736,12 @@ form,
     tab-size: 4;
 }
 
+.qs-log-code--plain {
+    padding-left: 0.65rem;
+    padding-right: 1.25rem;
+    white-space: pre;
+}
+
 .qs-log-line {
     display: grid;
     grid-template-columns: minmax(3.75rem, auto) minmax(max-content, 1fr);
@@ -5993,6 +5999,20 @@ body {
     font-size: 0.64rem;
     line-height: 1.35;
     color: var(--theme-text-muted);
+}
+
+.qs-active-work-detail-list {
+    display: grid;
+    gap: 0.08rem;
+    padding-top: 0.05rem;
+}
+
+.qs-active-work-detail-line {
+    min-width: 0;
+    font-size: 0.59rem;
+    line-height: 1.32;
+    color: rgba(226, 232, 240, 0.7);
+    overflow-wrap: anywhere;
 }
 
 .qs-active-work-chip {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -600,6 +600,8 @@ let qsLastMaintenancePaused = false
 let qsLastQueuedStartedAt = null
 const QS_LOGSCAN_REINGEST_POLL_INTERVAL_MS = 15000
 const QS_BACKGROUND_JOBS_POLL_INTERVAL_MS = 15000
+const QS_BULK_VALIDATION_POLL_INTERVAL_MS = 7000
+const QS_KOMETA_PROGRESS_POLL_INTERVAL_MS = 15000
 const qsCurrentTemplate = String(window.QS_CURRENT_TEMPLATE || document.documentElement.dataset.qsTemplate || '').trim()
 const qsSkipMaintenancePoll = qsCurrentTemplate === '900-kometa'
 const qsSkipImageMaidPoll = qsCurrentTemplate === '915-imagemaid'
@@ -608,12 +610,16 @@ const QS_APP_READINESS_POLL_INTERVAL_MS = 12000
 let qsLatestKometaStatus = null
 let qsLatestImageMaidStatus = null
 let qsLatestAppReadiness = null
+let qsLatestBulkValidationProgress = null
+let qsLatestKometaRunProgress = null
 let qsActiveBackgroundJobs = []
 let qsMaintenancePollInFlight = false
 let qsLogscanReingestPollInFlight = false
 let qsImageMaidPollInFlight = false
 let qsBackgroundJobsPollInFlight = false
 let qsAppReadinessPollInFlight = false
+let qsBulkValidationPollInFlight = false
+let qsKometaProgressPollInFlight = false
 
 function qsShouldPollBackgroundState () {
   return !document.hidden
@@ -654,6 +660,121 @@ function qsFormatElapsedLabel (seconds) {
   return parts.join(' ')
 }
 
+function qsFormatActiveNumber (value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return ''
+  return numeric.toLocaleString()
+}
+
+function qsFormatActivePercent (value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return ''
+  return `${numeric.toFixed(1)}%`
+}
+
+function qsFormatActiveMb (value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return ''
+  if (numeric >= 1024) return `${(numeric / 1024).toFixed(1)} GB`
+  return `${numeric.toFixed(1)} MB`
+}
+
+function qsFormatActiveRate (value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return ''
+  return `${Math.max(0, numeric).toFixed(2)} MB/s`
+}
+
+function qsPushActiveDetail (details, label, value) {
+  const text = String(value || '').trim()
+  if (!text) return
+  details.push(label ? `${label}: ${text}` : text)
+}
+
+function qsBuildRuntimeActiveDetails (data, processLabel) {
+  const details = []
+  const cpu = qsFormatActivePercent(data.cpu_percent)
+  const memory = qsFormatActiveMb(data.memory_rss_mb)
+  if (cpu || memory) qsPushActiveDetail(details, processLabel, [cpu ? `CPU ${cpu}` : '', memory ? `RAM ${memory}` : ''].filter(Boolean).join(' | '))
+
+  const systemCpu = qsFormatActivePercent(data.system_cpu_percent)
+  const systemMemoryUsed = qsFormatActiveMb(data.system_memory_used_mb)
+  const systemMemoryTotal = qsFormatActiveMb(data.system_memory_total_mb)
+  if (systemCpu || systemMemoryUsed || systemMemoryTotal) {
+    const memoryText = systemMemoryUsed && systemMemoryTotal ? `${systemMemoryUsed}/${systemMemoryTotal}` : (systemMemoryUsed || systemMemoryTotal)
+    qsPushActiveDetail(details, 'System', [systemCpu ? `CPU ${systemCpu}` : '', memoryText ? `RAM ${memoryText}` : ''].filter(Boolean).join(' | '))
+  }
+
+  const readRate = qsFormatActiveRate(data.disk_read_rate_mb_s)
+  const writeRate = qsFormatActiveRate(data.disk_write_rate_mb_s)
+  if (readRate || writeRate) qsPushActiveDetail(details, 'Disk rate', [readRate ? `R ${readRate}` : '', writeRate ? `W ${writeRate}` : ''].filter(Boolean).join(' | '))
+
+  const readTotal = qsFormatActiveMb(data.disk_read_mb)
+  const writeTotal = qsFormatActiveMb(data.disk_write_mb)
+  if (readTotal || writeTotal) qsPushActiveDetail(details, 'Disk total', [readTotal ? `${readTotal} read` : '', writeTotal ? `${writeTotal} written` : ''].filter(Boolean).join(' | '))
+
+  if (data.started_at) qsPushActiveDetail(details, 'Started', qsFormatTimestamp(data.started_at))
+  if (Number.isFinite(Number(data.log_age_seconds))) {
+    const age = qsFormatElapsedLabel(data.log_age_seconds)
+    qsPushActiveDetail(details, data.log_is_stale ? 'Log stale' : 'Log updated', age ? `${age} ago` : '')
+  }
+  return details
+}
+
+function qsBuildActiveTitleAttr (label, meta, details) {
+  return [label, meta, ...(Array.isArray(details) ? details : [])].filter(Boolean).join(' | ')
+}
+
+function qsFormatKometaPhaseLabel (phase) {
+  const normalized = String(phase || '').trim().toLowerCase()
+  const labels = {
+    operations: 'Operations',
+    metadata: 'Metadata',
+    collections: 'Collections',
+    overlays: 'Overlays',
+    playlists: 'Playlists'
+  }
+  return labels[normalized] || (normalized ? normalized.replaceAll('_', ' ') : '')
+}
+
+function qsBuildKometaProgressDetails () {
+  const progress = qsLatestKometaRunProgress
+  if (!progress || typeof progress !== 'object') return []
+
+  const details = []
+  const currentLibrary = String(progress.current_library || '').trim()
+  const phase = qsFormatKometaPhaseLabel(progress.phase_current)
+  const totalCount = Number(progress.total_count || 0)
+  const completedCount = Number(progress.completed_count || 0)
+  const phaseOrder = Array.isArray(progress.phase_order) && progress.phase_order.length
+    ? progress.phase_order
+    : ['operations', 'metadata', 'collections', 'overlays', 'playlists']
+  const phaseIndex = progress.phase_current ? Math.max(0, phaseOrder.indexOf(progress.phase_current)) : 0
+  const totalSteps = totalCount > 0 ? totalCount * Math.max(1, phaseOrder.length) : 0
+  const completedSteps = currentLibrary && totalSteps > 0
+    ? Math.min(totalSteps, (Math.max(0, completedCount) * Math.max(1, phaseOrder.length)) + phaseIndex)
+    : Math.max(0, completedCount) * Math.max(1, phaseOrder.length)
+
+  if (currentLibrary) {
+    qsPushActiveDetail(details, 'Current', phase ? `${currentLibrary} | ${phase}` : currentLibrary)
+  } else if (progress.playlist_running) {
+    qsPushActiveDetail(details, 'Current', 'Playlists')
+  } else if (phase) {
+    qsPushActiveDetail(details, 'Current phase', phase)
+  }
+  if (totalCount > 0) qsPushActiveDetail(details, 'Libraries', `${Math.min(Math.max(0, completedCount), totalCount)}/${totalCount} complete`)
+  if (totalSteps > 0) qsPushActiveDetail(details, 'Matrix step', `${completedSteps}/${totalSteps}`)
+  if (Number.isFinite(Number(progress.current_phase_elapsed_seconds))) {
+    const elapsed = qsFormatElapsedLabel(progress.current_phase_elapsed_seconds)
+    qsPushActiveDetail(details, 'Phase elapsed', elapsed)
+  }
+  if (Number.isFinite(Number(progress.preparation_elapsed_seconds))) {
+    const elapsed = qsFormatElapsedLabel(progress.preparation_elapsed_seconds)
+    qsPushActiveDetail(details, 'Preparation', elapsed)
+  }
+  return details
+}
+
 function qsBuildKometaActiveWorkEntry () {
   const data = qsLatestKometaStatus
   if (!data || typeof data !== 'object') return null
@@ -662,63 +783,70 @@ function qsBuildKometaActiveWorkEntry () {
   const href = '/step/900-kometa'
   const status = String(data.status || '').trim().toLowerCase()
   const running = status === 'running'
+  const runtimeDetails = qsBuildRuntimeActiveDetails(data, 'Kometa')
+  const progressDetails = qsBuildKometaProgressDetails()
   const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || running)
 
   if (unavailableBlocksWork) {
     const since = data.window_unavailable_since ? `Since ${qsFormatTimestamp(data.window_unavailable_since)}` : 'Maintenance window data unavailable'
+    const details = [...progressDetails, ...runtimeDetails]
+    if (windowLabel) qsPushActiveDetail(details, 'Window', windowLabel)
     return {
       key: 'kometa-window-unavailable',
       title: 'Maintenance window data unavailable',
       chip: 'Waiting',
       state: 'warn',
       meta: windowLabel ? `${since} • Window ${windowLabel}` : since,
+      details,
       href,
-      titleAttr: windowLabel
-        ? `Quickstart cannot read the configured Plex maintenance window ${windowLabel} while work is active.`
-        : 'Quickstart cannot read the configured Plex maintenance window while work is active.'
+      titleAttr: qsBuildActiveTitleAttr('Quickstart cannot read the configured Plex maintenance window while work is active.', since, details)
     }
   }
 
   if (data.pending_start) {
     const requested = data.pending_requested_at ? `Requested ${qsFormatTimestamp(data.pending_requested_at)}` : 'Queued for next available window'
+    const details = []
+    if (windowLabel) qsPushActiveDetail(details, 'Window', windowLabel)
     return {
       key: 'kometa-queued',
       title: 'Kometa queued',
       chip: 'Queued',
       state: 'warn',
       meta: windowLabel ? `${requested} • Window ${windowLabel}` : requested,
+      details,
       href,
-      titleAttr: windowLabel
-        ? `Kometa will start automatically when the maintenance window ${windowLabel} opens.`
-        : 'Kometa start has been queued.'
+      titleAttr: qsBuildActiveTitleAttr('Kometa start has been queued.', requested, details)
     }
   }
 
   if (data.maintenance_paused) {
     const pausedSince = data.maintenance_paused_since ? `Paused ${qsFormatTimestamp(data.maintenance_paused_since)}` : 'Paused for Plex maintenance'
+    const details = [...progressDetails, ...runtimeDetails]
+    if (windowLabel) qsPushActiveDetail(details, 'Window', windowLabel)
     return {
       key: 'kometa-paused',
       title: 'Kometa run',
       chip: 'Paused',
       state: 'warn',
       meta: windowLabel ? `${pausedSince} • Window ${windowLabel}` : pausedSince,
+      details,
       href,
-      titleAttr: windowLabel
-        ? `Kometa is paused for Plex maintenance during ${windowLabel}.`
-        : 'Kometa is paused for Plex maintenance.'
+      titleAttr: qsBuildActiveTitleAttr('Kometa is paused for Plex maintenance.', pausedSince, details)
     }
   }
 
   if (running) {
     const elapsed = qsFormatElapsedLabel(data.elapsed_seconds)
+    const details = [...progressDetails, ...runtimeDetails]
     return {
       key: 'kometa-running',
       title: 'Kometa run',
       chip: 'Running',
       state: 'unknown',
       meta: elapsed ? `Elapsed ${elapsed}` : 'Kometa is currently running.',
+      details,
       href,
-      titleAttr: elapsed ? `Kometa has been running for ${elapsed}.` : 'Kometa is currently running.'
+      titleAttr: qsBuildActiveTitleAttr('Kometa run', elapsed ? `Elapsed ${elapsed}` : 'Kometa is currently running.', details)
     }
   }
 
@@ -728,17 +856,57 @@ function qsBuildKometaActiveWorkEntry () {
 function qsBuildImageMaidActiveWorkEntry () {
   const data = qsLatestImageMaidStatus
   if (!data || typeof data !== 'object') return null
-  if (String(data.status || '').trim().toLowerCase() !== 'running') return null
+  const status = String(data.status || '').trim().toLowerCase()
+  if (status !== 'running' && status !== 'starting') return null
 
   const elapsed = qsFormatElapsedLabel(data.elapsed_seconds)
+  const details = qsBuildRuntimeActiveDetails(data, 'ImageMaid')
   return {
     key: 'imagemaid-running',
     title: 'ImageMaid run',
-    chip: 'Running',
+    chip: status === 'starting' ? 'Starting' : 'Running',
     state: 'unknown',
-    meta: elapsed ? `Elapsed ${elapsed}` : 'ImageMaid is currently running.',
+    meta: elapsed ? `Elapsed ${elapsed}` : (status === 'starting' ? 'ImageMaid is starting.' : 'ImageMaid is currently running.'),
+    details,
     href: '/step/915-imagemaid',
-    titleAttr: elapsed ? `ImageMaid has been running for ${elapsed}.` : 'ImageMaid is currently running.'
+    titleAttr: qsBuildActiveTitleAttr('ImageMaid run', elapsed ? `Elapsed ${elapsed}` : '', details)
+  }
+}
+
+function qsBuildBulkValidationActiveWorkEntry () {
+  const progress = qsLatestBulkValidationProgress
+  if (!progress || typeof progress !== 'object') return null
+  const phase = String(progress.phase || '').trim().toLowerCase()
+  if (phase !== 'running' && phase !== 'queued' && phase !== 'starting') return null
+
+  const total = Number(progress.total || 0)
+  const completed = Number(progress.completed || 0)
+  const currentLabel = String(progress.current_label || '').trim()
+  const currentStatus = String(progress.current_status || '').trim().toLowerCase()
+  const summary = progress.summary && typeof progress.summary === 'object' ? progress.summary : {}
+  const safeCompleted = Number.isFinite(completed) ? Math.max(0, completed) : 0
+  const safeTotal = Number.isFinite(total) ? Math.max(0, total) : 0
+  const pct = safeTotal > 0 ? Math.max(0, Math.min(100, Math.round((safeCompleted / safeTotal) * 100))) : null
+  const counts = qsGetBulkSummaryCounts(summary)
+  const details = []
+
+  if (currentLabel) qsPushActiveDetail(details, 'Current', currentStatus && currentStatus !== 'running' ? `${currentLabel} (${currentStatus})` : currentLabel)
+  if (safeTotal > 0) qsPushActiveDetail(details, 'Steps', `${Math.min(safeCompleted, safeTotal)}/${safeTotal}${pct !== null ? ` (${pct}%)` : ''}`)
+  qsPushActiveDetail(details, 'Results', `Validated ${counts.validated} | Failed ${counts.failed} | Skipped ${counts.skipped}`)
+  if (progress.updated_at) qsPushActiveDetail(details, 'Updated', qsFormatTimestamp(progress.updated_at))
+
+  const meta = safeTotal > 0
+    ? `Validating ${Math.min(safeCompleted, safeTotal)}/${safeTotal}${currentLabel ? ` - ${currentLabel}` : ''}`
+    : (currentLabel ? `Validating ${currentLabel}` : 'Validating services')
+  return {
+    key: `bulk-validation-${progress.run_id || 'active'}`,
+    title: 'Validate All',
+    chip: phase === 'queued' ? 'Queued' : 'Validating',
+    state: 'unknown',
+    meta,
+    details,
+    href: '/step/900-kometa',
+    titleAttr: qsBuildActiveTitleAttr('Validate All', meta, details)
   }
 }
 
@@ -792,10 +960,21 @@ function qsGetBackgroundJobMeta (job) {
   if (!job || typeof job !== 'object') return ''
 
   const parts = []
+  const jobType = String(job.job_type || '').trim()
   const pct = Number(job.pct)
   const text = String(job.text || '').trim()
   const currentFile = String(job.current_file || '').trim()
   const summary = job.summary && typeof job.summary === 'object' ? job.summary : {}
+
+  if (jobType === 'kometa_update') {
+    if (job.force) parts.push('Forced update')
+    else parts.push('Standard update')
+    if (job.kometa_branch) parts.push(`Branch ${job.kometa_branch}`)
+  } else if (jobType === 'imagemaid_update') {
+    if (job.force) parts.push('Forced update')
+    else parts.push('Standard update')
+    if (job.imagemaid_branch) parts.push(`Branch ${job.imagemaid_branch}`)
+  }
 
   if (text) parts.push(text)
   if (currentFile) parts.push(`File ${currentFile}`)
@@ -811,6 +990,62 @@ function qsGetBackgroundJobMeta (job) {
   return parts.filter(Boolean).slice(0, 3).join(' • ')
 }
 
+function qsGetLastBackgroundJobLogLine (job) {
+  const logs = Array.isArray(job && job.logs) ? job.logs : []
+  for (let index = logs.length - 1; index >= 0; index -= 1) {
+    const line = String(logs[index] || '').trim()
+    if (line) return line
+  }
+  return ''
+}
+
+function qsGetBackgroundJobDetails (job) {
+  if (!job || typeof job !== 'object') return []
+
+  const details = []
+  const jobType = String(job.job_type || '').trim()
+  const phase = String(job.phase || '').trim()
+  const trigger = String(job.trigger || '').trim()
+  const pct = Number(job.pct)
+  const started = job.started_at || (Number.isFinite(Number(job.started_epoch)) ? new Date(Number(job.started_epoch) * 1000).toISOString() : '')
+
+  if (phase) qsPushActiveDetail(details, 'Phase', phase.replaceAll('_', ' '))
+  if (Number.isFinite(pct)) qsPushActiveDetail(details, 'Progress', `${Math.max(0, Math.min(100, Math.round(pct)))}%`)
+  if (trigger && trigger !== 'manual') qsPushActiveDetail(details, 'Trigger', trigger.replaceAll('_', ' '))
+  if (started) qsPushActiveDetail(details, 'Started', qsFormatTimestamp(started))
+
+  if (jobType === 'logscan_reingest') {
+    if (Number.isFinite(Number(job.scanned)) && Number.isFinite(Number(job.total))) {
+      qsPushActiveDetail(details, 'Scanned', `${qsFormatActiveNumber(job.scanned)}/${qsFormatActiveNumber(job.total)}`)
+    }
+    qsPushActiveDetail(details, 'Ingested', qsFormatActiveNumber(job.ingested))
+    qsPushActiveDetail(details, 'Duplicates', qsFormatActiveNumber(job.duplicates))
+    const skipped = Number(job.skipped_incomplete || 0) + Number(job.skipped_invalid || 0)
+    if (skipped > 0) qsPushActiveDetail(details, 'Skipped', qsFormatActiveNumber(skipped))
+    if (job.current_file) qsPushActiveDetail(details, 'File', job.current_file)
+  } else if (jobType === 'kometa_update') {
+    qsPushActiveDetail(details, 'Mode', job.force ? 'Forced update' : 'Standard update')
+    qsPushActiveDetail(details, 'Kometa branch', job.kometa_branch)
+    qsPushActiveDetail(details, 'Quickstart branch', job.qs_branch)
+    qsPushActiveDetail(details, 'Last log', qsGetLastBackgroundJobLogLine(job))
+  } else if (jobType === 'imagemaid_update') {
+    qsPushActiveDetail(details, 'Mode', job.force ? 'Forced update' : 'Standard update')
+    qsPushActiveDetail(details, 'ImageMaid branch', job.imagemaid_branch)
+    qsPushActiveDetail(details, 'Last log', qsGetLastBackgroundJobLogLine(job))
+  } else if (jobType === 'test_library_install') {
+    if (Number.isFinite(Number(job.downloaded)) && Number.isFinite(Number(job.total))) {
+      qsPushActiveDetail(details, 'Download', `${qsFormatActiveMb(Number(job.downloaded) / (1024 * 1024))}/${qsFormatActiveMb(Number(job.total) / (1024 * 1024))}${job.estimated ? ' estimated' : ''}`)
+    }
+    if (Number.isFinite(Number(job.files_done)) && Number.isFinite(Number(job.files_total))) {
+      qsPushActiveDetail(details, 'Files', `${qsFormatActiveNumber(job.files_done)}/${qsFormatActiveNumber(job.files_total)}`)
+    }
+    qsPushActiveDetail(details, 'Target', job.target_path)
+  }
+
+  if (job.error) qsPushActiveDetail(details, 'Error', job.error)
+  return details.filter(Boolean).slice(0, 6)
+}
+
 function qsBuildBackgroundJobEntries () {
   if (!Array.isArray(qsActiveBackgroundJobs)) return []
   return qsActiveBackgroundJobs
@@ -820,6 +1055,7 @@ function qsBuildBackgroundJobEntries () {
       const chip = qsGetBackgroundJobChip(job)
       const meta = qsGetBackgroundJobMeta(job)
       const href = String(job.target_page || '').trim() || '#'
+      const details = qsGetBackgroundJobDetails(job)
       return {
         key: `job-${job.job_id || label}`,
         jobId: String(job.job_id || '').trim() || null,
@@ -828,8 +1064,9 @@ function qsBuildBackgroundJobEntries () {
         state: qsGetBackgroundJobState(job),
         badgeClasses: qsGetBackgroundJobBadgeClasses(job),
         meta: meta || 'In progress.',
+        details,
         href,
-        titleAttr: meta ? `${label}: ${meta}` : label
+        titleAttr: qsBuildActiveTitleAttr(label, meta || 'In progress.', details)
       }
     })
 }
@@ -859,6 +1096,8 @@ function qsRenderActiveWorkCard () {
   if (kometaEntry) entries.push(kometaEntry)
   const imageMaidEntry = qsBuildImageMaidActiveWorkEntry()
   if (imageMaidEntry) entries.push(imageMaidEntry)
+  const bulkValidationEntry = qsBuildBulkValidationActiveWorkEntry()
+  if (bulkValidationEntry) entries.push(bulkValidationEntry)
   entries.push(...qsBuildBackgroundJobEntries())
 
   const rollupState = qsComputeActiveWorkRollupState(entries)
@@ -896,6 +1135,10 @@ function qsRenderActiveWorkCard () {
       : ' href="#"'
     const titleAttr = entry.titleAttr ? ` title="${escapeHtml(entry.titleAttr)}"` : ''
     const targetLabelAttr = ` data-qs-target-label="${escapeHtml(entry.title)}"`
+    const detailRows = Array.isArray(entry.details)
+      ? entry.details.filter(Boolean).slice(0, 6).map((line) => `<div class="qs-active-work-detail-line">${escapeHtml(line)}</div>`).join('')
+      : ''
+    const detailsHtml = detailRows ? `<div class="qs-active-work-detail-list">${detailRows}</div>` : ''
     return `
       <a class="qs-active-work-item qs-active-work-item--${escapeHtml(entry.state)}"${hrefAttr}${titleAttr}${targetLabelAttr}>
         <div class="qs-active-work-item-head">
@@ -903,6 +1146,7 @@ function qsRenderActiveWorkCard () {
           <span class="qs-active-work-chip qs-active-work-chip--${escapeHtml(entry.state)}">${escapeHtml(entry.chip)}</span>
         </div>
         <div class="qs-active-work-item-meta">${escapeHtml(entry.meta || '')}</div>
+        ${detailsHtml}
       </a>`
   }).join('')
 }
@@ -935,6 +1179,8 @@ function qsRenderBackgroundJobPills () {
 function qsHandleMaintenanceStatus (data) {
   if (!data) return
   qsLatestKometaStatus = data
+  const active = String(data.status || '').trim().toLowerCase() === 'running' || Boolean(data.maintenance_paused)
+  if (!active) qsLatestKometaRunProgress = null
   const paused = Boolean(data.maintenance_paused)
   const windowLabel = data.maintenance_window ? ` (${data.maintenance_window})` : ''
   const status = String(data.status || '').trim().toLowerCase()
@@ -1040,6 +1286,13 @@ function qsHandleMaintenanceStatus (data) {
 
 window.QS_handleMaintenanceStatus = qsHandleMaintenanceStatus
 window.QS_formatTimestamp = qsFormatTimestamp
+
+function qsHandleKometaRunProgress (data) {
+  qsLatestKometaRunProgress = data && typeof data === 'object' ? data : null
+  qsRenderActiveWorkCard()
+}
+
+window.QS_handleKometaRunProgress = qsHandleKometaRunProgress
 
 function qsHandleImageMaidStatus (data) {
   qsLatestImageMaidStatus = data
@@ -1353,6 +1606,50 @@ window.QS_refreshAppReadiness = qsRefreshAppReadiness
   }
   setTimeout(poll, 1500)
   setInterval(poll, QS_BACKGROUND_JOBS_POLL_INTERVAL_MS)
+})()
+
+;(function qsKometaProgressPoll () {
+  if (qsSkipMaintenancePoll) return
+  const poll = () => {
+    if (!qsShouldPollBackgroundState() || qsKometaProgressPollInFlight) return
+    const active = qsLatestKometaStatus && (
+      String(qsLatestKometaStatus.status || '').trim().toLowerCase() === 'running' ||
+      Boolean(qsLatestKometaStatus.maintenance_paused)
+    )
+    if (!active) return
+    qsKometaProgressPollInFlight = true
+    fetch('/logscan/progress', { cache: 'no-store' })
+      .then(res => {
+        if (!res.ok) return null
+        return res.json()
+      })
+      .then(data => qsHandleKometaRunProgress(data))
+      .catch(() => {})
+      .finally(() => {
+        qsKometaProgressPollInFlight = false
+      })
+  }
+  setTimeout(poll, 2600)
+  setInterval(poll, QS_KOMETA_PROGRESS_POLL_INTERVAL_MS)
+})()
+
+;(function qsBulkValidationPoll () {
+  const poll = () => {
+    if (!qsShouldPollBackgroundState() || qsBulkValidationPollInFlight) return
+    qsBulkValidationPollInFlight = true
+    fetch('/validate_all_services/status', { cache: 'no-store' })
+      .then(res => res.json())
+      .then((data) => {
+        qsLatestBulkValidationProgress = data && data.success ? (data.progress || null) : null
+        qsRenderActiveWorkCard()
+      })
+      .catch(() => {})
+      .finally(() => {
+        qsBulkValidationPollInFlight = false
+      })
+  }
+  setTimeout(poll, 2200)
+  setInterval(poll, QS_BULK_VALIDATION_POLL_INTERVAL_MS)
 })()
 
 document.addEventListener('click', (event) => {
@@ -2237,6 +2534,19 @@ function qsRunBulkValidation (options = {}) {
   if (qsBulkValidationRequest) return qsBulkValidationRequest
 
   const runId = options.runId || `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  qsLatestBulkValidationProgress = {
+    run_id: runId,
+    phase: 'running',
+    total: 0,
+    completed: 0,
+    current_key: '',
+    current_label: 'Preparing validation',
+    current_status: 'running',
+    results: {},
+    summary: { validated: 0, failed: 0, skipped: 0 },
+    updated_at: new Date().toISOString()
+  }
+  qsRenderActiveWorkCard()
   document.dispatchEvent(new CustomEvent('qs:bulk-validation-start', { detail: { source: options.source || null, runId } }))
   qsSetBulkValidationLoading(true)
 
@@ -2264,6 +2574,8 @@ function qsRunBulkValidation (options = {}) {
       const results = data.results || {}
       const summary = data.summary || {}
       data.run_id = data.run_id || runId
+      qsLatestBulkValidationProgress = data.progress || null
+      qsRenderActiveWorkCard()
       qsApplyBulkValidationResults(results, summary)
       document.dispatchEvent(new CustomEvent('qs:bulk-validation-complete', { detail: data }))
 
@@ -2279,6 +2591,19 @@ function qsRunBulkValidation (options = {}) {
       if (typeof showToast === 'function') {
         showToast('error', message)
       }
+      qsLatestBulkValidationProgress = {
+        run_id: runId,
+        phase: 'error',
+        total: 0,
+        completed: 0,
+        current_key: '',
+        current_label: message,
+        current_status: 'failed',
+        results: {},
+        summary: { validated: 0, failed: 0, skipped: 0 },
+        updated_at: new Date().toISOString()
+      }
+      qsRenderActiveWorkCard()
       document.dispatchEvent(new CustomEvent('qs:bulk-validation-error', { detail: { message } }))
       throw err
     })

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -3,10 +3,10 @@ import {
   computeYamlLineCount,
   formatTimestampLocal,
   formatRunSeconds,
-  applyLogFilter,
   computeLogStats,
   filterLogLines,
   findYamlMajorSections,
+  buildLineNumberedText,
   renderLogRows,
   copyTextToClipboard,
   setMetaFlag
@@ -108,6 +108,11 @@ let lastLogText = ''
 let lastLogStartLine = 1
 let lastLogStatsTotal = null
 let logStatsPollCounter = 0
+let kometaLogInFlight = false
+let lastRenderedLogRawText = null
+let lastRenderedLogFilter = null
+let lastRenderedLogStartLine = null
+let lastFilteredLogResult = null
 let finalLogscanAnalyzeTriggered = false
 
 const runLog = document.getElementById('run-output-log')
@@ -196,22 +201,47 @@ function renderRunLogText (text, opts = {}) {
   if (!runLog) return
   const content = String(text || '')
   if (opts.numbered === false) {
+    runLog.classList.add('qs-log-code--plain')
     runLog.textContent = content
     return
   }
+  const lineCount = getDisplayedLogLineCount(content)
+  if (opts.compact !== false && lineCount > 800) {
+    runLog.classList.add('qs-log-code--plain')
+    runLog.textContent = buildLineNumberedText(content, {
+      startLine: opts.startLine || 1,
+      lineNumbers: opts.lineNumbers
+    })
+    return
+  }
+  runLog.classList.remove('qs-log-code--plain')
   renderLogRows(runLog, content, {
     startLine: opts.startLine || 1,
     lineNumbers: opts.lineNumbers
   })
 }
 
-function renderFilteredRunLog () {
+function renderFilteredRunLog (opts = {}) {
+  if (
+    !opts.force &&
+    lastFilteredLogResult &&
+    lastRenderedLogRawText === lastLogText &&
+    lastRenderedLogFilter === logFilter &&
+    lastRenderedLogStartLine === lastLogStartLine
+  ) {
+    return lastFilteredLogResult
+  }
   const result = filterLogLines(lastLogText, logFilter, { startLine: lastLogStartLine })
   const noMatchText = lastLogText ? 'No lines matched the current filter.' : ''
   renderRunLogText(result.text || noMatchText, {
     startLine: result.text ? undefined : 1,
     lineNumbers: result.text ? result.lineNumbers : undefined
   })
+  lastRenderedLogRawText = lastLogText
+  lastRenderedLogFilter = logFilter
+  lastRenderedLogStartLine = lastLogStartLine
+  lastFilteredLogResult = result
+  return result
 }
 
 function appendRunLogText (text) {
@@ -667,11 +697,12 @@ function updateStatRow (row, stats) {
   })
 }
 
-function renderLogStats () {
+function renderLogStats (filteredResult = lastFilteredLogResult) {
   if (!logStats && !logStatsFiltered) return
   const totalStats = lastLogStatsTotal || computeLogStats(lastLogText)
-  const filteredText = applyLogFilter(lastLogText, logFilter)
-  const filteredStats = computeLogStats(filteredText)
+  const filteredStats = logFilter
+    ? computeLogStats((filteredResult || renderFilteredRunLog()).text || '')
+    : totalStats
   updateStatRow(logStats, totalStats)
   updateStatRow(logStatsFiltered, filteredStats)
 }
@@ -733,17 +764,17 @@ function updateClearFilterButton () {
 
 filterInput?.addEventListener('input', function() {
   logFilter = this.value.trim()
-  renderFilteredRunLog()
+  const filteredResult = renderFilteredRunLog({ force: true })
   updateClearFilterButton()
-  renderLogStats()
+  renderLogStats(filteredResult)
 })
 
 clearFilterBtn?.addEventListener('click', function() {
   logFilter = ''
   filterInput.value = ''
-  renderFilteredRunLog()
+  const filteredResult = renderFilteredRunLog({ force: true })
   updateClearFilterButton()
-  renderLogStats()
+  renderLogStats(filteredResult)
   if (filterInput) filterInput.focus()
 })
 
@@ -752,9 +783,9 @@ if (levelButtons && levelButtons.length) {
     const val = this.dataset.level || ''
     logFilter = val
     if (filterInput) filterInput.value = val
-    renderFilteredRunLog()
+    const filteredResult = renderFilteredRunLog({ force: true })
     updateClearFilterButton()
-    renderLogStats()
+    renderLogStats(filteredResult)
   }))
 }
 
@@ -762,6 +793,7 @@ tailSelect?.addEventListener('change', function() {
   tailSize = this.value || '2000'
   const label = tailSize === 'all' ? 'entire log' : `last ${tailSize} lines of the log`
   if (tailNotice) tailNotice.innerHTML = `<i class="bi bi-info-circle"></i> Showing ${label}`
+  lastRenderedLogRawText = null
   fetchKometaLog()
 })
 
@@ -1280,6 +1312,8 @@ function performStopKometa () {
 
 function fetchKometaLog () {
   if (logPollingPaused) return
+  if (kometaLogInFlight) return
+  kometaLogInFlight = true
 
   const logEl = runLog
   const wasAtBottom = logEl ? (logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 5) : true
@@ -1299,15 +1333,26 @@ function fetchKometaLog () {
         updateLogRecency(null)
         return
       }
-      lastLogText = data.log || ''
-      lastLogStartLine = getTailStartLine(data, lastLogText)
+      const nextLogText = data.log || ''
+      const nextLogStartLine = getTailStartLine(data, nextLogText)
+      const logChanged = nextLogText !== lastLogText || nextLogStartLine !== lastLogStartLine
+      lastLogText = nextLogText
+      lastLogStartLine = nextLogStartLine
       updateLogRecency(data)
       if (data.stats) {
         lastLogStatsTotal = data.stats
       }
-      renderFilteredRunLog()
-      renderLogStats()
-      fetchLogscanAnalysis(false, { updateHeaderBadge: updateLogscanHeaderBadge, kometaState })
+      const filteredResult = logChanged ? renderFilteredRunLog() : lastFilteredLogResult
+      if (logChanged || data.stats || logFilter) {
+        renderLogStats(filteredResult)
+      }
+      if (logChanged) {
+        fetchLogscanAnalysis(false, {
+          updateHeaderBadge: updateLogscanHeaderBadge,
+          kometaState,
+          minIntervalMs: 60000
+        })
+      }
       const shouldStick = autoScrollEnabled || wasAtBottom
       if (shouldStick && logEl) {
         logEl.scrollTop = logEl.scrollHeight
@@ -1316,6 +1361,9 @@ function fetchKometaLog () {
     .catch(err => {
       console.error('Error fetching Kometa log:', err)
       appendRunLogText('\n⚠️ Error fetching log.')
+    })
+    .finally(() => {
+      kometaLogInFlight = false
     })
 }
 

--- a/static/local-js/modules/kometa/_logscan.js
+++ b/static/local-js/modules/kometa/_logscan.js
@@ -53,6 +53,7 @@ import { formatRunSeconds, linkifyText } from './_util.js'
 // Module-local state (was in 900-kometa.js before extraction).
 let pollCounter = 0
 let analyzeInFlight = false
+let lastAnalyzeAt = 0
 
 /**
  * Resolve the panel DOM references. Called lazily so this module
@@ -121,10 +122,14 @@ export function fetchLogscanAnalysis (force = false, opts = {}) {
   const dom = resolvePanel()
   if (!dom.panel) return
   pollCounter += 1
-  const shouldFetch = force || (pollCounter % 5 === 0) || !(kometaState && kometaState.lastLogscanPayload)
+  const now = Date.now()
+  const minIntervalMs = Math.max(0, Number(opts.minIntervalMs || 0) || 0)
+  const intervalDue = !lastAnalyzeAt || minIntervalMs <= 0 || (now - lastAnalyzeAt) >= minIntervalMs
+  const shouldFetch = force || ((pollCounter % 5 === 0) && intervalDue) || !(kometaState && kometaState.lastLogscanPayload)
   if (!shouldFetch || analyzeInFlight) return
 
   analyzeInFlight = true
+  lastAnalyzeAt = now
 
   fetch('/logscan/analyze')
     .then(res => res.json())
@@ -151,6 +156,7 @@ export function fetchLogscanAnalysis (force = false, opts = {}) {
 export function resetLogscanStateForTests () {
   pollCounter = 0
   analyzeInFlight = false
+  lastAnalyzeAt = 0
 }
 
 // ---------------------------------------------------------------------

--- a/static/local-js/modules/kometa/_runProgress.js
+++ b/static/local-js/modules/kometa/_runProgress.js
@@ -94,6 +94,9 @@ export function renderRunProgress (payload) {
   }
 
   kometaState.lastRunProgressPayload = payload
+  if (typeof window !== 'undefined' && typeof window.QS_handleKometaRunProgress === 'function') {
+    window.QS_handleKometaRunProgress(payload)
+  }
   const libraries = payload.libraries
   const total = payload.total_count || libraries.length
   const completed = payload.completed_count != null

--- a/tests/js/kometa/logscan.test.js
+++ b/tests/js/kometa/logscan.test.js
@@ -248,6 +248,37 @@ describe('fetchLogscanAnalysis', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2)
   })
 
+  it('honors minIntervalMs for non-forced cadence fetches', async () => {
+    const state = { lastLogscanPayload: null }
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(3000)
+      .mockReturnValueOnce(4000)
+      .mockReturnValueOnce(5000)
+      .mockReturnValueOnce(61000)
+      .mockReturnValueOnce(62000)
+      .mockReturnValueOnce(63000)
+      .mockReturnValueOnce(64000)
+      .mockReturnValueOnce(65000)
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 2
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 3
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 4
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 5, below interval
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 6
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 7
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 8
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 9
+    fetchLogscanAnalysis(false, { kometaState: state, minIntervalMs: 60000 }) // 10, interval due
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
   it('stashes payload into kometaState.lastLogscanPayload on success', async () => {
     const state = {}
     fetchLogscanAnalysis(true, { kometaState: state })

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1188,6 +1188,73 @@ def test_logscan_progress_cached_running_payload_keeps_live_elapsed(client, isol
     assert payload["playlist_elapsed_seconds"] == 305
 
 
+def test_logscan_progress_uses_persisted_snapshot_after_memory_cache_clear(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text(
+        "[2026-04-24 21:00:00,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|\n"
+        + "".join(f"[2026-04-24 21:00:01,000] [kometa.py:730] [INFO] noise {idx}\n" for idx in range(5000)),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: True)
+    monkeypatch.setattr(qs_module, "_load_progress_config", lambda *_args, **_kwargs: {})
+    qs_module._clear_logscan_progress_snapshot()
+
+    started_at = datetime.fromisoformat("2026-04-24T21:00:00")
+    with qs_module.RUN_CONTEXT_LOCK:
+        qs_module.RUN_CONTEXT["started_at"] = started_at
+        qs_module.RUN_CONTEXT["selected_libraries"] = ["Movies"]
+        qs_module.RUN_CONTEXT["config_path"] = None
+        qs_module.RUN_CONTEXT["run_mode"] = "all"
+        qs_module.RUN_CONTEXT["stop_requested_at"] = None
+
+    analyzer_calls = []
+
+    class _FakeProgressAnalyzer:
+        def extract_progress(self, content, **kwargs):
+            previous = kwargs.get("previous") if isinstance(kwargs.get("previous"), dict) else {}
+            analyzer_calls.append({"content": content, "previous": previous})
+            return {
+                "phase_current": "operations",
+                "phases_completed": [],
+                "phase_starts": previous.get("phase_starts") or {"Movies||operations": "2026-04-24T21:00:00"},
+                "libraries": previous.get("libraries") or [{"name": "Movies", "type": "movie", "status": "In progress", "durations": {"operations": 12}}],
+                "current_library": "Movies",
+                "completed_count": 0,
+                "total_count": 1,
+            }
+
+        def extract_maintenance_summary(self, content):
+            return {"had_pause": "Maintenance marker:" in content, "pause_count": 1 if "Maintenance marker:" in content else 0}
+
+    monkeypatch.setattr(qs_module.logscan, "LogscanAnalyzer", _FakeProgressAnalyzer)
+
+    first = client.get("/logscan/progress")
+    assert first.status_code == 200
+    assert analyzer_calls[-1]["previous"] == {}
+
+    qs_module.LOGSCAN_PROGRESS_CACHE.update({"mtime": None, "size": None, "aux_signature": None, "data": None})
+    (log_dir / "meta.quickstart-maintenance.log").write_text(
+        "[Quickstart] Maintenance marker: event=paused at=2026-04-24T21:10:00Z local_at=2026-04-24T17:10:00 window=03:00-05:00\n",
+        encoding="utf-8",
+    )
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("[2026-04-24 21:15:00,000] [kometa.py:730] [INFO] still running\n")
+    monkeypatch.setattr(qs_module, "_read_logscan_text", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("full log read should not be used")))
+
+    second = client.get("/logscan/progress")
+
+    assert second.status_code == 200
+    payload = second.get_json()
+    assert payload["maintenance_had_pause"] is True
+    assert analyzer_calls[-1]["previous"]["libraries"][0]["name"] == "Movies"
+    assert analyzer_calls[-1]["previous"]["current_library"] == "Movies"
+
+
 def test_logscan_progress_size_all_bypasses_matching_stale_cache(client, isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     log_dir = kometa_root / "config" / "logs"

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -39,6 +39,20 @@ def test_tail_log_stats_count_exact_level_markers(client, tmp_path, monkeypatch,
     assert stats["trace"] == 1
 
 
+def test_tail_log_size_reads_only_requested_tail(client, tmp_path, monkeypatch, qs_module):
+    log_dir = tmp_path / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "meta.log").write_text("".join(f"line {idx}\n" for idx in range(1, 51)), encoding="utf-8")
+    qs_module.LOG_STATS_CACHE.clear()
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+
+    resp = client.get("/tail-log?size=5")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["log"].splitlines() == ["line 46", "line 47", "line 48", "line 49", "line 50"]
+
+
 def test_start_kometa_queues_during_maintenance(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This PR improves responsiveness during long Kometa runs and makes the sidebar Active Work panel more useful for long-running tasks.

**Changes**
- Optimize `/tail-log` and `/logscan/progress` so they avoid repeatedly scanning entire large log files.
- Persist Kometa progress snapshots so long runs can recover progress state quickly after cache loss or page navigation.
- Include the Kometa maintenance sidecar log in progress snapshot validity checks.
- Reduce expensive Kometa page rerenders by caching log/filter render state and using a lighter plain-text renderer for very large tails.
- Throttle logscan analysis refreshes during live log polling.
- Expand Active Work detail rows for:
  - Kometa runs
  - ImageMaid runs
  - Validate All
  - Analytics reingest/migration
  - Kometa updates, including forced vs standard and branch
  - ImageMaid updates, including forced vs standard and branch
  - Test library installs
- Surface Kometa progress-matrix context in Active Work, including current library/phase, library count, matrix step, and phase elapsed time.

**Validation**
- `python -m pytest tests/test_start_stop.py tests/test_logscan_endpoints.py::test_logscan_progress_cached_running_payload_keeps_live_elapsed tests/test_logscan_endpoints.py::test_logscan_progress_uses_persisted_snapshot_after_memory_cache_clear tests/test_logscan_endpoints.py::test_logscan_progress_includes_maintenance_sidecar_and_invalidates_cache`
- `python -m pytest tests/test_update_flows.py tests/test_core_backend.py::test_validate_all_services_flags_invalid_library_arr_overrides`
- `node_modules\.bin\vitest.cmd run tests/js/kometa/logscan.test.js tests/js/kometa/util.test.js`
- `node_modules\.bin\vitest.cmd run tests/js/kometa/runProgress.test.js`
- `node_modules\.bin\eslint.cmd static/local-js/000-base.js static/local-js/900-kometa.js static/local-js/modules/kometa/_logscan.js static/local-js/modules/kometa/_runProgress.js`
- `python -m ruff check quickstart.py modules/process_control.py tests/test_logscan_endpoints.py tests/test_start_stop.py`
- `python -m py_compile quickstart.py modules/process_control.py`
- `git diff --check`

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791467793&installation_model_id=431096&pr_number=1806&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1806&signature=880bb2efb8de9862559e9752d42648972bfcbb92bce728c5082d1aaa55051b5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->