### PR TITLE
Kometa ready ornot

### DIFF
--- a/modules/workspace_rollups.py
+++ b/modules/workspace_rollups.py
@@ -295,8 +295,8 @@ def _workspace_step_status_from_app_readiness(state):
     normalized = str(state or "").strip().lower()
     if normalized in {"ready", "review", "running", "queued"}:
         return "ok"
-    if normalized == "needs_validation":
+    if normalized in {"needs_validation", "needs_prepare"}:
         return "warn"
-    if normalized in {"needs_prepare", "needs_setup", "blocked", "error"}:
+    if normalized in {"needs_setup", "blocked", "error"}:
         return "error"
     return "unknown"

--- a/modules/workspace_status.py
+++ b/modules/workspace_status.py
@@ -64,6 +64,7 @@ from modules.imagemaid import (
 )
 from modules.kometa_install import (
     build_kometa_install_context as _build_kometa_install_context,
+    probe_kometa_root_state as _probe_kometa_root_state,
 )
 
 # Constants extracted to modules.workspace_status_constants. Re-exported here.
@@ -152,14 +153,44 @@ def _build_workspace_app_readiness_from_status(config_name, workspace_status, te
         detail = "Open Kometa to validate, review, download, prepare, or run this config."
         if install_context.get("kometa_is_external_install"):
             detail = "Open Kometa to validate, review, download, and sync this config for your external Kometa install."
-        kometa.update(
-            state="ready",
-            summary="Ready",
-            detail=detail,
-            action_label="Open Kometa",
-            href=_step_href("900-kometa"),
-            target_step="900-kometa",
-        )
+            kometa.update(
+                state="review",
+                summary="Sync config",
+                detail=detail,
+                action_label="Open Kometa",
+                href=_step_href("900-kometa"),
+                target_step="900-kometa",
+                installed=False,
+                prepared=False,
+            )
+        else:
+            root_path = install_context.get("kometa_selected_root") or install_context.get("kometa_primary_path")
+            runtime_state = {}
+            if root_path:
+                try:
+                    runtime_state = _probe_kometa_root_state(root_path)
+                except Exception:
+                    runtime_state = {}
+            installed = bool(runtime_state.get("kometa_installed"))
+            prepared = bool(runtime_state.get("venv_python_exists"))
+            kometa.update(
+                state="ready" if installed and prepared else "review",
+                summary="Ready to run" if installed and prepared else ("Prepare Kometa" if installed else "Install Kometa"),
+                detail=(
+                    "Open Kometa to review the command preview and run this config."
+                    if installed and prepared
+                    else (
+                        "Open Kometa to prepare the Python environment before running this config."
+                        if installed
+                        else "Open Kometa to download/install Kometa before running this config."
+                    )
+                ),
+                action_label="Open Kometa",
+                href=_step_href("900-kometa"),
+                target_step="900-kometa",
+                installed=installed,
+                prepared=prepared,
+            )
 
     imagemaid_settings, imagemaid_section = _get_imagemaid_settings_section(config_name)
     imagemaid_state = _probe_imagemaid_root_state(helpers.get_imagemaid_root_path())

--- a/modules/workspace_status.py
+++ b/modules/workspace_status.py
@@ -174,7 +174,7 @@ def _build_workspace_app_readiness_from_status(config_name, workspace_status, te
             installed = bool(runtime_state.get("kometa_installed"))
             prepared = bool(runtime_state.get("venv_python_exists"))
             kometa.update(
-                state="ready" if installed and prepared else "review",
+                state="ready" if installed and prepared else "needs_prepare",
                 summary="Ready to run" if installed and prepared else ("Prepare Kometa" if installed else "Install Kometa"),
                 detail=(
                     "Open Kometa to review the command preview and run this config."

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -618,6 +618,7 @@ let qsLogscanReingestPollInFlight = false
 let qsImageMaidPollInFlight = false
 let qsBackgroundJobsPollInFlight = false
 let qsAppReadinessPollInFlight = false
+let qsAppReadinessRequest = null
 let qsBulkValidationPollInFlight = false
 let qsKometaProgressPollInFlight = false
 
@@ -1393,9 +1394,9 @@ function qsFormatAppReadinessSnippet (entry) {
     case 'queued':
       return `${name} queued`
     case 'needs_validation':
-      return `${name} needs validation`
+      return `${name}: ${summary || 'needs validation'}`
     case 'needs_prepare':
-      return `${name} needs preparation`
+      return `${name}: ${summary || 'needs preparation'}`
     case 'blocked':
     case 'needs_setup':
     case 'error':
@@ -1463,7 +1464,8 @@ function qsRenderAppReadiness () {
   const availableEntries = entries.filter(entry => qsIsAppReadinessAvailable(entry))
   const runningEntries = entries.filter(entry => qsGetAppReadinessState(entry) === 'running')
   const validationEntries = entries.filter(entry => qsGetAppReadinessState(entry) === 'needs_validation')
-  const setupEntries = entries.filter((entry) => ['needs_setup', 'needs_prepare', 'blocked', 'error'].includes(qsGetAppReadinessState(entry)))
+  const prepareEntries = entries.filter(entry => qsGetAppReadinessState(entry) === 'needs_prepare')
+  const setupEntries = entries.filter((entry) => ['needs_setup', 'blocked', 'error'].includes(qsGetAppReadinessState(entry)))
 
   let lineState = 'unknown'
   let lineText = 'Apps: checking status...'
@@ -1477,10 +1479,10 @@ function qsRenderAppReadiness () {
     lineState = 'warn'
     lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
     groupMetaText = `${availableEntries.length} Available`
-  } else if (validationEntries.length > 0) {
+  } else if (validationEntries.length > 0 || prepareEntries.length > 0) {
     lineState = 'warn'
     lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
-    groupMetaText = 'Validate'
+    groupMetaText = validationEntries.length > 0 ? 'Validate' : 'Prepare'
   } else if (setupEntries.length > 0) {
     lineState = 'error'
     lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
@@ -1508,8 +1510,48 @@ function qsRenderAppReadiness () {
   qsSetStepGroupIndicatorState(appsGroup, lineState)
 }
 
-function qsRefreshAppReadiness () {
-  qsRenderAppReadiness()
+function qsFetchAppReadiness () {
+  if (qsAppReadinessRequest) return qsAppReadinessRequest
+
+  qsAppReadinessPollInFlight = true
+  qsAppReadinessRequest = fetch(`/workspace_app_readiness?_=${Date.now()}`, {
+    method: 'GET',
+    cache: 'no-store',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' }
+  })
+    .then(res => res.json())
+    .then((data) => {
+      qsLatestAppReadiness = data
+      qsRenderAppReadiness()
+      return data
+    })
+    .catch(() => null)
+    .finally(() => {
+      qsAppReadinessPollInFlight = false
+      qsAppReadinessRequest = null
+    })
+
+  return qsAppReadinessRequest
+}
+
+function qsRefreshAppReadiness (options = {}) {
+  const shouldFetch = options === true || Boolean(options.fetch || options.immediate)
+  if (!shouldFetch) {
+    qsRenderAppReadiness()
+    return Promise.resolve(qsLatestAppReadiness)
+  }
+
+  const requests = [qsFetchAppReadiness()]
+  if (options.workspaceStatus !== false && typeof qsRefreshWorkspaceStatus === 'function') {
+    requests.push(qsRefreshWorkspaceStatus({
+      immediate: true,
+      configName: options.configName || ''
+    }))
+  }
+
+  return Promise.allSettled(requests)
+    .then(() => qsLatestAppReadiness)
 }
 
 window.QS_refreshAppReadiness = qsRefreshAppReadiness
@@ -1569,17 +1611,7 @@ window.QS_refreshAppReadiness = qsRefreshAppReadiness
 ;(function qsAppReadinessPoll () {
   const poll = () => {
     if (!qsShouldPollBackgroundState() || qsAppReadinessPollInFlight) return
-    qsAppReadinessPollInFlight = true
-    fetch('/workspace_app_readiness')
-      .then(res => res.json())
-      .then((data) => {
-        qsLatestAppReadiness = data
-        qsRenderAppReadiness()
-      })
-      .catch(() => {})
-      .finally(() => {
-        qsAppReadinessPollInFlight = false
-      })
+    qsFetchAppReadiness()
   }
   setTimeout(poll, 900)
   setInterval(poll, QS_APP_READINESS_POLL_INTERVAL_MS)

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -1383,10 +1383,11 @@ function qsHydrateImageMaidReadiness (entry) {
 function qsFormatAppReadinessSnippet (entry) {
   const state = qsGetAppReadinessState(entry)
   const name = String((entry && entry.name) || 'App').trim()
+  const summary = String((entry && entry.summary) || '').trim()
   switch (state) {
     case 'ready':
     case 'review':
-      return `${name} ready`
+      return `${name}: ${summary || 'available'}`
     case 'running':
       return `${name} running`
     case 'queued':
@@ -1398,9 +1399,9 @@ function qsFormatAppReadinessSnippet (entry) {
     case 'blocked':
     case 'needs_setup':
     case 'error':
-      return `${name}: ${String((entry && entry.summary) || 'needs attention').trim()}`
+      return `${name}: ${summary || 'needs attention'}`
     default:
-      return `${name}: ${String((entry && entry.summary) || 'checking status').trim()}`
+      return `${name}: ${summary || 'checking status'}`
   }
 }
 
@@ -1470,16 +1471,12 @@ function qsRenderAppReadiness () {
 
   if (availableEntries.length === entries.length) {
     lineState = 'ok'
-    if (entries.length === 1) {
-      lineText = `Apps: ${entries[0].name} is ready.`
-    } else {
-      lineText = `Apps: ${entries.map(entry => entry.name).join(' and ')} are ready.`
-    }
-    groupMetaText = runningEntries.length > 0 ? `${runningEntries.length} Running` : `${availableEntries.length} Ready`
+    lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
+    groupMetaText = runningEntries.length > 0 ? `${runningEntries.length} Running` : `${availableEntries.length} Available`
   } else if (availableEntries.length > 0) {
     lineState = 'warn'
     lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
-    groupMetaText = `${availableEntries.length} Ready`
+    groupMetaText = `${availableEntries.length} Available`
   } else if (validationEntries.length > 0) {
     lineState = 'warn'
     lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -236,6 +236,12 @@ function setText (el, text) {
   if (el) el.textContent = text
 }
 
+function refreshSidebarAppReadiness () {
+  if (typeof window !== 'undefined' && typeof window.QS_refreshAppReadiness === 'function') {
+    window.QS_refreshAppReadiness({ fetch: true })
+  }
+}
+
 function shortSha (value) {
   const text = String(value || '').trim()
   return text ? text.slice(0, 12) : ''
@@ -940,6 +946,7 @@ function probeRoot () {
         updateCheckCompleted: imagemaidUpdateCheckCompleted,
         updateCheckSkipped: imagemaidUpdateCheckSkipped
       })
+      refreshSidebarAppReadiness()
     })
     .catch(() => {
       setInstallState('error', 'ImageMaid probe failed.')
@@ -1101,9 +1108,11 @@ function validateImageMaid () {
       updateModeHelp()
       if (ok && body.validated) {
         setValidationState('ok', 'ImageMaid is ready to run.')
+        refreshSidebarAppReadiness()
         return true
       } else {
         setValidationState('error', body.details || body.error || 'ImageMaid validation failed.')
+        refreshSidebarAppReadiness()
         return false
       }
     })
@@ -1113,6 +1122,7 @@ function validateImageMaid () {
       restoreFolderModeConflict = false
       updateModeHelp()
       setValidationState('error', 'ImageMaid validation failed.')
+      refreshSidebarAppReadiness()
       return false
     })
     .finally(() => {

--- a/static/local-js/modules/kometa/_validateRoot.js
+++ b/static/local-js/modules/kometa/_validateRoot.js
@@ -71,6 +71,12 @@ function readValidationFlag (id, key) {
   return el ? el.dataset[key] : ''
 }
 
+function refreshSidebarAppReadiness () {
+  if (typeof window !== 'undefined' && typeof window.QS_refreshAppReadiness === 'function') {
+    window.QS_refreshAppReadiness({ fetch: true })
+  }
+}
+
 /**
  * Check whether Kometa is validated. See module docstring for full
  * contract.
@@ -241,6 +247,7 @@ export function validateKometaRoot (options = {}) {
     updateRunNowState()
     syncUpdateButtonLabel()
     syncKometaRollupBadge()
+    refreshSidebarAppReadiness()
     if (typeof hideNavigationLoadingOverlay === 'function') {
       hideNavigationLoadingOverlay()
     }

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -47,13 +47,13 @@
                     <div class="fw-semibold">Kometa workflow</div>
                   </div>
                   <span class="start-app-state start-app-state-{{ 'ready' if kometa_ready else 'pending' }}">
-                    {{ 'Ready' if kometa_ready else 'Setup needed' }}
+                    {{ 'Available' if kometa_ready else 'Setup needed' }}
                   </span>
                 </div>
                 {% if kometa_ready %}
-                <p class="small text-muted mb-3">This config has a saved, valid Kometa workflow choice. Open Kometa when you want to validate, review, download, prepare, or run it.</p>
+                <p class="small text-muted mb-3">This config can continue on the Kometa page. Open Kometa to validate, review, download, prepare, or run it.</p>
                 {% else %}
-                <p class="small text-muted mb-3">Save a valid Kometa install ownership choice and finish required setup before this workflow is ready.</p>
+                <p class="small text-muted mb-3">Save a valid Kometa install ownership choice and finish required setup before opening the Kometa workflow.</p>
                 {% endif %}
                 <div class="border rounded p-3 mb-3" id="start-kometa-install-settings"
                   data-install-mode="{{ page_info.kometa_install_mode }}"
@@ -144,7 +144,7 @@
                     <div class="fw-semibold">ImageMaid workflow</div>
                   </div>
                   <span class="start-app-state start-app-state-{{ 'ready' if imagemaid_ready else 'pending' }}">
-                    {{ 'Ready' if imagemaid_ready else 'Setup needed' }}
+                    {{ 'Ready to run' if imagemaid_ready else 'Setup needed' }}
                   </span>
                 </div>
                 {% if imagemaid_ready %}

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -1,4 +1,10 @@
+from pathlib import Path
+
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE_JS_PATH = ROOT / "static" / "local-js" / "000-base.js"
+START_TEMPLATE_PATH = ROOT / "templates" / "001-start.html"
 
 TAUTULLI_COLLECTION_KEY = "mov-library_movies-collection_tautulli"
 TRAKT_COLLECTION_KEY = "sho-library_tv-collection_trakt"
@@ -602,7 +608,20 @@ def test_workspace_app_readiness_kometa_freshness_stays_ready(monkeypatch, qs_mo
             "todo_blockers": [],
         },
     )
-    monkeypatch.setattr(workspace_status_module, "_build_kometa_install_context", lambda _name: {})
+    monkeypatch.setattr(
+        workspace_status_module,
+        "_build_kometa_install_context",
+        lambda _name: {
+            "kometa_selected_root": "/srv/kometa",
+            "kometa_primary_path": "/srv/kometa",
+            "kometa_is_external_install": False,
+        },
+    )
+    monkeypatch.setattr(
+        workspace_status_module,
+        "_probe_kometa_root_state",
+        lambda _path: {"kometa_installed": True, "venv_python_exists": True},
+    )
     monkeypatch.setattr(workspace_status_module, "_get_imagemaid_settings_section", lambda _name: ({}, {}))
     monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: "")
     monkeypatch.setattr(workspace_status_module, "_probe_imagemaid_root_state", lambda _path: {})
@@ -612,8 +631,53 @@ def test_workspace_app_readiness_kometa_freshness_stays_ready(monkeypatch, qs_mo
     payload = qs_module._build_workspace_app_readiness("cfg")
 
     assert payload["kometa"]["state"] == "ready"
-    assert payload["kometa"]["summary"] == "Ready"
+    assert payload["kometa"]["summary"] == "Ready to run"
+    assert payload["kometa"]["installed"] is True
+    assert payload["kometa"]["prepared"] is True
     assert payload["kometa"]["action_label"] == "Open Kometa"
+    assert payload["kometa"]["href"] == "/step/900-kometa"
+
+
+def test_workspace_app_readiness_kometa_managed_not_installed_says_install(monkeypatch, qs_module, workspace_status_module):
+    monkeypatch.setattr(qs_module.helpers, "get_menu_list", _template_list)
+    monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
+    monkeypatch.setattr(workspace_status_module, "_build_workspace_status_context", lambda *_args, **_kwargs: {"readiness": {}})
+    monkeypatch.setattr(
+        workspace_status_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "freshness",
+            "todo_count": 0,
+            "todo_blockers": [],
+        },
+    )
+    monkeypatch.setattr(
+        workspace_status_module,
+        "_build_kometa_install_context",
+        lambda _name: {
+            "kometa_selected_root": "/srv/kometa",
+            "kometa_primary_path": "/srv/kometa",
+            "kometa_is_external_install": False,
+        },
+    )
+    monkeypatch.setattr(
+        workspace_status_module,
+        "_probe_kometa_root_state",
+        lambda _path: {"kometa_installed": False, "venv_python_exists": False},
+    )
+    monkeypatch.setattr(workspace_status_module, "_get_imagemaid_settings_section", lambda _name: ({}, {}))
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: "")
+    monkeypatch.setattr(workspace_status_module, "_probe_imagemaid_root_state", lambda _path: {})
+    monkeypatch.setattr(qs_module.database, "retrieve_section_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(workspace_status_module, "_validate_imagemaid_settings", lambda *_args, **_kwargs: (False, "", ""))
+
+    payload = qs_module._build_workspace_app_readiness("cfg")
+
+    assert payload["kometa"]["state"] == "review"
+    assert payload["kometa"]["summary"] == "Install Kometa"
+    assert payload["kometa"]["installed"] is False
+    assert payload["kometa"]["prepared"] is False
+    assert "download/install Kometa" in payload["kometa"]["detail"]
     assert payload["kometa"]["href"] == "/step/900-kometa"
 
 
@@ -658,6 +722,19 @@ def test_workspace_app_readiness_route_returns_app_payload(client, monkeypatch, 
     assert payload["config_name"] == "cfg"
     assert payload["apps"]["kometa"]["summary"] == "Config cfg ready"
     assert payload["apps"]["imagemaid"]["summary"] == "Prepare ImageMaid"
+
+
+def test_app_readiness_menu_uses_available_and_app_summaries():
+    script = BASE_JS_PATH.read_text(encoding="utf-8")
+    start_template = START_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert "return `${name}: ${summary || 'available'}`" in script
+    assert "entries.map(qsFormatAppReadinessSnippet).join('; ')" in script
+    assert "`${availableEntries.length} Available`" in script
+    assert "Apps: ${entries[0].name} is ready" not in script
+    assert "Apps: ${entries.map(entry => entry.name).join(' and ')} are ready" not in script
+    assert "{{ 'Available' if kometa_ready else 'Setup needed' }}" in start_template
+    assert "{{ 'Ready to run' if imagemaid_ready else 'Setup needed' }}" in start_template
 
 
 def test_workspace_context_promotes_trakt_to_required(monkeypatch, qs_module):

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -5,6 +5,8 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 BASE_JS_PATH = ROOT / "static" / "local-js" / "000-base.js"
 START_TEMPLATE_PATH = ROOT / "templates" / "001-start.html"
+IMAGEMAID_JS_PATH = ROOT / "static" / "local-js" / "915-imagemaid.js"
+KOMETA_VALIDATE_JS_PATH = ROOT / "static" / "local-js" / "modules" / "kometa" / "_validateRoot.js"
 
 TAUTULLI_COLLECTION_KEY = "mov-library_movies-collection_tautulli"
 TRAKT_COLLECTION_KEY = "sho-library_tv-collection_trakt"
@@ -673,12 +675,31 @@ def test_workspace_app_readiness_kometa_managed_not_installed_says_install(monke
 
     payload = qs_module._build_workspace_app_readiness("cfg")
 
-    assert payload["kometa"]["state"] == "review"
+    assert payload["kometa"]["state"] == "needs_prepare"
     assert payload["kometa"]["summary"] == "Install Kometa"
     assert payload["kometa"]["installed"] is False
     assert payload["kometa"]["prepared"] is False
     assert "download/install Kometa" in payload["kometa"]["detail"]
     assert payload["kometa"]["href"] == "/step/900-kometa"
+
+
+def test_workspace_status_context_marks_prepare_needed_apps_warn(monkeypatch, qs_module, workspace_status_module):
+    monkeypatch.setattr(qs_module.database, "retrieve_config_sections", lambda _name: [])
+    monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
+    template_list = _template_list() + [("915-imagemaid.html", "ImageMaid")]
+
+    def fake_app_readiness(_config_name, workspace_status, template_list=None):
+        return {
+            "kometa": {"state": "needs_prepare"},
+            "imagemaid": {"state": "needs_prepare"},
+        }
+
+    monkeypatch.setattr(workspace_status_module, "_build_workspace_app_readiness_from_status", fake_app_readiness)
+
+    ctx = qs_module._build_workspace_status_context("cfg", template_list, available_configs=["cfg"])
+
+    assert ctx["step_statuses"]["900-kometa"] == "warn"
+    assert ctx["step_statuses"]["915-imagemaid"] == "warn"
 
 
 def test_workspace_status_context_aligns_app_steps_with_app_readiness(monkeypatch, qs_module, workspace_status_module):
@@ -729,12 +750,26 @@ def test_app_readiness_menu_uses_available_and_app_summaries():
     start_template = START_TEMPLATE_PATH.read_text(encoding="utf-8")
 
     assert "return `${name}: ${summary || 'available'}`" in script
+    assert "return `${name}: ${summary || 'needs preparation'}`" in script
     assert "entries.map(qsFormatAppReadinessSnippet).join('; ')" in script
     assert "`${availableEntries.length} Available`" in script
+    assert "const prepareEntries = entries.filter(entry => qsGetAppReadinessState(entry) === 'needs_prepare')" in script
+    assert "groupMetaText = validationEntries.length > 0 ? 'Validate' : 'Prepare'" in script
     assert "Apps: ${entries[0].name} is ready" not in script
     assert "Apps: ${entries.map(entry => entry.name).join(' and ')} are ready" not in script
     assert "{{ 'Available' if kometa_ready else 'Setup needed' }}" in start_template
     assert "{{ 'Ready to run' if imagemaid_ready else 'Setup needed' }}" in start_template
+
+
+def test_app_install_flows_refresh_sidebar_readiness():
+    base_script = BASE_JS_PATH.read_text(encoding="utf-8")
+    imagemaid_script = IMAGEMAID_JS_PATH.read_text(encoding="utf-8")
+    kometa_validate_script = KOMETA_VALIDATE_JS_PATH.read_text(encoding="utf-8")
+
+    assert "fetch(`/workspace_app_readiness?_=${Date.now()}`" in base_script
+    assert "qsRefreshWorkspaceStatus({" in base_script
+    assert "window.QS_refreshAppReadiness({ fetch: true })" in imagemaid_script
+    assert "window.QS_refreshAppReadiness({ fetch: true })" in kometa_validate_script
 
 
 def test_workspace_context_promotes_trakt_to_required(monkeypatch, qs_module):


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1694 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
- Refresh app readiness from the server after Kometa validation/install/update and ImageMaid install/prepare/validation state changes.
- Upgrade `QS_refreshAppReadiness({ fetch: true })` so it fetches fresh `/workspace_app_readiness` and refreshes `/workspace_status`, keeping sidebar app rows and group badges current without a page reload.
- Add a contract test to prevent the refresh hook from regressing back to cached-only rendering.

**Validation**
- `node --check static\local-js\000-base.js`
- `node --check static\local-js\915-imagemaid.js`
- `node --check static\local-js\modules\kometa\_validateRoot.js`
- `python -m pytest tests\test_workspace_dependency_logic.py -q`
- `npx.cmd eslint static/local-js/000-base.js static/local-js/915-imagemaid.js static/local-js/modules/kometa/_validateRoot.js`

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791589435&installation_model_id=431096&pr_number=1812&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1812&signature=b7f961e162eea3c08161263d7d97fed5afd34b970bcb259e8c4cee1cbdab0afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->