### PR TITLE
plex pass cache on libraries page

### DIFF
--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -7,6 +7,14 @@ from modules import database, helpers, persistence, url_validation, validations
 bp = Blueprint("validation_routes", __name__)
 
 
+def _telemetry_with_validated_plex_pass(telemetry, plex_data):
+    """Keep Libraries telemetry aligned with the authoritative Plex validation result."""
+    normalized = dict(telemetry) if isinstance(telemetry, dict) else {}
+    if isinstance(plex_data, dict) and "has_plex_pass" in plex_data:
+        normalized["plex_pass"] = bool(plex_data.get("has_plex_pass"))
+    return normalized
+
+
 def _unpack_validation_result(result):
     """Normalise a validator return value into ``(flask_response, status_code)``.
 
@@ -98,6 +106,7 @@ def validate_plex():
     try:
         telemetry = helpers.get_plex_metadata(plex_url=data.get("plex_url"), plex_token=data.get("plex_token")) or {}
         if telemetry:
+            telemetry = _telemetry_with_validated_plex_pass(telemetry, plex_data)
             persistence.save_settings("plex_telemetry", telemetry)
             if config_name:
                 try:
@@ -166,6 +175,9 @@ def refresh_plex_libraries():
         cached_refresh = helpers.get_cached_plex_refresh(plex_url, plex_token)
         if cached_refresh:
             helpers.ts_log("Using cached Plex library refresh payload.", level="DEBUG")
+            cached_refresh = dict(cached_refresh)
+            if "has_plex_pass" in cached_refresh:
+                cached_refresh["plex_pass"] = bool(cached_refresh.get("has_plex_pass"))
             all_libs = list(cached_refresh.get("movie_libraries") or []) + list(cached_refresh.get("show_libraries") or []) + list(cached_refresh.get("music_libraries") or [])
             if all_libs and isinstance(all_libs[0], dict):
                 persistence.migrate_library_keys_to_plex_ids(config_name, all_libs)
@@ -189,6 +201,7 @@ def refresh_plex_libraries():
                     "has_plex_pass",
                 }
             }
+            cached_telemetry = _telemetry_with_validated_plex_pass(cached_telemetry, cached_refresh)
             persistence.save_settings("plex_telemetry", cached_telemetry)
             try:
                 database.save_section_data(
@@ -223,6 +236,7 @@ def refresh_plex_libraries():
 
         # Get fresh telemetry using helpers and store it
         telemetry = helpers.get_plex_metadata(plex_url=plex_url, plex_token=plex_token)
+        telemetry = _telemetry_with_validated_plex_pass(telemetry, plex_data)
         persistence.save_settings("plex_telemetry", telemetry)
         try:
             database.save_section_data(

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4466,6 +4466,7 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
         )
 
     telemetry = {
+        "plex_pass": False,
         "server_name": "Test Plex",
         "db_cache": "2048 MB",
         "maintenance_window": "02:00 – 05:00",
@@ -4474,8 +4475,17 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
 
     monkeypatch.setattr(qs_module.validations, "validate_plex_server", fake_validate)
     monkeypatch.setattr(qs_module.helpers, "get_plex_metadata", lambda **_kwargs: telemetry)
-    monkeypatch.setattr(qs_module.persistence, "save_settings", lambda *_args, **_kwargs: calls.__setitem__("save_settings", calls["save_settings"] + 1))
-    monkeypatch.setattr(qs_module.database, "save_section_data", lambda **_kwargs: calls.__setitem__("save_section", calls["save_section"] + 1))
+
+    def fake_save_settings(section_name, payload):
+        calls["save_settings"] += 1
+        captured["save_settings"] = {"section_name": section_name, "payload": payload}
+
+    def fake_save_section_data(**kwargs):
+        calls["save_section"] += 1
+        captured["save_section"] = kwargs
+
+    monkeypatch.setattr(qs_module.persistence, "save_settings", fake_save_settings)
+    monkeypatch.setattr(qs_module.database, "save_section_data", fake_save_section_data)
 
     def fake_update_stored_plex_libraries(section_name, movie_libraries, show_libraries, music_libraries, user_list):
         calls["update_libraries"] += 1
@@ -4497,8 +4507,12 @@ def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch
     payload = resp.get_json()
     assert payload["validated"] is True
     assert payload["db_cache"] == 2048
+    assert payload["plex_pass"] is True
     assert payload["maintenance_window"] == "02:00 – 05:00"
     assert calls == {"save_settings": 1, "save_section": 1, "update_libraries": 1}
+    assert captured["save_settings"]["section_name"] == "plex_telemetry"
+    assert captured["save_settings"]["payload"]["plex_pass"] is True
+    assert captured["save_section"]["data"]["plex_telemetry"]["plex_pass"] is True
     assert captured["update_libraries"] == {
         "section_name": "010-plex",
         "movie_libraries": [{"id": 1, "name": "Movies"}],
@@ -4720,6 +4734,40 @@ def test_refresh_plex_libraries_reuses_short_lived_cache(client, monkeypatch, qs
     assert second.status_code == 200
     assert first.get_json() == second.get_json()
     assert calls == {"validate": 1, "metadata": 1, "update": 2, "save": 2}
+
+
+def test_refresh_plex_libraries_cached_payload_uses_validation_plex_pass(client, monkeypatch, qs_module):
+    cached_refresh = {
+        "validated": True,
+        "has_plex_pass": True,
+        "plex_pass": False,
+        "server_name": "Test Plex",
+        "movie_libraries": [{"id": 1, "name": "Movies"}],
+        "show_libraries": [],
+        "music_libraries": [],
+        "user_list": ["User One"],
+        "libraries": {"1": {"name": "Movies", "type": "movie"}},
+    }
+    saved = {}
+
+    monkeypatch.setattr(qs_module.persistence, "get_stored_plex_credentials", lambda _name: ("http://localhost:32400", "token"))
+    monkeypatch.setattr(qs_module.persistence, "get_dummy_data", lambda _name: {"url": "http://placeholder", "token": "placeholder"})
+    monkeypatch.setattr(qs_module.helpers, "get_cached_plex_refresh", lambda *_args, **_kwargs: cached_refresh)
+    monkeypatch.setattr(qs_module.persistence, "migrate_library_keys_to_plex_ids", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(qs_module.persistence, "update_stored_plex_libraries", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module.persistence, "save_settings", lambda section_name, payload: saved.update({"section_name": section_name, "payload": payload}))
+    monkeypatch.setattr(qs_module.database, "save_section_data", lambda **kwargs: saved.update({"section": kwargs}))
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = "pytest_plex_cached_pass"
+
+    resp = client.post("/refresh_plex_libraries")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["plex_pass"] is True
+    assert saved["section_name"] == "plex_telemetry"
+    assert saved["payload"]["plex_pass"] is True
+    assert saved["section"]["data"]["plex_telemetry"]["plex_pass"] is True
 
 
 def test_yaml_generation_sets_session_and_redacts(client, isolated_config_dir, monkeypatch, qs_module):


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
Fixes a Plex Pass cache mismatch where the Plex page could correctly show Plex Pass detected, but the Libraries page still showed “Plex Pass not detected.”

**Changes**
- Treat the Plex validation result `has_plex_pass` as authoritative.
- Normalize saved telemetry so Libraries receives the matching `plex_pass` value.
- Apply the normalization during:
  - direct `/validate_plex`
  - fresh `/refresh_plex_libraries`
  - cached `/refresh_plex_libraries` responses
- Prevent stale cached telemetry from disabling Plex Pass-only library options after a successful Plex validation.

**Testing**
```bash
python -m pytest tests\test_core_backend.py::test_validate_plex_persists_telemetry_for_current_config tests\test_core_backend.py::test_libraries_picker_falls_back_to_plex_telemetry_when_tmp_library_ids_missing tests\test_core_backend.py::test_refresh_plex_libraries_reuses_short_lived_cache tests\test_core_backend.py::test_refresh_plex_libraries_cached_payload_uses_validation_plex_pass -q
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791671953&installation_model_id=431096&pr_number=1822&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1822&signature=83caf4c54f58a036a58c5a1fd49746cb7e47b6cc2dd10cbaebe2552cd885369d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->