### PR TITLE
update readme and heamthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,6 @@ COPY . /
 # in the final image.
 COPY --from=jsbuild /jsbuild/static/dist/ /static/dist/
 VOLUME /config
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+ CMD curl -fsS "http://127.0.0.1:${QS_PORT:-7171}/kometa-status" >/dev/null || exit 1
 ENTRYPOINT ["/tini", "-s", "python3", "quickstart.py", "--"]

--- a/Dockerfile.arm7
+++ b/Dockerfile.arm7
@@ -46,4 +46,6 @@ RUN echo "**** cleanup system packages ****" \
 COPY . /
 COPY --from=jsbuild /jsbuild/static/dist/ /static/dist/
 VOLUME /config
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+ CMD curl -fsS "http://127.0.0.1:${QS_PORT:-7171}/kometa-status" >/dev/null || exit 1
 ENTRYPOINT ["/tini", "-s", "python3", "quickstart.py", "--"]

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ Kometa Quickstart is more than just a YAML generator - it's a full interactive e
 - **Library Telemetry:** Pulls real Plex server data (Plex Pass status, library types, agent/scanner compatibility)
 - **Dynamic Toggles & Templates:** Rich UI for enabling collections, overlays, and builder template variables
 - **Organized Library Defaults:** Collections, overlays, attributes, and playlists are grouped into logical accordions with override counters, visual override indicators, and scoped reset-to-defaults actions.
+- **Lazy Library Rendering:** Library cards, heavy collection/overlay sections, collection groups, and collection detail controls load on demand so large Plex installs remain usable while preserving saved override counts.
+- **Bulk Child Toggles:** Long child/included-item sections such as languages, resolutions, content ratings, streaming services, and chart lists include scoped select-all and unselect-all controls.
 - **Library Mirroring:** Copy compatible library selections from one Plex library to another, then explicitly include the destination library in the generated config after validation.
 - **Dependency-Aware Optional Pages:** Optional pages such as GitHub, Tautulli, OMDb, MDBList, Notifiarr, Gotify, ntfy, Apprise, Yamtrack, Webhooks, AniDB, Radarr, Sonarr, Trakt, and MyAnimeList become required when selected library features need them
 - **TODO Sidebar:** Outstanding dependency and validation tasks are grouped into clickable cards that save the current page and open the affected setup page
+- **Active Work Sidebar:** Long-running work such as Validate All, Kometa runs, Kometa/ImageMaid install or update jobs, and Analytics reingest appears in the sidebar with current status and elapsed time.
 - **Library-Scoped Playlists:** Playlist file selection now lives on the Libraries page so playlists stay tied to the libraries included in the generated YAML
 - **Library Collection Files:** Add multiple raw `collection_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML with a non-empty top-level `collections:` mapping before output
 - **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML with a non-empty top-level `metadata:` mapping before output
@@ -90,11 +93,31 @@ Kometa Quickstart is more than just a YAML generator - it's a full interactive e
 - **Runtime Flags & Environment Variables:** Supported Kometa runtime flags are grouped on the final page, including validation/schema options, logging options, run modes, and related environment variable guidance.
 - **Validation Levels:** Kometa validation commands support `syntax`, `structure`, and `full` validate-level choices from the UI.
 - **Process Management:** In `managed` and `existing direct` modes, start, stop, and monitor Kometa runs directly from the web interface
+- **Health status endpoint:** `GET /kometa-status` returns lightweight JSON for Kometa runtime state, pending starts, maintenance state, and resource metrics when Kometa is running. The endpoint is safe for Docker/Unraid health polling because it does not create or write a browser session.
 - **Maintenance-Aware Runs:** Detects Plex maintenance windows, pauses active runs, and queues new runs until maintenance ends (with global UI badges and toasts)
 - **Incomplete Run Recovery:** If a Kometa run stops early, Quickstart preserves the run context and surfaces resume or recovery guidance when it can determine the affected scope
 - **Mode-aware final page:** In `managed` mode, the final Kometa page includes install/update controls and run controls. In `existing direct` mode, the same page can validate the install, check version/update availability, and launch runs, but updates must be done manually outside Quickstart. In `external` mode, the page becomes a sync/status view that shows the external config target, log availability, and mode limitations instead of runtime controls.
 
 This reduces the chance of Plex background maintenance colliding with long Kometa runs, keeps Plex more responsive during the window, and avoids wasting time starting a run that would immediately pause.
+
+Health/status checks:
+
+```bash
+curl -fsS http://localhost:7171/kometa-status
+wget -qO- http://localhost:7171/kometa-status
+```
+
+For Unraid, replace `localhost` with the host/IP and port mapped to the Quickstart container, for example:
+
+```bash
+curl -fsS http://192.168.1.10:7171/kometa-status
+```
+
+Quickstart's Docker images include a built-in container healthcheck against `http://127.0.0.1:${QS_PORT:-7171}/kometa-status`. This uses the container's internal port, so host mappings such as `8008:7171` do not affect the healthcheck. You can inspect Docker's health state with:
+
+```bash
+docker inspect --format='{{json .State.Health}}' quickstart
+```
 
 #### ImageMaid
 - **Prepare / install / update flow:** Quickstart can install or update ImageMaid in its own managed directory before running it


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [x] Documentation Update
- [ ] Other

## Description

**Summary**
- Adds a built-in Docker healthcheck to both standard and ARM7 Quickstart images.
- Healthcheck calls the sessionless `/kometa-status` endpoint from inside the container using `${QS_PORT:-7171}`.
- Keeps host port mappings independent from health status checks, since the check uses `127.0.0.1` inside the container.
- Updates README health/status docs with direct `curl`/`wget` examples, Unraid host/IP guidance, and `docker inspect` health-state lookup.
- Also documents recent Libraries performance/QOL improvements and Active Work sidebar behavior.

**Testing**
- Verified Dockerfile and README healthcheck references with `rg`.
- Docker image build not run.

**Notes**
- The healthcheck confirms Quickstart is responsive.
- It does not require Kometa to be actively running.

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791629332&installation_model_id=431096&pr_number=1818&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1818&signature=0adf3a9089b22bbd35a3a038c790e500f405792a4fe3f1b5bdc831ab09eb2ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->