### PR TITLE
enhance mirror flow and toggle fix

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -168,6 +168,127 @@ def _normalize_library_toggle_names(libraries_data):
     return normalized
 
 
+def _is_blank_library_value(value):
+    if value is None:
+        return True
+    if value is False:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"", "none", "null"}
+    return False
+
+
+def _find_library_value(libraries_data, library_id, suffixes):
+    if not isinstance(libraries_data, dict):
+        return None
+    for suffix in suffixes:
+        direct = f"{library_id}-{suffix}"
+        if direct in libraries_data:
+            return libraries_data.get(direct)
+    for key, value in libraries_data.items():
+        if not isinstance(key, str) or not key.startswith(f"{library_id}-"):
+            continue
+        if any(key.endswith(suffix) for suffix in suffixes):
+            return value
+    return None
+
+
+def _mirror_separator_placeholder_issues(libraries_data, library_id, library_name, source_type, quickstart_module):
+    use_separator = _find_library_value(
+        libraries_data,
+        library_id,
+        ["template_variables[use_separator]", "attribute_use_separator"],
+    )
+    if not _is_truthy_setting_value(use_separator):
+        return []
+
+    media_type = "movie" if source_type == "mov" else "show"
+    placeholder_keys = [
+        "attribute_template_variables[placeholder_imdb_id]",
+        "template_variables[placeholder_imdb_id]",
+    ]
+    if media_type == "movie":
+        placeholder_keys = [
+            "attribute_template_variables[placeholder_tmdb_movie]",
+            "template_variables[placeholder_tmdb_movie]",
+        ] + placeholder_keys
+    else:
+        placeholder_keys = [
+            "attribute_template_variables[placeholder_tvdb_show]",
+            "template_variables[placeholder_tvdb_show]",
+        ] + placeholder_keys
+
+    placeholder = _find_library_value(libraries_data, library_id, placeholder_keys)
+    if _is_blank_library_value(placeholder):
+        return [f"{library_name}: separator placeholders are enabled but no placeholder ID is selected."]
+
+    placeholder_text = str(placeholder).strip()
+    if media_type == "show" and placeholder_text.isdigit():
+        return [f"{library_name}: TVDb placeholder {placeholder_text} cannot be verified automatically against Plex; review this library before including it."]
+
+    if placeholder_text.isdigit():
+        try:
+            tmdb_result = quickstart_module._lookup_tmdb_numeric_id(placeholder_text, media_type=media_type)
+        except Exception as exc:
+            return [f"{library_name}: TMDb placeholder {placeholder_text} could not be verified: {exc}."]
+        if not tmdb_result.get("valid") or not tmdb_result.get("verified"):
+            message = str(tmdb_result.get("message") or "").strip()
+            return [f"{library_name}: TMDb placeholder {placeholder_text} could not be verified. {message}".strip()]
+        result_type = str(tmdb_result.get("result_type") or "").strip().lower()
+        if result_type and result_type != media_type:
+            return [f"{library_name}: TMDb placeholder {placeholder_text} resolves to {result_type}, not {media_type}."]
+        tmdb_label = str(tmdb_result.get("label") or "").strip()
+        if tmdb_label:
+            try:
+                plex_match = quickstart_module.helpers.find_item_by_title(library_name, tmdb_label)
+            except Exception as exc:
+                return [f"{library_name}: Plex lookup for placeholder '{tmdb_label}' failed: {exc}."]
+            if plex_match and plex_match.get("title"):
+                return []
+        return [f"{library_name}: placeholder '{tmdb_label or placeholder_text}' was not found in this Plex library."]
+
+    try:
+        tmdb_result = quickstart_module._lookup_tmdb_by_imdb_id(placeholder_text, media_type=media_type)
+    except Exception:
+        tmdb_result = {}
+    tmdb_label = str(tmdb_result.get("label") or "").strip()
+    try:
+        plex_match = quickstart_module.helpers.find_item_by_imdb_id(library_name, placeholder_text, media_type, fallback_title=tmdb_label)
+    except TypeError:
+        plex_match = quickstart_module.helpers.find_item_by_imdb_id(library_name, placeholder_text, media_type)
+    except Exception as exc:
+        return [f"{library_name}: Plex lookup for placeholder {placeholder_text} failed: {exc}."]
+    if plex_match and plex_match.get("title"):
+        return []
+    if tmdb_result.get("valid") and tmdb_result.get("verified"):
+        return [f"{library_name}: placeholder '{tmdb_label or placeholder_text}' was not found in this Plex library."]
+    return [f"{library_name}: placeholder {placeholder_text} could not be verified against Plex."]
+
+
+def _build_mirror_include_report(libraries_data, target_id, target_name, source_type, quickstart_module):
+    candidate = dict(libraries_data)
+    candidate[f"{target_id}-library"] = target_name
+    target_items = {k: v for k, v in candidate.items() if isinstance(k, str) and k.startswith(f"{target_id}-")}
+    issues = []
+    issues.extend(path_validation.validate_payload(target_items))
+    issues.extend(quickstart_module._validate_library_collection_files(candidate, [target_id]))
+    issues.extend(quickstart_module._validate_library_metadata_files(candidate, [target_id]))
+    issues.extend(quickstart_module._validate_library_overlay_files(candidate, [target_id]))
+    issues.extend(quickstart_module._validate_library_auto_sort_hubs(candidate, [target_id]))
+    override_result = quickstart_module._validate_library_service_overrides(target_id, candidate)
+    if not override_result.get("valid") and not override_result.get("skipped"):
+        issues.extend(list(override_result.get("errors") or []))
+    issues.extend(_mirror_separator_placeholder_issues(candidate, target_id, target_name, source_type, quickstart_module))
+
+    return {
+        "target_id": target_id,
+        "target_name": target_name,
+        "included": not issues,
+        "status": "included" if not issues else "needs_review",
+        "issues": issues,
+    }
+
+
 def _legacy_playlist_library_names():
     settings = persistence.retrieve_settings("027-playlist_files") or {}
     playlist_payload = settings.get("playlist_files", {}) if isinstance(settings, dict) else {}
@@ -1353,6 +1474,24 @@ def copy_library_settings():
             try:
                 clean_payload = persistence.clean_form_data(MultiDict(source_payload_for_merge))
                 incoming_dict = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
+                for raw_key, raw_value in source_payload_for_merge.items():
+                    if not isinstance(raw_key, str) or not raw_key.startswith(f"{source_prefix}-"):
+                        continue
+                    if not raw_key.endswith(("-attribute_use_separator", "-template_variables[use_separator]")):
+                        continue
+                    if isinstance(raw_value, str):
+                        raw_text = raw_value.strip()
+                        raw_lc = raw_text.lower()
+                        if raw_lc in {"", "none", "null"}:
+                            incoming_dict[raw_key] = None
+                        elif raw_lc in {"false", "off", "0"}:
+                            incoming_dict[raw_key] = False
+                        elif raw_lc in {"true", "on", "1"}:
+                            incoming_dict[raw_key] = True
+                        else:
+                            incoming_dict[raw_key] = raw_value
+                    else:
+                        incoming_dict[raw_key] = raw_value
                 normalized_incoming, normalization_errors, _ = _qs._normalize_library_file_entries_payload(
                     incoming_dict,
                     session.get("config_name") or source_payload_for_merge.get("config_name"),
@@ -1464,6 +1603,7 @@ def copy_library_settings():
         if not source_items:
             helpers.ts_log(f"Copy aborted: no saved settings found for source {source_prefix}", level="ERROR")
             return jsonify({"success": False, "error": "No saved settings found for source library"}), 404
+        source_included = _is_truthy_setting_value(source_items.get(f"{source_prefix}-library"))
 
         movie_libraries, show_libraries, _telemetry = _build_library_lists()
         name_map = {lib["id"]: lib["name"] for lib in (movie_libraries + show_libraries)}
@@ -1502,12 +1642,11 @@ def copy_library_settings():
                 if existing_key.startswith(f"{target_id}-"):
                     merged.pop(existing_key, None)
 
+            if target_id != source_prefix:
+                merged[f"{target_id}-library"] = ""
+
             for key, value in source_items.items():
                 if target_id != source_prefix and key.endswith("-library"):
-                    # Do not opt target libraries into YAML automatically.
-                    # Mirrored settings remain saved and become active if the
-                    # user explicitly includes the target later.
-                    merged[f"{target_id}-library"] = ""
                     continue
                 new_key = key.replace(source_prefix, target_id, 1)
                 new_value = value
@@ -1521,6 +1660,42 @@ def copy_library_settings():
                     elif key.endswith("-overlay_files"):
                         new_value = _qs._clone_library_file_entries_for_target("overlay_files", value, config_name, target_id)
                 merged[new_key] = new_value
+
+        mirror_report = []
+        included_targets = []
+        review_targets = []
+        for target_id in filtered_targets:
+            if target_id == source_prefix:
+                continue
+            target_name = name_map.get(target_id, "")
+            if not source_included:
+                mirror_report.append(
+                    {
+                        "target_id": target_id,
+                        "target_name": target_name,
+                        "included": False,
+                        "status": "source_excluded",
+                        "issues": ["Source library is excluded, so the mirrored target was left excluded."],
+                    }
+                )
+                continue
+            if not target_name:
+                report = {
+                    "target_id": target_id,
+                    "target_name": target_id,
+                    "included": False,
+                    "status": "needs_review",
+                    "issues": ["Target library name could not be resolved from Plex."],
+                }
+            else:
+                report = _build_mirror_include_report(merged, target_id, target_name, source_type, _qs)
+            if report.get("included"):
+                merged[f"{target_id}-library"] = target_name
+                included_targets.append(target_id)
+            else:
+                merged[f"{target_id}-library"] = ""
+                review_targets.append(target_id)
+            mirror_report.append(report)
 
         # Update the aggregated libraries list to include all configured library names
         configured_names = []
@@ -1543,7 +1718,16 @@ def copy_library_settings():
             level="DEBUG",
         )
 
-        return jsonify({"success": True, "updated": target_ids})
+        return jsonify(
+            {
+                "success": True,
+                "updated": filtered_targets,
+                "source_included": source_included,
+                "included_targets": included_targets,
+                "review_targets": review_targets,
+                "mirror_report": mirror_report,
+            }
+        )
 
     except Exception as e:
         helpers.ts_log(f"Failed to copy library settings: {e}", level="ERROR")

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -30,6 +30,7 @@ const copyModalEl = document.getElementById('copyLibraryModal')
 const copyTargetsContainer = document.getElementById('copyLibraryTargets')
 const copySubtitle = document.getElementById('copyLibrarySubtitle')
 const copyWarning = document.getElementById('copyLibraryWarning')
+const copyReport = document.getElementById('copyLibraryReport')
 const copyConfirmBtn = document.getElementById('copyLibraryConfirm')
 const copySelectAllBtn = document.getElementById('copySelectAll')
 const copyDeselectAllBtn = document.getElementById('copyDeselectAll')
@@ -152,7 +153,6 @@ const dependencyHintConfigs = {
 }
 let dependencyHintRefreshTimer = null
 let dependencyHintRequestToken = 0
-const advancedVisibilityStorageKey = 'qsLibrariesAdvancedVisible'
 
 function normalizeMetadataFileEntry (entry) {
   if (!entry || typeof entry !== 'object') return null
@@ -6037,6 +6037,68 @@ function refreshPickerLabels () {
   updateConfiguredCounts()
 }
 
+function clearCopyLibraryReport () {
+  if (!copyReport) return
+  copyReport.classList.add('d-none')
+  copyReport.replaceChildren()
+}
+
+function renderCopyLibraryReport (data) {
+  if (!copyReport) return false
+  clearCopyLibraryReport()
+  const report = Array.isArray(data?.mirror_report) ? data.mirror_report : []
+  if (!report.length) return false
+
+  const included = report.filter(item => item && item.status === 'included')
+  const sourceExcluded = report.filter(item => item && item.status === 'source_excluded')
+  const needsReview = report.filter(item => item && item.status === 'needs_review')
+  const heading = document.createElement('div')
+  heading.className = 'fw-semibold mb-2'
+  if (sourceExcluded.length && !included.length && !needsReview.length) {
+    heading.textContent = 'Mirror complete. Targets stayed excluded because the source library is excluded.'
+  } else {
+    const parts = []
+    if (included.length) parts.push(`${included.length} included`)
+    if (needsReview.length) parts.push(`${needsReview.length} need review`)
+    heading.textContent = `Mirror complete: ${parts.join(', ') || 'no target changes'}.`
+  }
+  copyReport.appendChild(heading)
+
+  report.forEach(item => {
+    const row = document.createElement('div')
+    row.className = 'mb-2'
+    const label = document.createElement('div')
+    label.className = 'fw-semibold'
+    const name = item?.target_name || item?.target_id || 'Target library'
+    if (item?.status === 'included') {
+      label.textContent = `${name}: included in config`
+    } else if (item?.status === 'source_excluded') {
+      label.textContent = `${name}: left excluded`
+    } else {
+      label.textContent = `${name}: needs review`
+    }
+    row.appendChild(label)
+
+    const issues = Array.isArray(item?.issues) ? item.issues.filter(Boolean) : []
+    issues.slice(0, 4).forEach(issue => {
+      const issueEl = document.createElement('div')
+      issueEl.className = 'small text-muted'
+      issueEl.textContent = issue
+      row.appendChild(issueEl)
+    })
+    if (issues.length > 4) {
+      const more = document.createElement('div')
+      more.className = 'small text-muted'
+      more.textContent = `${issues.length - 4} more issue(s).`
+      row.appendChild(more)
+    }
+    copyReport.appendChild(row)
+  })
+
+  copyReport.classList.remove('d-none')
+  return needsReview.length > 0 || sourceExcluded.length > 0
+}
+
 function isLibraryCardInitializing (card) {
   return libraryCardInitializing > 0 || card?.dataset?.libraryInitializing === 'true'
 }
@@ -6157,30 +6219,28 @@ function setAdvancedVisibility (card, visible) {
   })
   const toggle = card.querySelector('.library-advanced-toggle')
   if (toggle) {
-    toggle.textContent = visible ? 'Hide Advanced' : 'Show Advanced'
+    toggle.checked = !!visible
     toggle.setAttribute('aria-expanded', visible ? 'true' : 'false')
   }
   card.dataset.advancedVisible = visible ? 'true' : 'false'
 }
 
+function getPreferredAdvancedVisibility (card) {
+  return hasConfiguredAdvancedValues(card)
+}
+
 function wireAdvancedToggle (card) {
-  if (!card || card.dataset.advancedToggleBound === 'true') return
+  if (!card) return
   const toggle = card.querySelector('.library-advanced-toggle')
   if (!toggle) return
 
-  let persisted = null
-  try {
-    persisted = window.localStorage ? window.localStorage.getItem(advancedVisibilityStorageKey) : null
-  } catch {}
-  const initialVisible = persisted === 'true' || (persisted !== 'false' && hasConfiguredAdvancedValues(card))
-  setAdvancedVisibility(card, initialVisible)
+  setAdvancedVisibility(card, getPreferredAdvancedVisibility(card))
 
-  toggle.addEventListener('click', () => {
-    const nextVisible = card.dataset.advancedVisible !== 'true'
+  if (card.dataset.advancedToggleBound === 'true') return
+
+  toggle.addEventListener('change', () => {
+    const nextVisible = toggle.checked
     setAdvancedVisibility(card, nextVisible)
-    try {
-      if (window.localStorage) window.localStorage.setItem(advancedVisibilityStorageKey, nextVisible ? 'true' : 'false')
-    } catch {}
   })
 
   card.dataset.advancedToggleBound = 'true'
@@ -7056,6 +7116,7 @@ function autosaveActiveLibrary (options = {}) {
 function openCopyModal (sourceId, sourceName, sourceType) {
   if (!copyModal) return
   copyWarning.style.display = 'none'
+  clearCopyLibraryReport()
   copySubtitle.textContent = `Mirror settings from "${sourceName}" to other ${sourceType === 'movie' ? 'movie' : 'show'} libraries`
   copyTargetsContainer.replaceChildren()
 
@@ -7089,7 +7150,10 @@ function openCopyModal (sourceId, sourceName, sourceType) {
   }
 
   const checkboxes = () => Array.from(copyTargetsContainer.querySelectorAll('.copy-target-checkbox'))
-  const clearWarning = () => { copyWarning.style.display = 'none' }
+  const clearWarning = () => {
+    copyWarning.style.display = 'none'
+    clearCopyLibraryReport()
+  }
   checkboxes().forEach(cb => cb.addEventListener('change', clearWarning))
 
   if (copySelectAllBtn) {
@@ -7108,6 +7172,7 @@ function openCopyModal (sourceId, sourceName, sourceType) {
   copyModal.show()
 
   const onConfirm = () => {
+    let keepCopyModalOpen = false
     const selected = Array.from(copyTargetsContainer.querySelectorAll('.copy-target-checkbox:checked')).map(cb => cb.value)
     const prefix = sourceType === 'movie' ? 'mov-' : 'sho-'
     const filtered = selected.filter(id => id.startsWith(prefix))
@@ -7147,9 +7212,11 @@ function openCopyModal (sourceId, sourceName, sourceType) {
         return res.json()
       })
       .then((data) => {
+        keepCopyModalOpen = renderCopyLibraryReport(data)
         // Clear all cached cards to avoid stale data
         libraryCache.replaceChildren()
 
+        const includedTargets = new Set(Array.isArray(data?.included_targets) ? data.included_targets : [])
         filtered.forEach(id => {
           const cached = libraryCache.querySelector(`[data-library-id="${id}"]`)
           if (cached && cached.parentElement === libraryCache) {
@@ -7160,7 +7227,7 @@ function openCopyModal (sourceId, sourceName, sourceType) {
           }
           const opt = libraryPicker.querySelector(`option[value="${id}"]`)
           if (opt) {
-            opt.dataset.configured = 'false'
+            opt.dataset.configured = includedTargets.has(id) ? 'true' : 'false'
           }
         })
         refreshPickerLabels()
@@ -7171,7 +7238,15 @@ function openCopyModal (sourceId, sourceName, sourceType) {
         refreshTemplateOverrideState(libraryContainer?.firstElementChild || document)
         if (typeof showToast === 'function') {
           const label = filtered.length === 1 ? 'library' : 'libraries'
-          showToast('success', `Mirrored settings to ${filtered.length} ${label}.`)
+          const reviewCount = Array.isArray(data?.review_targets) ? data.review_targets.length : 0
+          const includedCount = includedTargets.size
+          if (data?.source_included === false) {
+            showToast('success', `Mirrored settings to ${filtered.length} ${label}; targets stayed excluded.`)
+          } else if (reviewCount > 0) {
+            showToast('warning', `Mirrored settings to ${filtered.length} ${label}; included ${includedCount}, ${reviewCount} need review.`)
+          } else {
+            showToast('success', `Mirrored settings to ${filtered.length} ${label}; included ${includedCount}.`)
+          }
         }
         scheduleDependencyRequirementHintRefresh(0)
         document.dispatchEvent(new CustomEvent('qs:workspace-data-changed', { detail: { source: 'libraries-copy', delayMs: 80 } }))
@@ -7186,7 +7261,9 @@ function openCopyModal (sourceId, sourceName, sourceType) {
         if (copyConfirmBtn && typeof copyConfirmBtn.blur === 'function') {
           copyConfirmBtn.blur()
         }
-        copyModal.hide()
+        if (!keepCopyModalOpen) {
+          copyModal.hide()
+        }
       })
   }
 

--- a/templates/025-libraries.html
+++ b/templates/025-libraries.html
@@ -271,16 +271,15 @@
       <div class="modal-body">
         <p class="text-muted small mb-2" id="copyLibrarySubtitle"></p>
         <div class="alert alert-info small mb-3" role="alert">
-          Mirroring copies the selected library settings, but it does not include target libraries in the final config automatically.
-          Target libraries stay excluded because enabling <strong>Include in config</strong> runs the normal library validation flow.
-          That gives Quickstart a chance to catch library-specific mirrored values that may not apply to the target, such as placeholder IDs.
-          After mirroring, open each target library, review the copied settings, and enable <strong>Include in config</strong> if you want that mirrored library in the final config.
+          Mirroring copies the selected library settings. If the source library is excluded, mirrored targets stay excluded.
+          If the source library is included, Quickstart tries to include safe targets automatically and reports any target-specific values that need review, such as placeholder IDs.
         </div>
         <div class="d-flex justify-content-end gap-2 mb-2">
           <button type="button" class="btn btn-sm btn-outline-secondary" id="copySelectAll">Select all</button>
           <button type="button" class="btn btn-sm btn-outline-secondary" id="copyDeselectAll">Deselect all</button>
         </div>
         <div id="copyLibraryTargets" class="list-group"></div>
+        <div class="alert alert-secondary mt-3 mb-0 d-none" id="copyLibraryReport" role="status"></div>
         <div class="alert alert-warning mt-3 mb-0" id="copyLibraryWarning" style="display:none;">
           Select at least one target library.
         </div>

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -222,7 +222,7 @@
         <button class="btn nav-button btn-sm collapsed" type="button" data-bs-toggle="collapse"
           data-bs-target="#logscan-recent-runs-collapse" aria-expanded="false"
           aria-controls="logscan-recent-runs-collapse" id="logscan-table-toggle">
-          Show table
+          Show Runs
         </button>
       </div>
     </div>

--- a/templates/partials/_library_card.html
+++ b/templates/partials/_library_card.html
@@ -34,9 +34,13 @@
       <div class="small text-muted">
         Advanced reveals library-level file imports and per-library Arr modifications.
       </div>
-      <button type="button" class="btn btn-outline-secondary btn-sm library-advanced-toggle">
-        Show Advanced
-      </button>
+      <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
+        <input class="form-check-input library-advanced-toggle" type="checkbox"
+          id="{{ library.id }}-advanced-toggle" role="switch">
+        <label class="form-check-label small mb-0" for="{{ library.id }}-advanced-toggle">
+          Show Advanced
+        </label>
+      </div>
     </div>
     {% include "partials/_movie_library_settings.html" %}
   </div>
@@ -76,9 +80,13 @@
       <div class="small text-muted">
         Advanced reveals library-level file imports and per-library Arr modifications.
       </div>
-      <button type="button" class="btn btn-outline-secondary btn-sm library-advanced-toggle">
-        Show Advanced
-      </button>
+      <div class="form-check form-switch mb-0 d-flex align-items-center gap-2">
+        <input class="form-check-input library-advanced-toggle" type="checkbox"
+          id="{{ library.id }}-advanced-toggle" role="switch">
+        <label class="form-check-label small mb-0" for="{{ library.id }}-advanced-toggle">
+          Show Advanced
+        </label>
+      </div>
     </div>
     {% include "partials/_show_library_settings.html" %}
   </div>

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -155,13 +155,38 @@ def test_libraries_lookup_label_autosave_uses_narrow_payload():
     assert "lookupLabelsOnly ? buildLookupLabelPayloadFromCard(card) : buildPayloadFromCard(card)" in script
 
 
-def test_mirror_modal_explains_targets_stay_excluded():
+def test_mirror_modal_explains_auto_include_report():
     template = LIBRARIES_TEMPLATE_PATH.read_text(encoding="utf-8")
 
-    assert "does not include target libraries in the final config automatically" in template
-    assert "runs the normal library validation flow" in template
+    assert "If the source library is excluded, mirrored targets stay excluded" in template
+    assert "tries to include safe targets automatically" in template
+    assert "reports any target-specific values that need review" in template
     assert "placeholder IDs" in template
-    assert "enable <strong>Include in config</strong>" in template
+    assert 'id="copyLibraryReport"' in template
+
+
+def test_libraries_advanced_toggle_derives_initial_state_from_modifications():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+    partial = LIBRARY_CARD_PARTIAL_PATH.read_text(encoding="utf-8")
+
+    assert "function getPreferredAdvancedVisibility" in script
+    get_preferred = script.split("function getPreferredAdvancedVisibility", 1)[1].split("function wireAdvancedToggle", 1)[0]
+    assert "return hasConfiguredAdvancedValues(card)" in get_preferred
+    assert "localStorage" not in get_preferred
+    assert "advancedUserChoice" not in get_preferred
+    assert "setAdvancedVisibility(card, getPreferredAdvancedVisibility(card))" in script
+    assert "if (card.dataset.advancedToggleBound === 'true') return" in script
+    assert "toggle.addEventListener('change'" in script
+    assert "const nextVisible = toggle.checked" in script
+    assert "toggle.checked = !!visible" in script
+    assert "advancedVisibilityStorageKey" not in script
+    assert "advancedUserChoice" not in script
+    assert "MutationObserver(() => syncAdvancedToggleLabel(card))" not in script
+    assert "syncAdvancedToggleLabels(root)" not in script
+    assert 'type="checkbox"' in partial
+    assert 'role="switch"' in partial
+    assert "Show Advanced" in partial
+    assert "Hide Advanced" not in partial
 
 
 def test_playlist_toggle_preserves_mirrored_state_when_excluded():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -5951,7 +5951,7 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
     assert target_file.read_text(encoding="utf-8") == managed_file.read_text(encoding="utf-8")
 
 
-def test_copy_library_settings_keeps_target_excluded_for_playlist_and_content_rating(client, isolated_config_dir, monkeypatch, app, library_routes_module):
+def test_copy_library_settings_keeps_target_excluded_when_source_is_excluded(client, isolated_config_dir, monkeypatch, app, library_routes_module):
     from modules import database
     from flask import session
 
@@ -6001,7 +6001,7 @@ def test_copy_library_settings_keeps_target_excluded_for_playlist_and_content_ra
             "source_library_id": "mov-library_movies",
             "target_library_ids": ["mov-library_target"],
             "source_payload": {
-                "mov-library_movies-library": "Movies",
+                "mov-library_movies-library": "false",
                 "mov-library_movies-playlist": "true",
                 "mov-library_movies-collection_content_rating_us": True,
                 "mov-library_movies-template_collection_content_rating_us_limit": "40",
@@ -6014,6 +6014,10 @@ def test_copy_library_settings_keeps_target_excluded_for_playlist_and_content_ra
     assert resp.status_code == 200
     payload = resp.get_json()
     assert payload["success"] is True
+    assert payload["source_included"] is False
+    assert payload["included_targets"] == []
+    assert payload["review_targets"] == []
+    assert payload["mirror_report"][0]["status"] == "source_excluded"
 
     _validated, _user_entered, stored = database.retrieve_section_data(config_name, "libraries")
     libraries = stored["libraries"]
@@ -6023,6 +6027,140 @@ def test_copy_library_settings_keeps_target_excluded_for_playlist_and_content_ra
     assert libraries["mov-library_target-template_collection_content_rating_us_limit"] == 40
     assert libraries["mov-library_target-movie-overlay_content_rating"] == "uk"
     assert libraries["mov-library_target-movie-template_overlay_content_rating_uk[color]"] == "white"
+
+
+def test_copy_library_settings_auto_includes_safe_targets_when_source_is_included(client, isolated_config_dir, monkeypatch, app, library_routes_module):
+    from modules import database
+    from flask import session
+
+    config_name = "pytest_copy_auto_include"
+    database.save_section_data(
+        section="libraries",
+        validated=False,
+        user_entered=True,
+        name=config_name,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_content_rating_us": True,
+                "mov-library_target-library": "",
+                "libraries": "Movies",
+            },
+            "validated": False,
+        },
+    )
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: (
+            [
+                {"id": "mov-library_movies", "name": "Movies"},
+                {"id": "mov-library_target", "name": "Other Movies"},
+            ],
+            [],
+            {},
+        ),
+    )
+
+    with app.test_request_context("/copy_library_settings"):
+        session["config_name"] = config_name
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/copy_library_settings",
+        json={
+            "source_library_id": "mov-library_movies",
+            "target_library_ids": ["mov-library_target"],
+            "source_payload": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-collection_content_rating_us": True,
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["source_included"] is True
+    assert payload["included_targets"] == ["mov-library_target"]
+    assert payload["review_targets"] == []
+    assert payload["mirror_report"][0]["status"] == "included"
+
+    _validated, _user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    libraries = stored["libraries"]
+    assert libraries["mov-library_target-library"] == "Other Movies"
+    assert "Other Movies" in libraries["libraries"]
+
+
+def test_copy_library_settings_reports_placeholder_missing_from_target(client, isolated_config_dir, monkeypatch, app, qs_module, library_routes_module):
+    from modules import database
+    from flask import session
+
+    config_name = "pytest_copy_placeholder_report"
+    database.save_section_data(
+        section="libraries",
+        validated=False,
+        user_entered=True,
+        name=config_name,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_use_separator": "gray",
+                "mov-library_movies-attribute_template_variables[placeholder_tmdb_movie]": "603",
+                "libraries": "Movies",
+            },
+            "validated": False,
+        },
+    )
+    monkeypatch.setattr(
+        library_routes_module,
+        "_build_library_lists",
+        lambda: (
+            [
+                {"id": "mov-library_movies", "name": "Movies"},
+                {"id": "mov-library_target", "name": "Movies 4K"},
+            ],
+            [],
+            {},
+        ),
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_lookup_tmdb_numeric_id",
+        lambda value, media_type="": {"valid": True, "verified": True, "label": "The Matrix", "result_type": "movie"},
+    )
+    monkeypatch.setattr(qs_module.helpers, "find_item_by_title", lambda library_name, title: None)
+
+    with app.test_request_context("/copy_library_settings"):
+        session["config_name"] = config_name
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/copy_library_settings",
+        json={
+            "source_library_id": "mov-library_movies",
+            "target_library_ids": ["mov-library_target"],
+            "source_payload": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_use_separator": "gray",
+                "mov-library_movies-attribute_template_variables[placeholder_tmdb_movie]": "603",
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["included_targets"] == []
+    assert payload["review_targets"] == ["mov-library_target"]
+    assert payload["mirror_report"][0]["status"] == "needs_review"
+    assert "The Matrix" in payload["mirror_report"][0]["issues"][0]
+
+    _validated, _user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert stored["libraries"]["mov-library_target-library"] == ""
 
 
 def test_copy_library_settings_preserves_unloaded_lazy_source_sections(client, isolated_config_dir, monkeypatch, app, library_routes_module):
@@ -6091,7 +6229,7 @@ def test_copy_library_settings_preserves_unloaded_lazy_source_sections(client, i
     assert libraries["mov-library_movies-attribute_language"] == "fr"
     assert libraries["mov-library_movies-template_collection_award_style"] == "signature"
     assert libraries["mov-library_movies-movie-template_overlay_resolution[horizontal_align]"] == "right"
-    assert libraries["mov-library_target-library"] == ""
+    assert libraries["mov-library_target-library"] == "Other Movies"
     assert libraries["mov-library_target-playlist"] is True
     assert libraries["mov-library_target-attribute_language"] == "fr"
     assert libraries["mov-library_target-collection_award"] is True


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1700 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

- Improve library mirroring so the Include in config state is handled safely:
  - if the source library is excluded, mirrored targets stay excluded
  - if the source library is included, Quickstart auto-includes only targets that pass mirror preflight checks
  - targets that cannot be safely included remain excluded and are reported with reasons
- Add mirror reporting in the UI so users can see which targets were included and which need review.
- Validate mirrored separator placeholder IDs against the target Plex library when possible, so cases like a movie/show placeholder missing from the mirrored target are surfaced instead of silently enabling a bad config.
- Replace the changing Show Advanced / Hide Advanced button with a stable Show Advanced switch.
  - switch on shows advanced sections
  - switch off hides advanced sections
  - initial switch state is derived from whether advanced modifications exist, not persisted UI state

Closes #1700

## Testing

- `node --check static\local-js\025-libraries.js`
- `python -m pytest tests\test_collection_details_contract.py -k "advanced_toggle"`
- `python -m pytest tests\test_core_backend.py -k "copy_library_settings"`
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791582055&installation_model_id=431096&pr_number=1810&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1810&signature=07a1c70f483d6758e03c69ed9aae825d0365b439641667afc4096cbd8a8a9a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->