### PR TITLE
fixes for updater

### DIFF
--- a/modules/helpers/_qs_update.py
+++ b/modules/helpers/_qs_update.py
@@ -100,7 +100,7 @@ def _is_remote_quickstart_version_newer(local_version, remote_version):
 
 def check_for_update():
     """Compare the local version with the remote version and determine Kometa branch."""
-    from modules.helpers._version import get_branch, get_remote_version
+    from modules.helpers._version import get_branch, get_remote_version_status
     from modules.helpers._os import get_running_os
 
     branch = get_branch()
@@ -112,7 +112,8 @@ def check_for_update():
         if age <= QS_UPDATE_CACHE_TTL_SECONDS:
             return copy.deepcopy(cached.get("payload") or {})
 
-    remote_version = get_remote_version(branch)
+    remote_status = get_remote_version_status(branch)
+    remote_version = remote_status.get("version")
 
     update_available = _is_remote_quickstart_version_newer(local_version, remote_version)
     update_remote = get_quickstart_update_remote()
@@ -125,9 +126,13 @@ def check_for_update():
     payload = {
         "local_version": local_version,
         "remote_version": remote_version,
+        "remote_base_version": remote_status.get("base_version"),
+        "remote_buildnum": remote_status.get("buildnum"),
         "branch": branch,
         "kometa_branch": kometa_branch,
         "update_available": update_available,
+        "update_check_status": remote_status.get("status") or "ok",
+        "update_message": remote_status.get("message") or "",
         "update_remote": update_remote,
         "update_command": build_quickstart_update_command(branch, remote=update_remote),
         "running_on": os_name,

--- a/modules/helpers/_qs_update.py
+++ b/modules/helpers/_qs_update.py
@@ -2,6 +2,7 @@
 
 import copy
 import os
+import re
 import subprocess
 import sys
 import time
@@ -66,6 +67,37 @@ def get_version(branch):
     return "unknown"
 
 
+def _parse_quickstart_version(value):
+    match = re.fullmatch(r"v?(\d+(?:\.\d+)*)(?:-build(\d+))?", str(value or "").strip(), re.IGNORECASE)
+    if not match:
+        return None
+    base = tuple(int(part) for part in match.group(1).split("."))
+    return base, int(match.group(2) or 0), bool(match.group(2))
+
+
+def _is_remote_quickstart_version_newer(local_version, remote_version):
+    if not remote_version:
+        return False
+    if str(local_version or "").strip().lower() in {"", "unknown"}:
+        return True
+
+    local = _parse_quickstart_version(local_version)
+    remote = _parse_quickstart_version(remote_version)
+    if not local or not remote:
+        return str(remote_version).strip() != str(local_version or "").strip()
+
+    local_base, local_build, local_has_build = local
+    remote_base, remote_build, remote_has_build = remote
+    max_len = max(len(local_base), len(remote_base))
+    padded_local_base = local_base + (0,) * (max_len - len(local_base))
+    padded_remote_base = remote_base + (0,) * (max_len - len(remote_base))
+    if padded_remote_base != padded_local_base:
+        return padded_remote_base > padded_local_base
+    if local_has_build or remote_has_build:
+        return remote_build > local_build
+    return False
+
+
 def check_for_update():
     """Compare the local version with the remote version and determine Kometa branch."""
     from modules.helpers._version import get_branch, get_remote_version
@@ -82,7 +114,7 @@ def check_for_update():
 
     remote_version = get_remote_version(branch)
 
-    update_available = remote_version and remote_version != local_version
+    update_available = _is_remote_quickstart_version_newer(local_version, remote_version)
     update_remote = get_quickstart_update_remote()
 
     # Determine Kometa branch

--- a/modules/helpers/_version.py
+++ b/modules/helpers/_version.py
@@ -23,6 +23,9 @@ def get_remote_version(branch):
         version = response.text.strip()
     except requests.RequestException:
         return None  # If request fails, return None
+    if branch == "master":
+        return version
+
     try:
         response = requests.get(
             f"https://raw.githubusercontent.com/Kometa-Team/Quickstart/{branch}/BUILDNUM",
@@ -31,8 +34,11 @@ def get_remote_version(branch):
         response.raise_for_status()
         build_num = response.text.strip()
     except requests.RequestException:
-        build_num = "0"
-    return version if branch == "master" else f"{version}-build{build_num}"
+        return None
+
+    if not build_num or not build_num.isdigit():
+        return None
+    return f"{version}-build{build_num}"
 
 
 def get_branch():

--- a/modules/helpers/_version.py
+++ b/modules/helpers/_version.py
@@ -11,9 +11,8 @@ except ImportError:
 import requests
 
 
-def get_remote_version(branch):
-    """Fetch the latest VERSION file from the correct GitHub branch."""
-
+def get_remote_version_status(branch):
+    """Fetch remote Quickstart version metadata with an explicit status."""
     try:
         response = requests.get(
             f"https://raw.githubusercontent.com/Kometa-Team/Quickstart/{branch}/VERSION",
@@ -22,9 +21,22 @@ def get_remote_version(branch):
         response.raise_for_status()
         version = response.text.strip()
     except requests.RequestException:
-        return None  # If request fails, return None
+        return {
+            "version": None,
+            "base_version": None,
+            "buildnum": None,
+            "status": "unavailable",
+            "message": "Quickstart update metadata is unavailable right now. Try again later.",
+        }
+
     if branch == "master":
-        return version
+        return {
+            "version": version,
+            "base_version": version,
+            "buildnum": None,
+            "status": "ok",
+            "message": "",
+        }
 
     try:
         response = requests.get(
@@ -34,11 +46,34 @@ def get_remote_version(branch):
         response.raise_for_status()
         build_num = response.text.strip()
     except requests.RequestException:
-        return None
+        return {
+            "version": None,
+            "base_version": version,
+            "buildnum": None,
+            "status": "build_pending",
+            "message": "Quickstart build metadata is still publishing. Try again in a few minutes.",
+        }
 
     if not build_num or not build_num.isdigit():
-        return None
-    return f"{version}-build{build_num}"
+        return {
+            "version": None,
+            "base_version": version,
+            "buildnum": None,
+            "status": "build_pending",
+            "message": "Quickstart build metadata is incomplete. Try again in a few minutes.",
+        }
+    return {
+        "version": f"{version}-build{build_num}",
+        "base_version": version,
+        "buildnum": build_num,
+        "status": "ok",
+        "message": "",
+    }
+
+
+def get_remote_version(branch):
+    """Fetch the latest VERSION file from the correct GitHub branch."""
+    return get_remote_version_status(branch).get("version")
 
 
 def get_branch():

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -3148,25 +3148,49 @@ function getQuickstartUpdateCommand (info) {
   return `git fetch ${remote} --prune && git switch -C ${branch} --track ${remoteRef} && git reset --hard ${remoteRef} && python -m pip install --upgrade pip && python -m pip install --no-cache-dir --upgrade -r requirements.txt`
 }
 
+function isQuickstartBuildPending (info) {
+  return String(info?.update_check_status || '') === 'build_pending'
+}
+
+function getQuickstartBuildPendingMessage (info) {
+  return String(info?.update_message || 'Quickstart build metadata is still publishing. Try again in a few minutes.')
+}
+
 function renderQuickstartUpdateAlert (info) {
   const existingAlerts = document.querySelectorAll('[data-qs-update-alert]')
   existingAlerts.forEach(el => el.remove())
   document.querySelectorAll('[data-qs-update-alert-spacer]').forEach(el => el.remove())
 
-  if (!info || !info.update_available) return
+  const buildPending = isQuickstartBuildPending(info)
+  if (!info || (!info.update_available && !buildPending)) return
 
   const anchor = document.querySelector('[data-qs-update-alert-anchor]') || document.querySelector('.early-warning')
   const wrapper = anchor?.parentElement || document.querySelector('.qs-content-wrapper')
   if (!wrapper) return
 
   const alert = document.createElement('div')
-  alert.className = 'alert alert-danger text-center qs-wide-alert'
+  alert.className = `alert ${buildPending ? 'alert-warning' : 'alert-danger'} text-center qs-wide-alert`
   alert.id = 'quickstart-update-alert'
   alert.dataset.qsUpdateAlert = 'true'
   alert.setAttribute('role', 'alert')
 
   const icon = document.createElement('i')
-  icon.className = 'bi bi-arrow-up-circle'
+  icon.className = `bi ${buildPending ? 'bi-hourglass-split' : 'bi-arrow-up-circle'}`
+  if (buildPending) {
+    alert.append(icon, document.createTextNode(` ${getQuickstartBuildPendingMessage(info)}`))
+    if (info.remote_base_version) {
+      alert.append(document.createElement('br'))
+      const version = document.createElement('strong')
+      version.textContent = info.remote_base_version
+      alert.append(document.createTextNode('Remote version detected: '), version)
+    }
+    const spacer = document.createElement('br')
+    spacer.dataset.qsUpdateAlertSpacer = 'true'
+    wrapper.insertBefore(alert, anchor || wrapper.firstChild)
+    wrapper.insertBefore(spacer, anchor || alert.nextSibling)
+    return
+  }
+
   alert.append(icon, document.createTextNode(' A new version of Quickstart ('))
 
   const version = document.createElement('strong')
@@ -3230,6 +3254,8 @@ async function runQuickstartUpdateCheck (options = {}) {
   if (!options.silent && typeof showToast === 'function') {
     if (data.version_info?.update_available) {
       showToast('warning', `Quickstart update available: ${data.version_info.remote_version || 'unknown'}`)
+    } else if (isQuickstartBuildPending(data.version_info)) {
+      showToast('info', getQuickstartBuildPendingMessage(data.version_info))
     } else {
       showToast('success', 'Quickstart is up to date.')
     }
@@ -3359,6 +3385,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (info?.update_available) {
           setUpdateStatus(`${info.local_version || 'unknown'} -> ${info.remote_version || 'unknown'}`, false)
           showToast('warning', `Quickstart update available: ${info.remote_version || 'unknown'}`)
+        } else if (isQuickstartBuildPending(info)) {
+          setUpdateStatus('Build publishing; try again soon.', false)
+          showToast('info', getQuickstartBuildPendingMessage(info))
         } else {
           setUpdateStatus(`Up to date (${info?.local_version || 'unknown'})`, false)
           showToast('success', 'Quickstart is up to date.')

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -89,7 +89,18 @@
     <div class="qs-page-container">
       <div class="content-wrapper qs-content-wrapper">
       <!-- New Version Available Message for user-->
-      {% if version_info and version_info.update_available %}
+      {% set qs_update_status = version_info.update_check_status | default('') if version_info else '' %}
+      {% if version_info and qs_update_status == "build_pending" %}
+      <div class="alert alert-warning text-center qs-wide-alert" id="quickstart-update-alert" data-qs-update-alert role="alert">
+        <i class="bi bi-hourglass-split"></i>
+        {{ version_info.update_message or "Quickstart build metadata is still publishing. Try again in a few minutes." }}
+        {% if version_info.remote_base_version %}
+        <br>
+        <span>Remote version detected: <strong>{{ version_info.remote_base_version }}</strong></span>
+        {% endif %}
+      </div>
+      <br data-qs-update-alert-spacer>
+      {% elif version_info and version_info.update_available %}
       <div class="alert alert-danger text-center qs-wide-alert" id="quickstart-update-alert" data-qs-update-alert role="alert">
         <i class="bi bi-arrow-up-circle"></i>
         A new version of Quickstart (<strong>{{ version_info.remote_version }}</strong>) is available!

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import requests
 
 from modules import helpers
-from modules.helpers import _qs_update
+from modules.helpers import _qs_update, _version
 
 ROOT = Path(__file__).resolve().parents[1]
 BASE_TEMPLATE_PATH = ROOT / "templates" / "000-base.html"
@@ -16,6 +16,16 @@ BASE_JS_PATH = ROOT / "static" / "local-js" / "000-base.js"
 class _RemoteResult:
     def __init__(self, stdout):
         self.stdout = stdout
+
+
+class _HttpResponse:
+    def __init__(self, text="", exc=None):
+        self.text = text
+        self.exc = exc
+
+    def raise_for_status(self):
+        if self.exc:
+            raise self.exc
 
 
 def test_quickstart_update_remote_prefers_official_remote(monkeypatch):
@@ -51,6 +61,46 @@ def test_quickstart_update_alert_uses_shared_update_command_contract():
     assert "window.QS_renderQuickstartUpdateAlert = renderQuickstartUpdateAlert" in script
     assert "git checkout ${branch}" not in script
     assert "git fetch && git checkout {{ version_info.branch }}" not in template
+
+
+def test_develop_remote_version_is_unknown_when_buildnum_is_unavailable(monkeypatch):
+    def fake_get(url, **_kwargs):
+        if url.endswith("/VERSION"):
+            return _HttpResponse("0.10.6")
+        if url.endswith("/BUILDNUM"):
+            return _HttpResponse(exc=requests.RequestException("not published yet"))
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(_version.requests, "get", fake_get)
+
+    assert helpers.get_remote_version("develop") is None
+
+
+def test_quickstart_update_ignores_lower_remote_develop_build(monkeypatch):
+    _qs_update._QS_UPDATE_CACHE.clear()
+    monkeypatch.setattr(_version, "get_branch", lambda: "develop")
+    monkeypatch.setattr(_version, "get_remote_version", lambda _branch: "0.10.6-build0")
+    monkeypatch.setattr(_qs_update, "get_version", lambda _branch: "0.10.6-build29")
+    monkeypatch.setattr(_qs_update, "get_quickstart_update_remote", lambda *_args, **_kwargs: "origin")
+
+    info = _qs_update.check_for_update()
+
+    assert info["local_version"] == "0.10.6-build29"
+    assert info["remote_version"] == "0.10.6-build0"
+    assert info["update_available"] is False
+
+
+def test_quickstart_update_detects_higher_remote_develop_build(monkeypatch):
+    _qs_update._QS_UPDATE_CACHE.clear()
+    monkeypatch.setattr(_version, "get_branch", lambda: "develop")
+    monkeypatch.setattr(_version, "get_remote_version", lambda _branch: "0.10.6-build30")
+    monkeypatch.setattr(_qs_update, "get_version", lambda _branch: "0.10.6-build29")
+    monkeypatch.setattr(_qs_update, "get_quickstart_update_remote", lambda *_args, **_kwargs: "origin")
+
+    info = _qs_update.check_for_update()
+
+    assert info["remote_version"] == "0.10.6-build30"
+    assert info["update_available"] is True
 
 
 def test_cached_kometa_update_reuses_lookup(tmp_path, monkeypatch):

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -57,7 +57,9 @@ def test_quickstart_update_alert_uses_shared_update_command_contract():
     script = BASE_JS_PATH.read_text(encoding="utf-8")
 
     assert "{{ version_info.update_command }}" in template
+    assert 'qs_update_status == "build_pending"' in template
     assert "info?.update_command" in script
+    assert "isQuickstartBuildPending" in script
     assert "window.QS_renderQuickstartUpdateAlert = renderQuickstartUpdateAlert" in script
     assert "git checkout ${branch}" not in script
     assert "git fetch && git checkout {{ version_info.branch }}" not in template
@@ -74,12 +76,26 @@ def test_develop_remote_version_is_unknown_when_buildnum_is_unavailable(monkeypa
     monkeypatch.setattr(_version.requests, "get", fake_get)
 
     assert helpers.get_remote_version("develop") is None
+    status = helpers.get_remote_version_status("develop")
+    assert status["status"] == "build_pending"
+    assert status["base_version"] == "0.10.6"
+    assert status["version"] is None
 
 
 def test_quickstart_update_ignores_lower_remote_develop_build(monkeypatch):
     _qs_update._QS_UPDATE_CACHE.clear()
     monkeypatch.setattr(_version, "get_branch", lambda: "develop")
-    monkeypatch.setattr(_version, "get_remote_version", lambda _branch: "0.10.6-build0")
+    monkeypatch.setattr(
+        _version,
+        "get_remote_version_status",
+        lambda _branch: {
+            "version": "0.10.6-build0",
+            "base_version": "0.10.6",
+            "buildnum": "0",
+            "status": "ok",
+            "message": "",
+        },
+    )
     monkeypatch.setattr(_qs_update, "get_version", lambda _branch: "0.10.6-build29")
     monkeypatch.setattr(_qs_update, "get_quickstart_update_remote", lambda *_args, **_kwargs: "origin")
 
@@ -93,7 +109,17 @@ def test_quickstart_update_ignores_lower_remote_develop_build(monkeypatch):
 def test_quickstart_update_detects_higher_remote_develop_build(monkeypatch):
     _qs_update._QS_UPDATE_CACHE.clear()
     monkeypatch.setattr(_version, "get_branch", lambda: "develop")
-    monkeypatch.setattr(_version, "get_remote_version", lambda _branch: "0.10.6-build30")
+    monkeypatch.setattr(
+        _version,
+        "get_remote_version_status",
+        lambda _branch: {
+            "version": "0.10.6-build30",
+            "base_version": "0.10.6",
+            "buildnum": "30",
+            "status": "ok",
+            "message": "",
+        },
+    )
     monkeypatch.setattr(_qs_update, "get_version", lambda _branch: "0.10.6-build29")
     monkeypatch.setattr(_qs_update, "get_quickstart_update_remote", lambda *_args, **_kwargs: "origin")
 
@@ -101,6 +127,32 @@ def test_quickstart_update_detects_higher_remote_develop_build(monkeypatch):
 
     assert info["remote_version"] == "0.10.6-build30"
     assert info["update_available"] is True
+
+
+def test_quickstart_update_reports_pending_develop_build(monkeypatch):
+    _qs_update._QS_UPDATE_CACHE.clear()
+    monkeypatch.setattr(_version, "get_branch", lambda: "develop")
+    monkeypatch.setattr(
+        _version,
+        "get_remote_version_status",
+        lambda _branch: {
+            "version": None,
+            "base_version": "0.10.6",
+            "buildnum": None,
+            "status": "build_pending",
+            "message": "Quickstart build metadata is still publishing. Try again in a few minutes.",
+        },
+    )
+    monkeypatch.setattr(_qs_update, "get_version", lambda _branch: "0.10.6-build29")
+    monkeypatch.setattr(_qs_update, "get_quickstart_update_remote", lambda *_args, **_kwargs: "origin")
+
+    info = _qs_update.check_for_update()
+
+    assert info["remote_version"] is None
+    assert info["remote_base_version"] == "0.10.6"
+    assert info["update_available"] is False
+    assert info["update_check_status"] == "build_pending"
+    assert "publishing" in info["update_message"]
 
 
 def test_cached_kometa_update_reuses_lookup(tmp_path, monkeypatch):


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
Fixes the Quickstart update check showing bogus develop updates like `0.10.6-build0` while a new build is still publishing.

**Changes**
- Stop synthesizing `build0` when remote develop `BUILDNUM` is missing or invalid.
- Compare Quickstart versions numerically so lower/equal builds are not treated as updates.
- Add a `build_pending` update-check status when `VERSION` is available but `BUILDNUM` is not ready.
- Show a yellow “build metadata is still publishing” message instead of a red update banner.
- Update the manual `Check Updates` button to show `Build publishing; try again soon.` with an info toast.
- Keep valid higher builds, like `0.10.6-build30`, showing as available.

**Testing**
```bash
python -m pytest tests\test_update_flows.py -q
npx.cmd eslint static\local-js\000-base.js
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791655417&installation_model_id=431096&pr_number=1821&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1821&signature=62ab63c1d5394fb837a2cdbb65e086f38c4dc4a4c54d0fbb316f82c62302f5ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->