### PR TITLE
Adds scoped bulk control

### DIFF
--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6494,6 +6494,7 @@ function initializeLibraryCardControls (card, libraryId) {
     initRelativeYearInputs(card)
     initScheduleBuilders(card)
     initLibraryAssetDirectoryInputs(card)
+    wireChildToggleBulkActions(card)
     wireOffsetReset(card)
     wireRatingsOffsetSync(card)
     initSortablesInScope(card)
@@ -7409,6 +7410,7 @@ wireOverlayTemplateSections()
 wireCollectionTemplateSections()
 wireOverlayVariableSections()
 wireCollectionVariableSections()
+wireChildToggleBulkActions()
 wireRatingsOffsetSync()
 
 document.addEventListener('click', (e) => {
@@ -8260,6 +8262,70 @@ async function runCollectionGroupReset (btn, group, options = {}) {
     btn.dataset.resetBusy = 'false'
     setLibrariesButtonPersistentBusy(btn, false)
   }
+}
+
+async function runChildToggleBulkAction (btn, checked) {
+  if (!btn || btn.dataset.bulkBusy === 'true') return
+
+  const section = btn.closest('[data-collection-variable-section="true"], [data-overlay-variable-section="true"]')
+  const sectionBody = section?.querySelector('.collection-variable-section-body, .overlay-variable-section-body') || section
+  if (!sectionBody) return
+
+  const toggles = Array.from(sectionBody.querySelectorAll('input.template-child-toggle[type="checkbox"]'))
+    .filter(input => !input.disabled)
+  if (!toggles.length) return
+
+  const sectionLabel = section?.querySelector('.fw-semibold')?.textContent?.trim() || 'section'
+  const idleLabel = btn.dataset.bulkIdleLabel || btn.textContent.trim()
+  btn.dataset.bulkIdleLabel = idleLabel
+  btn.dataset.bulkBusy = 'true'
+  setLibrariesButtonPersistentBusy(btn, true, checked ? 'Selecting...' : 'Clearing...')
+
+  try {
+    await new Promise(resolve => requestAnimationFrame(() => resolve()))
+
+    const changed = []
+    for (let index = 0; index < toggles.length; index += 1) {
+      const input = toggles[index]
+      if (input.checked === checked) continue
+      input.checked = checked
+      changed.push(input)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+      if (index > 0 && index % 25 === 0) {
+        await new Promise(resolve => window.setTimeout(resolve, 0))
+      }
+    }
+
+    refreshTemplateOverrideState(section.closest('.template-toggle-group') || section)
+    updateAccordionHighlights()
+    if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
+      ValidationHandler.updateValidationState()
+    }
+    if (typeof showToast === 'function') {
+      const action = checked ? 'Selected' : 'Unselected'
+      showToast('info', `${action} ${changed.length} item${changed.length === 1 ? '' : 's'} in ${sectionLabel}.`)
+    }
+  } finally {
+    btn.dataset.bulkBusy = 'false'
+    setLibrariesButtonPersistentBusy(btn, false)
+  }
+}
+
+function wireChildToggleBulkActions (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-child-toggle-bulk-action]').forEach(btn => {
+    if (btn.dataset.listenerAdded === 'true') return
+    btn.addEventListener('click', () => {
+      runChildToggleBulkAction(btn, btn.dataset.childToggleBulkAction === 'select').catch(error => {
+        console.error('[child toggle bulk action failed]', error)
+        if (typeof showToast === 'function') {
+          showToast('error', 'Bulk toggle action failed.')
+        }
+      })
+    })
+    btn.dataset.listenerAdded = 'true'
+  })
 }
 
 function wireOffsetReset (scope) {

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1351,6 +1351,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% for render_group in render_groups.items %}
                         {% if not render_group.flat %}
                         {% set section_body_id = collection_details_id ~ '-section-' ~ render_group.id %}
+                        {% set has_child_bulk_actions = render_group.id in ['included_items', 'child_collections', 'child_defaults', 'child_override_maps'] %}
                         <div class="border rounded p-2 mb-3 collection-variable-section" data-collection-variable-section="true"
                             data-section-id="{{ render_group.id }}">
                             <div class="d-flex align-items-center justify-content-between gap-2 flex-wrap mb-2">
@@ -1375,7 +1376,19 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 data-detail-section="true"
                                 data-default-open="{{ 'true' if render_group.default_open else 'false' }}"
                                 style="display: {{ 'block' if render_group.default_open else 'none' }};">
-                                <div class="d-flex justify-content-end mb-2">
+                                <div class="d-flex justify-content-end gap-2 flex-wrap mb-2">
+                                    {% if has_child_bulk_actions %}
+                                    <button type="button"
+                                        class="btn btn-sm btn-outline-secondary btn-overlay"
+                                        data-child-toggle-bulk-action="select">
+                                        Select all
+                                    </button>
+                                    <button type="button"
+                                        class="btn btn-sm btn-outline-secondary btn-overlay"
+                                        data-child-toggle-bulk-action="unselect">
+                                        Unselect all
+                                    </button>
+                                    {% endif %}
                                     <button type="button"
                                         class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn"
                                         data-collection-variable-section-reset="true">
@@ -2229,6 +2242,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                 {% for render_group in overlay_render_groups %}
                                                 {% if not render_group.flat %}
                                                 {% set render_group_body_id = template_name ~ '-' ~ render_group.id ~ '-section-body' %}
+                                                {% set has_child_bulk_actions = render_group.id in ['included_items', 'child_collections', 'child_defaults', 'child_override_maps'] %}
                                                 <div class="border rounded p-2 mb-3 collection-variable-section overlay-variable-section"
                                                     data-overlay-variable-section="true"
                                                     data-overlay-variable-section-id="{{ render_group.id }}">
@@ -2254,7 +2268,19 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                         data-detail-section="true"
                                                         data-default-open="{{ 'true' if render_group.default_open else 'false' }}"
                                                         style="display: {{ 'block' if render_group.default_open else 'none' }};">
-                                                        <div class="d-flex justify-content-end mb-2">
+                                                        <div class="d-flex justify-content-end gap-2 flex-wrap mb-2">
+                                                            {% if has_child_bulk_actions %}
+                                                            <button type="button"
+                                                                class="btn btn-sm btn-outline-secondary btn-overlay"
+                                                                data-child-toggle-bulk-action="select">
+                                                                Select all
+                                                            </button>
+                                                            <button type="button"
+                                                                class="btn btn-sm btn-outline-secondary btn-overlay"
+                                                                data-child-toggle-bulk-action="unselect">
+                                                                Unselect all
+                                                            </button>
+                                                            {% endif %}
                                                             <button type="button"
                                                                 class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn"
                                                                 data-overlay-variable-section-reset="true">

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -61,6 +61,23 @@ def test_libraries_script_wires_collection_detail_toggles():
     assert "[data-collection-field-wrapper]" in script
 
 
+def test_child_toggle_sections_have_bulk_select_controls():
+    macros = MACROS_PATH.read_text(encoding="utf-8")
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert 'data-child-toggle-bulk-action="select"' in macros
+    assert 'data-child-toggle-bulk-action="unselect"' in macros
+    assert "render_group.id in ['included_items', 'child_collections', 'child_defaults', 'child_override_maps']" in macros
+    assert "Select all" in macros
+    assert "Unselect all" in macros
+    assert "function runChildToggleBulkAction" in script
+    assert "function wireChildToggleBulkActions" in script
+    assert 'input.template-child-toggle[type="checkbox"]' in script
+    assert "btn.dataset.childToggleBulkAction === 'select'" in script
+    assert "wireChildToggleBulkActions(card)" in script
+    assert "wireChildToggleBulkActions()" in script
+
+
 def test_event_handler_does_not_scan_selects_inside_input_loop():
     script = EVENT_HANDLER_JS_PATH.read_text(encoding="utf-8")
     attach_section = script.split("initializeOverlays(libraryId, isMovie)", 1)[1]


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds scoped bulk controls for long child/included-item sections on the Libraries page.

Changes:
- Adds `Select all` and `Unselect all` buttons to generated collection/overlay variable sections.
- Limits those controls to child-style sections only:
  - `included_items`
  - `child_collections`
  - `child_defaults`
  - `child_override_maps`
- Wires the buttons to affect only enabled `.template-child-toggle` checkboxes inside the current section.
- Refreshes override summaries, accordion highlights, and validation state after bulk changes.
- Adds contract coverage for the generated controls and JS wiring.

Validation:
- `node --check static\local-js\025-libraries.js`
- `python -m pytest tests\test_collection_details_contract.py`

Result:
- `31 passed`
## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791583959&installation_model_id=431096&pr_number=1811&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1811&signature=7fd4c96a9456ff25cc07231267a4e47d99a5c1194ccce278dd3a98039dba5e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->