### PR TITLE
accordion fix

### DIFF
--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -548,8 +548,7 @@
             </span>
           </button>
         </h2>
-        <div id="collapse-mode" class="accordion-collapse collapse" aria-labelledby="heading-mode"
-          data-bs-parent="#run-command-accordion">
+        <div id="collapse-mode" class="accordion-collapse collapse" aria-labelledby="heading-mode">
           <div class="accordion-body">
             <div class="form-check form-switch mb-2">
               <input class="form-check-input" type="checkbox" id="show-cli-toggle">
@@ -570,8 +569,7 @@
             </span>
           </button>
         </h2>
-        <div id="collapse-runopt" class="accordion-collapse collapse" aria-labelledby="heading-runopt"
-          data-bs-parent="#run-command-accordion">
+        <div id="collapse-runopt" class="accordion-collapse collapse" aria-labelledby="heading-runopt">
           <div class="accordion-body">
             <fieldset>
               <div class="form-check form-check-inline">
@@ -639,8 +637,7 @@
             </span>
           </button>
         </h2>
-        <div id="collapse-modeflags" class="accordion-collapse collapse" aria-labelledby="heading-modeflags"
-          data-bs-parent="#run-command-accordion">
+        <div id="collapse-modeflags" class="accordion-collapse collapse" aria-labelledby="heading-modeflags">
           <div class="accordion-body">
             <fieldset>
               <div class="form-check form-check-inline">
@@ -669,8 +666,7 @@
             </span>
           </button>
         </h2>
-        <div id="collapse-logflags" class="accordion-collapse collapse" aria-labelledby="heading-logflags"
-          data-bs-parent="#run-command-accordion">
+        <div id="collapse-logflags" class="accordion-collapse collapse" aria-labelledby="heading-logflags">
           <div class="accordion-body">
             <fieldset>
               <div class="form-check form-check-inline">
@@ -699,8 +695,7 @@
             </span>
           </button>
         </h2>
-        <div id="collapse-validationflags" class="accordion-collapse collapse" aria-labelledby="heading-validationflags"
-          data-bs-parent="#run-command-accordion">
+        <div id="collapse-validationflags" class="accordion-collapse collapse" aria-labelledby="heading-validationflags">
           <div class="accordion-body">
             <div class="alert alert-secondary small mb-3">
               Validation modes make Kometa validate and exit instead of running collections, overlays, operations, or schedules.
@@ -772,8 +767,7 @@
             </span>
           </button>
         </h2>
-        <div id="collapse-otherflags" class="accordion-collapse collapse" aria-labelledby="heading-otherflags"
-          data-bs-parent="#run-command-accordion">
+        <div id="collapse-otherflags" class="accordion-collapse collapse" aria-labelledby="heading-otherflags">
           <div class="accordion-body">
             <fieldset>
               <div class="row">

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -7,6 +7,7 @@ BASE_JS_PATH = ROOT / "static" / "local-js" / "000-base.js"
 START_TEMPLATE_PATH = ROOT / "templates" / "001-start.html"
 IMAGEMAID_JS_PATH = ROOT / "static" / "local-js" / "915-imagemaid.js"
 KOMETA_VALIDATE_JS_PATH = ROOT / "static" / "local-js" / "modules" / "kometa" / "_validateRoot.js"
+KOMETA_TEMPLATE_PATH = ROOT / "templates" / "900-kometa.html"
 
 TAUTULLI_COLLECTION_KEY = "mov-library_movies-collection_tautulli"
 TRAKT_COLLECTION_KEY = "sho-library_tv-collection_trakt"
@@ -60,6 +61,25 @@ def _section_row(section, *, validated=False, user_entered=False, data=None):
         "user_entered": user_entered,
         "data": data or {},
     }
+
+
+def test_kometa_run_command_accordion_allows_multiple_panels_open():
+    template = KOMETA_TEMPLATE_PATH.read_text(encoding="utf-8")
+    start = template.index('id="run-command-accordion"')
+    end = template.index('id="run-command-output-accordion"', start)
+    run_command_markup = template[start:end]
+
+    for collapse_id in [
+        "collapse-mode",
+        "collapse-runopt",
+        "collapse-modeflags",
+        "collapse-logflags",
+        "collapse-validationflags",
+        "collapse-otherflags",
+    ]:
+        collapse_start = run_command_markup.index(f'id="{collapse_id}"')
+        collapse_snippet = run_command_markup[collapse_start : collapse_start + 220]
+        assert 'data-bs-parent="#run-command-accordion"' not in collapse_snippet
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #1692 

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

- Keep Kometa Run Command Builder accordions independently expandable.
- Remove the shared Bootstrap accordion parent from the Kometa command option panels so opening one section no longer auto-closes another.
- Add a contract test to prevent the Kometa run-command accordion behavior from regressing.

## Testing

- `python -m pytest tests\test_workspace_dependency_logic.py -q`

Closes #1692
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791592287&installation_model_id=431096&pr_number=1813&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1813&signature=dfb1cb0b79976876810c2e5dfca92bb7a721dd8581f8376b718110d9e9eb785f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->