### PR TITLE
fix dropdown picker

### DIFF
--- a/blueprints/library_routes.py
+++ b/blueprints/library_routes.py
@@ -138,7 +138,38 @@ def _build_library_lists():
         if lib_id
     ]
 
+    if not movie_libraries and not show_libraries:
+        movie_libraries, show_libraries = _library_lists_from_telemetry(telemetry_data)
+
     return movie_libraries, show_libraries, telemetry_data
+
+
+def _library_lists_from_telemetry(telemetry_data):
+    """Build picker library descriptors from Plex telemetry when tmp IDs are missing."""
+    libraries = telemetry_data.get("libraries", {}) if isinstance(telemetry_data, dict) else {}
+    if not isinstance(libraries, dict):
+        return [], []
+
+    movie_libraries = []
+    show_libraries = []
+    for lib_id, lib_info in libraries.items():
+        if not isinstance(lib_info, dict):
+            continue
+        lib_type = str(lib_info.get("type") or "").strip().lower()
+        if lib_type not in {"movie", "show"}:
+            continue
+        name = str(lib_info.get("name") or lib_id).strip() or str(lib_id)
+        entry = {
+            "id": f"{'mov' if lib_type == 'movie' else 'sho'}-library_{lib_id}",
+            "name": name,
+            "type": lib_type,
+        }
+        if lib_type == "movie":
+            movie_libraries.append(entry)
+        else:
+            show_libraries.append(entry)
+
+    return movie_libraries, show_libraries
 
 
 def _normalize_library_toggle_names(libraries_data):

--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -120,6 +120,16 @@ def validate_plex():
             persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
         except Exception as e:
             helpers.ts_log(f"Library key migration failed during validate_plex: {e}", level="WARNING")
+    try:
+        persistence.update_stored_plex_libraries(
+            "010-plex",
+            plex_data.get("movie_libraries", []),
+            plex_data.get("show_libraries", []),
+            plex_data.get("music_libraries", []),
+            plex_data.get("user_list", []),
+        )
+    except Exception as e:
+        helpers.ts_log(f"Failed to persist Plex library lists during validation: {e}", level="WARNING")
 
     # Keep validator fields authoritative for the Plex page contract. Telemetry
     # uses display strings like "2048 MB", while the page's db_cache input needs

--- a/quickstart.py
+++ b/quickstart.py
@@ -2402,6 +2402,25 @@ def step(name):
         if lib_id
     ]
 
+    if name == "025-libraries" and not movie_libraries and not show_libraries:
+        telemetry_libraries = telemetry_data.get("libraries", {}) if isinstance(telemetry_data, dict) else {}
+        if isinstance(telemetry_libraries, dict):
+            for lib_id, lib_info in telemetry_libraries.items():
+                if not isinstance(lib_info, dict):
+                    continue
+                lib_type = str(lib_info.get("type") or "").strip().lower()
+                if lib_type not in {"movie", "show"}:
+                    continue
+                entry = {
+                    "id": f"{'mov' if lib_type == 'movie' else 'sho'}-library_{lib_id}",
+                    "name": str(lib_info.get("name") or lib_id).strip() or str(lib_id),
+                    "type": lib_type,
+                }
+                if lib_type == "movie":
+                    movie_libraries.append(entry)
+                else:
+                    show_libraries.append(entry)
+
     # Ensure `libraries` dictionary exists
     if "libraries" not in data:
         data["libraries"] = {}

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -106,6 +106,23 @@ def test_support_info_uses_library_ids_not_boolean_toggles(client, isolated_conf
     assert captured["value"] == {"1": "Movies", "2": "TV Movies", "5": "Shows"}
 
 
+def test_library_lists_from_telemetry_builds_movie_and_show_descriptors():
+    from blueprints import library_routes
+
+    movie_libraries, show_libraries = library_routes._library_lists_from_telemetry(
+        {
+            "libraries": {
+                "1": {"name": "Movies", "type": "movie"},
+                "2": {"name": "TV Shows", "type": "show"},
+                "3": {"name": "Music", "type": "artist"},
+            }
+        }
+    )
+
+    assert movie_libraries == [{"id": "mov-library_1", "name": "Movies", "type": "movie"}]
+    assert show_libraries == [{"id": "sho-library_2", "name": "TV Shows", "type": "show"}]
+
+
 # ===========================================================================
 # /clear_session
 # ===========================================================================

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4449,7 +4449,8 @@ def test_validate_plex_bad_token(client, monkeypatch, qs_module):
 
 
 def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch, qs_module):
-    calls = {"save_settings": 0, "save_section": 0}
+    calls = {"save_settings": 0, "save_section": 0, "update_libraries": 0}
+    captured = {}
 
     def fake_validate(_data):
         return qs_module.jsonify(
@@ -4458,8 +4459,8 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
                 "db_cache": 2048,
                 "user_list": ["User One"],
                 "music_libraries": [],
-                "movie_libraries": ["Movies"],
-                "show_libraries": ["Shows"],
+                "movie_libraries": [{"id": 1, "name": "Movies"}],
+                "show_libraries": [{"id": 2, "name": "Shows"}],
                 "has_plex_pass": True,
             }
         )
@@ -4476,6 +4477,18 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
     monkeypatch.setattr(qs_module.persistence, "save_settings", lambda *_args, **_kwargs: calls.__setitem__("save_settings", calls["save_settings"] + 1))
     monkeypatch.setattr(qs_module.database, "save_section_data", lambda **_kwargs: calls.__setitem__("save_section", calls["save_section"] + 1))
 
+    def fake_update_stored_plex_libraries(section_name, movie_libraries, show_libraries, music_libraries, user_list):
+        calls["update_libraries"] += 1
+        captured["update_libraries"] = {
+            "section_name": section_name,
+            "movie_libraries": movie_libraries,
+            "show_libraries": show_libraries,
+            "music_libraries": music_libraries,
+            "user_list": user_list,
+        }
+
+    monkeypatch.setattr(qs_module.persistence, "update_stored_plex_libraries", fake_update_stored_plex_libraries)
+
     with client.session_transaction() as sess:
         sess["config_name"] = "pytest_validate_plex"
 
@@ -4485,7 +4498,14 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
     assert payload["validated"] is True
     assert payload["db_cache"] == 2048
     assert payload["maintenance_window"] == "02:00 – 05:00"
-    assert calls == {"save_settings": 1, "save_section": 1}
+    assert calls == {"save_settings": 1, "save_section": 1, "update_libraries": 1}
+    assert captured["update_libraries"] == {
+        "section_name": "010-plex",
+        "movie_libraries": [{"id": 1, "name": "Movies"}],
+        "show_libraries": [{"id": 2, "name": "Shows"}],
+        "music_libraries": [],
+        "user_list": ["User One"],
+    }
 
 
 def test_plex_page_normalizes_formatted_db_cache_on_load(client, isolated_config_dir):
@@ -4517,6 +4537,77 @@ def test_plex_page_normalizes_formatted_db_cache_on_load(client, isolated_config
     match = re.search(r'id="plex_db_cache"[^>]+value="([^"]*)"', html)
     assert match is not None
     assert match.group(1) == "2048"
+
+
+def test_libraries_picker_falls_back_to_plex_telemetry_when_tmp_library_ids_missing(client, isolated_config_dir, monkeypatch, qs_module):
+    from modules import database
+
+    config_name = "pytest_telemetry_library_picker"
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    database.save_section_data(
+        name=config_name,
+        section="plex",
+        validated=True,
+        user_entered=True,
+        data={
+            "validated": True,
+            "plex": {
+                "url": "http://localhost:32400",
+                "token": "token",
+                "tmp_movie_libraries": "",
+                "tmp_show_libraries": "",
+                "tmp_music_libraries": "",
+                "tmp_library_names": "{}",
+            },
+        },
+    )
+    database.save_section_data(
+        name=config_name,
+        section="plex_telemetry",
+        validated=True,
+        user_entered=False,
+        data={
+            "plex_telemetry": {
+                "plex_pass": True,
+                "server_name": "Test Plex",
+                "version": "1.0",
+                "platform": "Linux",
+                "update_channel": "Public update channel",
+                "libraries": {
+                    "1": {
+                        "name": "Movies",
+                        "type": "movie",
+                        "scanner": "Plex Movie",
+                        "agent": "tv.plex.agents.movie",
+                        "ratings_source": "Rotten Tomatoes",
+                        "movie_count": 10,
+                    },
+                    "2": {
+                        "name": "TV Shows",
+                        "type": "show",
+                        "scanner": "Plex TV Series",
+                        "agent": "tv.plex.agents.series",
+                        "ratings_source": "N/A",
+                        "show_count": 3,
+                        "episode_count": 12,
+                    },
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.helpers, "load_quickstart_config", lambda _filename: [])
+    monkeypatch.setattr(qs_module.helpers, "load_quickstart_overlay_config", lambda: [])
+
+    resp = client.get("/step/025-libraries")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'value="mov-library_1"' in html
+    assert "[Movies]" in html
+    assert 'value="sho-library_2"' in html
+    assert "[TV Shows]" in html
 
 
 def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
Fixes a fresh-config Libraries page regression where Plex validation could successfully discover libraries, but the `025-libraries` picker stayed empty because the temporary Plex library cache had not been persisted yet.

**Changes**
- Persist Plex movie/show/music library IDs and user list during `/validate_plex`.
- Add a telemetry fallback for the Libraries picker when cached temporary library IDs are missing.
- Apply the fallback to both the full `025-libraries` page render and shared library route list builder.
- Add regression coverage for:
  - Plex validation persisting discovered library lists.
  - Libraries picker rendering from Plex telemetry when temp IDs are absent.
  - Telemetry conversion into movie/show picker descriptors.

**Testing**
```bash
python -m pytest tests\test_core_backend.py::test_validate_plex_persists_telemetry_for_current_config tests\test_core_backend.py::test_libraries_picker_falls_back_to_plex_telemetry_when_tmp_library_ids_missing tests\test_config_and_library_routes.py::test_library_lists_from_telemetry_builds_movie_and_show_descriptors -q
python -m pytest tests\test_core_backend.py::test_refresh_plex_libraries_reuses_short_lived_cache -q
```
## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791654471&installation_model_id=431096&pr_number=1820&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1820&signature=015c6cb835b00d0c0044a78c317ab46fccb579dafc7a2046ba7f67691017ec73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->