### PR TITLE
docker health-status

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -1386,9 +1386,21 @@ app.config["SESSION_USE_SIGNER"] = False
 app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16MB, adjust as needed
 app.config["MAX_FORM_MEMORY_SIZE"] = 16 * 1024 * 1024  # 16 MB
 
+SESSIONLESS_HEALTHCHECK_ENDPOINTS = {"kometa_status"}
+SESSIONLESS_HEALTHCHECK_PATHS = {"/kometa-status"}
+
+
+def _is_sessionless_healthcheck_request():
+    if request.method != "GET":
+        return False
+    return request.endpoint in SESSIONLESS_HEALTHCHECK_ENDPOINTS or request.path in SESSIONLESS_HEALTHCHECK_PATHS
+
 
 @app.before_request
 def before_request():
+    if _is_sessionless_healthcheck_request():
+        return None
+
     # Assign user UUID if not already present
     if "qs_session_id" not in session:
         session["qs_session_id"] = str(uuid.uuid4())[:8]
@@ -1473,6 +1485,16 @@ def check_quickstart_update():
 
 # Initialize Flask-Session
 server_session = Session(app)
+_save_server_session = app.session_interface.save_session
+
+
+def _save_session_unless_sessionless_healthcheck(app_obj, session_obj, response):
+    if has_request_context() and _is_sessionless_healthcheck_request():
+        return None
+    return _save_server_session(app_obj, session_obj, response)
+
+
+app.session_interface.save_session = _save_session_unless_sessionless_healthcheck
 server_thread = None
 shutdown_event = threading.Event()
 

--- a/tests/test_status_endpoint.py
+++ b/tests/test_status_endpoint.py
@@ -1,3 +1,6 @@
+from cachelib.file import FileSystemCache
+
+
 def test_kometa_status_has_expected_fields(client):
     resp = client.get("/kometa-status")
     assert resp.status_code == 200
@@ -15,3 +18,21 @@ def test_kometa_status_has_expected_fields(client):
         "pending_requested_at",
     ]:
         assert key in data
+
+
+def test_kometa_status_healthcheck_does_not_create_session_files(tmp_path, app, monkeypatch, qs_module):
+    session_dir = tmp_path / "flask_session"
+    session_cache = FileSystemCache(cache_dir=str(session_dir), threshold=500, default_timeout=3600)
+    monkeypatch.setattr(app.session_interface, "cache", session_cache)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_refresh_maintenance_window_availability", lambda **_: None)
+
+    healthcheck_client = app.test_client(use_cookies=False)
+    before_files = {path.relative_to(session_dir) for path in session_dir.rglob("*") if path.is_file()}
+    responses = [healthcheck_client.get("/kometa-status", headers={"User-Agent": "Docker-Healthcheck"}) for _ in range(3)]
+    after_files = {path.relative_to(session_dir) for path in session_dir.rglob("*") if path.is_file()}
+
+    assert [resp.status_code for resp in responses] == [200, 200, 200]
+    assert all("Set-Cookie" not in resp.headers for resp in responses)
+    assert after_files == before_files


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

- Make `GET /kometa-status` safe for Docker/Unraid healthchecks.
- Skip Quickstart’s request session initialization for the status endpoint.
- Skip Flask-Session persistence for the same endpoint so repeated healthcheck polling does not create session cookies or new Flask session files.
- Keep the existing Kometa status payload and stale PID cleanup behavior unchanged.

## Unraid / Docker Healthcheck

Suggested container healthcheck command:

```bash
curl -fsS http://127.0.0.1:7171/kometa-status >/dev/null || exit 1
```

Example Docker extra parameters:

```bash
--health-cmd="curl -fsS http://127.0.0.1:7171/kometa-status >/dev/null || exit 1" --health-interval=1m --health-timeout=10s --health-retries=3 --health-start-period=30s
```

Manual check from the Unraid terminal:

```bash
docker exec <container_name> curl -fsS http://127.0.0.1:7171/kometa-status
```

Check Docker health state:

```bash
docker inspect --format='{{.State.Health.Status}}' <container_name>
```

Note: this verifies that Quickstart is responding. A response where Kometa is `not started` is still a healthy Quickstart container.

## Testing

```powershell
python -m pytest tests\test_status_endpoint.py tests\test_even_more_paths.py::test_kometa_status_done_cleans_pid tests\test_even_more_paths.py::test_kometa_status_no_such_process_cleans_pid tests\test_next_set.py::test_kometa_status_reconnects_pid_file -q
```

Closes #1772 
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791595698&installation_model_id=431096&pr_number=1814&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1814&signature=33e0a075649d220d4682e46942bcaf7dc9686a4b6b2188c0f84990b6be7c2f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->