### PR TITLE
fixes for add radarr to collections

### DIFF
--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -508,6 +508,51 @@ def _normalize_list_template_vars(template_vars):
             template_vars.pop(list_key, None)
 
 
+def _normalize_template_default_for_compare(value):
+    text = str(value or "").strip().lower()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", "", text)
+    return re.sub(r"(?<=[(/,\-|])0+(\d)", r"\1", text)
+
+
+def _seasonal_child_schedule_defaults():
+    defaults = {}
+    try:
+        groups = helpers.load_quickstart_config("quickstart_collections.json")
+    except Exception as exc:
+        helpers.ts_log(f"Failed to load quickstart_collections.json for seasonal schedule defaults: {exc}", level="ERROR")
+        return defaults
+
+    for group in groups or []:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []) or []:
+            if not isinstance(collection, dict) or collection.get("id") != "collection_seasonal":
+                continue
+            for item in collection.get("template_variables", []) or []:
+                if not isinstance(item, dict):
+                    continue
+                key = str(item.get("key") or "").strip()
+                if key.startswith("schedule_") and "default" in item:
+                    defaults[key] = _normalize_template_default_for_compare(item.get("default"))
+            return defaults
+    return defaults
+
+
+def _drop_default_seasonal_child_schedules(template_vars, raw_id):
+    if str(raw_id or "").strip().lower() != "seasonal":
+        return
+    defaults = _seasonal_child_schedule_defaults()
+    if not defaults:
+        return
+    for key in list(template_vars.keys()):
+        if key not in defaults:
+            continue
+        if _normalize_template_default_for_compare(template_vars.get(key)) == defaults[key]:
+            template_vars.pop(key, None)
+
+
 def _parse_template_lookup_labels(value):
     if isinstance(value, dict):
         return {str(k).strip(): str(v).strip() for k, v in value.items() if str(k).strip() and str(v).strip()}
@@ -557,6 +602,7 @@ def _apply_template_var_normalizers(template_vars, raw_id):
             template_vars.pop(template_key, None)
         else:
             template_vars[template_key] = normalized_value
+    _drop_default_seasonal_child_schedules(template_vars, raw_id)
 
 
 def _is_collectionless_entry(item):

--- a/tests/fixtures/schema/config-schema.json
+++ b/tests/fixtures/schema/config-schema.json
@@ -13505,6 +13505,58 @@
       "patternProperties": {
         "^schedule_.+$": {
           "type": "string"
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific seasonal collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific seasonal collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_.+$": {
+          "description": "Override Radarr monitor for a specific seasonal collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific seasonal collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific seasonal collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific seasonal collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific seasonal collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific seasonal collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
       }
     },

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3094,6 +3094,35 @@ def test_runtime_config_schema_accepts_playlist_exclude_users_keyed_override(iso
     assert errors == []
 
 
+def test_runtime_config_schema_accepts_seasonal_child_radarr_add_missing(isolated_config_dir):
+    import json
+
+    import jsonschema
+
+    schema_path = isolated_config_dir / ".schema" / "config-schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    sample = {
+        "plex": {"url": "http://example", "token": "x"},
+        "tmdb": {"apikey": "x"},
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "seasonal",
+                        "template_variables": {
+                            "radarr_add_missing_christmas": True,
+                        },
+                    }
+                ]
+            }
+        },
+    }
+
+    errors = sorted(jsonschema.Draft7Validator(schema).iter_errors(sample), key=lambda err: list(err.path))
+
+    assert errors == []
+
+
 def test_build_libraries_section_emits_collection_hub_priority(app):
     from modules import output
 
@@ -3121,6 +3150,30 @@ def test_build_libraries_section_emits_collection_hub_priority(app):
     assert movie_entry["template_variables"]["hub_priority"] == "2"
     assert movie_entry["template_variables"]["visible_home_12A"] is True
     assert movie_entry["template_variables"]["hub_priority_12A"] == "1"
+
+
+def test_build_libraries_section_prunes_default_seasonal_schedule_and_keeps_child_radarr(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_collections={
+                "movies": {
+                    "mov-library_movies-collection_seasonal": True,
+                    "mov-library_movies-template_collection_seasonal_schedule_memorial": "range(05/18-06/07)",
+                    "mov-library_movies-template_collection_seasonal_radarr_add_missing_christmas": "true",
+                }
+            },
+        )
+
+    seasonal_entry = next(
+        (entry for entry in libraries_section["libraries"]["Movies"]["collection_files"] if entry.get("default") == "seasonal"),
+        None,
+    )
+
+    assert seasonal_entry is not None
+    assert seasonal_entry["template_variables"] == {"radarr_add_missing_christmas": True}
 
 
 def test_build_libraries_section_expands_franchise_dynamic_child_override_maps(app):

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -122,6 +122,30 @@ def test_apply_template_var_normalizers_expands_seasonal_dynamic_child_override_
     assert "child_imdb_search_overrides" not in template_vars
 
 
+def test_apply_template_var_normalizers_drops_unchanged_seasonal_child_schedule_defaults():
+    template_vars = {
+        "schedule_memorial": "range(05/18-06/07)",
+        "schedule_christmas": "range(12/01-12/31)",
+        "radarr_add_missing_christmas": True,
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "seasonal")
+
+    assert "schedule_memorial" not in template_vars
+    assert "schedule_christmas" not in template_vars
+    assert template_vars["radarr_add_missing_christmas"] is True
+
+
+def test_apply_template_var_normalizers_keeps_custom_seasonal_child_schedule():
+    template_vars = {
+        "schedule_memorial": "weekly(sunday)",
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "seasonal")
+
+    assert template_vars["schedule_memorial"] == "weekly(sunday)"
+
+
 def test_apply_template_var_normalizers_expands_region_dynamic_child_override_maps():
     template_vars = {
         "child_use_overrides": '{"North America": "false"}',


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description
**PR Description**

Fixes Seasonal collection output and validation issues when enabling Seasonal defaults or per-holiday Radarr options.

### What changed

- Prevented untouched Seasonal child schedule defaults from being emitted into generated YAML.
  - Example: enabling Seasonal no longer writes a stray `schedule_memorial` override just because that default field was rendered.
  - Custom schedule edits are still preserved.

- Updated the local Kometa config schema fixture/cache so Seasonal child Radarr overrides validate correctly.
  - Adds support under `seasonal-template-vars.patternProperties` for:
    - `radarr_add_missing_*`
    - `radarr_folder_*`
    - `radarr_monitor_*`
    - `radarr_monitor_existing_*`
    - `radarr_search_*`
    - `radarr_tag_*`
    - `radarr_upgrade_existing_*`
    - `item_radarr_tag_*`

- Added regression coverage for:
  - Pruning unchanged Seasonal schedule defaults.
  - Keeping custom Seasonal schedule overrides.
  - Emitting `radarr_add_missing_christmas` while omitting unchanged `schedule_memorial`.
  - Schema validation accepting Seasonal child Radarr overrides.

### Upstream note

The schema change should also be applied upstream in Kometa at:

`json-schema/config-schema.json`

Definition:

`definitions.seasonal-template-vars.patternProperties`

### Testing

```bash
python -m pytest tests\test_output_collection_child_override_contract.py tests\test_core_backend.py::test_build_libraries_section_prunes_default_seasonal_schedule_and_keeps_child_radarr tests\test_core_backend.py::test_runtime_config_schema_accepts_seasonal_child_radarr_add_missing -q
```

Result:

```text
22 passed
```

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791690414&installation_model_id=431096&pr_number=1824&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1824&signature=1c7499f3200b6bf26a362a0ac7ad261dbbf0606b3d069011e0876583d60e1b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->