### PR TITLE
Fix strange update status

### DIFF
--- a/modules/helpers/_qs_update.py
+++ b/modules/helpers/_qs_update.py
@@ -11,6 +11,40 @@ from pathlib import Path
 from modules.helpers._constants import BUILDNUM_FILE, QS_UPDATE_CACHE_TTL_SECONDS, VERSION_FILE, _QS_UPDATE_CACHE
 
 
+def _run_git_remote(qs_root):
+    qs_root = Path(qs_root or ".").resolve()
+    is_windows = sys.platform.startswith("win")
+    return subprocess.run(
+        ["git", "remote"],
+        cwd=qs_root,
+        capture_output=True,
+        text=True,
+        shell=is_windows,
+    )
+
+
+def get_quickstart_update_remote(qs_root=None):
+    try:
+        remotes_out = _run_git_remote(qs_root or ".")
+        remotes = (remotes_out.stdout or "").split()
+    except Exception:
+        remotes = []
+    return "kometa-team" if "kometa-team" in remotes else "origin"
+
+
+def build_quickstart_update_command(branch="master", qs_root=None, remote=None):
+    branch = str(branch or "master").strip() or "master"
+    remote = str(remote or get_quickstart_update_remote(qs_root)).strip() or "origin"
+    remote_ref = f"{remote}/{branch}"
+    return (
+        f"git fetch {remote} --prune && "
+        f"git switch -C {branch} --track {remote_ref} && "
+        f"git reset --hard {remote_ref} && "
+        "python -m pip install --upgrade pip && "
+        "python -m pip install --no-cache-dir --upgrade -r requirements.txt"
+    )
+
+
 def get_kometa_branch():
     """Fetch the correct branch (master or nightly)."""
     version_info = check_for_update()
@@ -49,6 +83,7 @@ def check_for_update():
     remote_version = get_remote_version(branch)
 
     update_available = remote_version and remote_version != local_version
+    update_remote = get_quickstart_update_remote()
 
     # Determine Kometa branch
     kometa_branch = "nightly"
@@ -61,6 +96,8 @@ def check_for_update():
         "branch": branch,
         "kometa_branch": kometa_branch,
         "update_available": update_available,
+        "update_remote": update_remote,
+        "update_command": build_quickstart_update_command(branch, remote=update_remote),
         "running_on": os_name,
         "file_ext": os_ext,
     }
@@ -88,16 +125,7 @@ def perform_quickstart_update(qs_root, branch="master"):
         qs_root = Path(qs_root).resolve()
         is_windows = sys.platform.startswith("win")
 
-        # pick upstream remote (prefer official)
-        remotes_out = subprocess.run(
-            ["git", "remote"],
-            cwd=qs_root,
-            capture_output=True,
-            text=True,
-            shell=is_windows,
-        )
-        remotes = (remotes_out.stdout or "").split()
-        upstream = "kometa-team" if "kometa-team" in remotes else "origin"
+        upstream = get_quickstart_update_remote(qs_root)
         logs.append(f"🔗 Using Quickstart remote: {upstream}")
         logs.append(f"⚙️ Target Quickstart branch: {branch}")
 

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -3142,9 +3142,10 @@ function restartQuickstart (reason) {
 
 function getQuickstartUpdateCommand (info) {
   const branch = String(info?.branch || 'master')
-  if (branch === 'master') return 'git pull && pip install -r requirements.txt'
-  if (branch === 'develop') return 'git fetch && git reset --hard kometa-team/develop && pip install -r requirements.txt'
-  return `git fetch && git checkout ${branch} && pip install -r requirements.txt`
+  if (info?.update_command) return String(info.update_command)
+  const remote = String(info?.update_remote || 'kometa-team')
+  const remoteRef = `${remote}/${branch}`
+  return `git fetch ${remote} --prune && git switch -C ${branch} --track ${remoteRef} && git reset --hard ${remoteRef} && python -m pip install --upgrade pip && python -m pip install --no-cache-dir --upgrade -r requirements.txt`
 }
 
 function renderQuickstartUpdateAlert (info) {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -4944,6 +4944,7 @@ window.showNavigationLoadingOverlay = showNavigationLoadingOverlay
 window.showSpinner = showSpinner
 window.showToast = showToast
 window.qsQueueFlashToast = qsQueueFlashToast
+window.QS_renderQuickstartUpdateAlert = renderQuickstartUpdateAlert
 
 // ES module exports for other modules. Currently consumed by
 // static/local-js/001-start.js (which is also loaded as type="module").

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -104,13 +104,7 @@
         <br><br>
         <span>Update with:</span>
         <br>
-        {% if version_info.branch == "master" %}
-        <code>git pull && pip install -r requirements.txt</code>
-        {% elif version_info.branch == "develop" %}
-        <code>git fetch && git reset --hard kometa-team/develop && pip install -r requirements.txt</code>
-        {% else %}
-        <code>git fetch && git checkout {{ version_info.branch }} && pip install -r requirements.txt</code>
-        {% endif %}
+        <code>{{ version_info.update_command }}</code>
         <br>
         <button id="updateQuickstartBtn" class="btn btn-warning mt-2" data-branch="{{ version_info.branch }}">
           <i class="bi bi-arrow-clockwise"></i> Run Update Now

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -48,6 +48,7 @@ def test_quickstart_update_alert_uses_shared_update_command_contract():
 
     assert "{{ version_info.update_command }}" in template
     assert "info?.update_command" in script
+    assert "window.QS_renderQuickstartUpdateAlert = renderQuickstartUpdateAlert" in script
     assert "git checkout ${branch}" not in script
     assert "git fetch && git checkout {{ version_info.branch }}" not in template
 

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -1,10 +1,55 @@
 import io
 import shutil
 import zipfile
+from pathlib import Path
 
 import requests
 
 from modules import helpers
+from modules.helpers import _qs_update
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE_TEMPLATE_PATH = ROOT / "templates" / "000-base.html"
+BASE_JS_PATH = ROOT / "static" / "local-js" / "000-base.js"
+
+
+class _RemoteResult:
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def test_quickstart_update_remote_prefers_official_remote(monkeypatch):
+    monkeypatch.setattr(_qs_update, "_run_git_remote", lambda *_args, **_kwargs: _RemoteResult("origin\nkometa-team\n"))
+
+    assert helpers.get_quickstart_update_remote() == "kometa-team"
+
+
+def test_quickstart_update_remote_falls_back_to_origin(monkeypatch):
+    monkeypatch.setattr(_qs_update, "_run_git_remote", lambda *_args, **_kwargs: _RemoteResult("origin\nfork\n"))
+
+    assert helpers.get_quickstart_update_remote() == "origin"
+
+
+def test_quickstart_update_command_matches_backend_update_flow():
+    command = helpers.build_quickstart_update_command("fix/plex-section-id-library-identity", remote="kometa-team")
+
+    assert command == (
+        "git fetch kometa-team --prune && "
+        "git switch -C fix/plex-section-id-library-identity --track kometa-team/fix/plex-section-id-library-identity && "
+        "git reset --hard kometa-team/fix/plex-section-id-library-identity && "
+        "python -m pip install --upgrade pip && "
+        "python -m pip install --no-cache-dir --upgrade -r requirements.txt"
+    )
+
+
+def test_quickstart_update_alert_uses_shared_update_command_contract():
+    template = BASE_TEMPLATE_PATH.read_text(encoding="utf-8")
+    script = BASE_JS_PATH.read_text(encoding="utf-8")
+
+    assert "{{ version_info.update_command }}" in template
+    assert "info?.update_command" in script
+    assert "git checkout ${branch}" not in script
+    assert "git fetch && git checkout {{ version_info.branch }}" not in template
 
 
 def test_cached_kometa_update_reuses_lookup(tmp_path, monkeypatch):


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

- Make the local Quickstart update banner show the same branch-aware update flow used by the backend updater.
- Add shared helpers to resolve the update remote, preferring `kometa-team` and falling back to `origin`.
- Generate a deterministic manual update command that fetches/prunes, switches the local branch from the selected remote branch, hard-resets to the remote tip, upgrades pip, and installs requirements.
- Update both the server-rendered banner and dynamically rendered update alert to use the generated command.
- Add a namespaced QA hook for testing the dynamic update alert from DevTools.

## Testing

```powershell
python -m pytest tests\test_update_flows.py -q
npx.cmd eslint static/local-js/000-base.js
python -m pytest tests\test_status_endpoint.py tests\test_workspace_dependency_logic.py -q
```

Closes #1789
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791599993&installation_model_id=431096&pr_number=1815&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1815&signature=5d115eb10fa5ac0c3b832bd28e5eaad0bd902007b823e5b96fce37ed87cfb578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->