### PR TITLE
Run command fixes

### DIFF
--- a/modules/logscan_finished_runs.py
+++ b/modules/logscan_finished_runs.py
@@ -229,7 +229,7 @@ def find_last_run_time_index(lines: list[str]) -> tuple[Optional[int], bool]:
         if fallback_index is None:
             fallback_index = idx
         previous_line = lines[idx - 1] if idx > 0 else ""
-        previous_is_finished_run = re.search(r"\bFinished\s+Run\b", previous_line, re.IGNORECASE)
+        previous_is_finished_run = re.search(r"\bFinished(?:\s+(?:Libraries|\d{1,2}:\d{2}))?\s+Run\b", previous_line, re.IGNORECASE)
         if "Finished:" in line or "Start Time:" in line or previous_is_finished_run:
             run_time_index = idx
             return run_time_index, True

--- a/modules/logscan_progress_engine.py
+++ b/modules/logscan_progress_engine.py
@@ -68,6 +68,13 @@ def extract_mapping_library(message):
     return None
 
 
+def is_finished_run_marker(message):
+    """Return True for whole-run finished banners, including scheduled runs."""
+    if not message:
+        return False
+    return bool(re.search(r"\bFinished(?:\s+(?:Libraries|\d{1,2}:\d{2}))?\s+Run\b", str(message), re.IGNORECASE))
+
+
 def map_section_to_phase(section_name):
     """Map a section header like ``Overlays`` to a phase key like ``overlays``."""
     if not section_name:
@@ -539,15 +546,7 @@ def extract_progress(
                     current_library = None
             continue
 
-        if "Finished Libraries Run" in msg:
-            finished_run_seen = True
-            if current_library and current_library in statuses and statuses[current_library] != "Skipped":
-                statuses[current_library] = "Done"
-            current_library = None
-            playlist_running = False
-            continue
-
-        if "Finished Run" in msg:
+        if is_finished_run_marker(msg):
             if current_library and current_library in statuses and statuses[current_library] != "Skipped":
                 statuses[current_library] = "Done"
             current_library = None
@@ -675,7 +674,7 @@ def extract_progress(
         for phase in completed_from_sequence:
             if phase not in phases_completed:
                 phases_completed.append(phase)
-    if "Finished Run" in content and phase_current and phase_current not in phases_completed:
+    if is_finished_run_marker(content) and phase_current and phase_current not in phases_completed:
         phases_completed.append(phase_current)
 
     if finished_run_seen and phase_start:

--- a/quickstart.py
+++ b/quickstart.py
@@ -25,6 +25,7 @@ import os
 import platform
 import psutil
 import re
+import shlex
 import shutil
 import signal
 import socket
@@ -3912,6 +3913,157 @@ def shutdown():
     return jsonify(success=True, message="Shutting down..."), 200
 
 
+def _hhmm_to_minutes(value):
+    match = re.match(r"^([01]\d|2[0-3]):([0-5]\d)$", str(value or "").strip())
+    if not match:
+        return None
+    return int(match.group(1)) * 60 + int(match.group(2))
+
+
+def _minutes_to_hhmm(value):
+    minutes = int(value or 0) % 1440
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def _time_min_within_window(time_min, start_min, end_min):
+    if time_min is None or start_min is None or end_min is None or start_min == end_min:
+        return False
+    if start_min < end_min:
+        return start_min <= time_min < end_min
+    return time_min >= start_min or time_min < end_min
+
+
+def _split_kometa_command_parts(command):
+    try:
+        return shlex.split(str(command or ""), posix=not sys.platform.startswith("win"))
+    except Exception:
+        return str(command or "").split()
+
+
+def _strip_cli_value_quotes(value):
+    text = str(value or "").strip()
+    if len(text) >= 2 and ((text[0] == '"' and text[-1] == '"') or (text[0] == "'" and text[-1] == "'")):
+        return text[1:-1]
+    return text
+
+
+def _extract_kometa_scheduled_times(command):
+    parts = _split_kometa_command_parts(command)
+    if not parts:
+        return ["05:00"], True
+    for idx, part in enumerate(parts):
+        if part.startswith("--times="):
+            raw = _strip_cli_value_quotes(part.split("=", 1)[1])
+            return [item.strip() for item in raw.split("|") if item.strip()], False
+        if part == "--times" and idx + 1 < len(parts):
+            raw = _strip_cli_value_quotes(parts[idx + 1])
+            return [item.strip() for item in raw.split("|") if item.strip()], False
+    immediate_flags = {"--run", "--run-libraries"}
+    if any(part in immediate_flags or part.startswith("--run-libraries=") for part in parts):
+        return [], False
+    return ["05:00"], True
+
+
+def _next_local_datetime_for_hhmm(value, now=None):
+    minutes = _hhmm_to_minutes(value)
+    if minutes is None:
+        return None
+    now = now or datetime.now()
+    candidate = now.replace(hour=minutes // 60, minute=minutes % 60, second=0, microsecond=0)
+    if candidate < now:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def _format_local_datetime_payload(value):
+    if not value:
+        return None, None
+    return value.isoformat(), value.strftime("%Y-%m-%d %I:%M %p").lstrip("0")
+
+
+def _build_kometa_schedule_timing_payload(command, now=None):
+    times, uses_default = _extract_kometa_scheduled_times(command)
+    candidates = [_next_local_datetime_for_hhmm(value, now=now) for value in times]
+    candidates = [value for value in candidates if value is not None]
+    if not candidates:
+        return {"schedule_times": times, "scheduled_run_at": None, "scheduled_run_local": None, "uses_default_schedule_time": uses_default}
+    scheduled = min(candidates)
+    scheduled_at, scheduled_local = _format_local_datetime_payload(scheduled)
+    return {
+        "schedule_times": times,
+        "scheduled_run_at": scheduled_at,
+        "scheduled_run_local": scheduled_local,
+        "uses_default_schedule_time": uses_default,
+    }
+
+
+def _maintenance_window_end_datetime(now, start_min, end_min):
+    if start_min is None or end_min is None or start_min == end_min:
+        return None
+    now = now or datetime.now()
+    end_dt = now.replace(hour=end_min // 60, minute=end_min % 60, second=0, microsecond=0)
+    if start_min < end_min:
+        if end_dt <= now:
+            end_dt += timedelta(days=1)
+        return end_dt
+    if (now.hour * 60 + now.minute) >= start_min:
+        end_dt += timedelta(days=1)
+    return end_dt
+
+
+def _build_kometa_queue_timing_payload(command, start_min, end_min, now=None):
+    now = now or datetime.now()
+    queued_start = _maintenance_window_end_datetime(now, start_min, end_min)
+    queued_start_at, queued_start_local = _format_local_datetime_payload(queued_start)
+    payload = {
+        "queued_start_at": queued_start_at,
+        "queued_start_local": queued_start_local,
+    }
+    payload.update(_build_kometa_schedule_timing_payload(command, now=now))
+    return payload
+
+
+def _get_pending_kometa_timing_payload(pending=None, now=None, include_window=True):
+    pending = pending if pending is not None else _peek_pending_kometa_start()
+    if not pending:
+        return {}
+    config_name = pending.get("config_name")
+    start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=config_name)
+    if start_min is None or end_min is None:
+        start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=config_name)
+    payload = _build_kometa_queue_timing_payload(pending.get("command"), start_min, end_min, now=now or datetime.now())
+    if include_window and window_str:
+        payload["maintenance_window"] = window_str
+    payload["queued_reason"] = "plex_maintenance"
+    return payload
+
+
+def _get_kometa_schedule_maintenance_conflict(command, start_min, end_min, window_str=None):
+    if start_min is None or end_min is None:
+        return None
+    times, uses_default = _extract_kometa_scheduled_times(command)
+    overlapping = []
+    for value in times:
+        minutes = _hhmm_to_minutes(value)
+        if _time_min_within_window(minutes, start_min, end_min):
+            overlapping.append(value)
+    if not overlapping:
+        return None
+    if uses_default:
+        message = f"Kometa default scheduled time 05:00 starts during Plex maintenance ({window_str or f'{_minutes_to_hhmm(start_min)}-{_minutes_to_hhmm(end_min)}'}). Choose --run to start immediately, or set --times after the maintenance window."
+    else:
+        label = ", ".join(overlapping)
+        message = f"Kometa scheduled time{'s' if len(overlapping) > 1 else ''} {label} start{'s' if len(overlapping) == 1 else ''} during Plex maintenance ({window_str or f'{_minutes_to_hhmm(start_min)}-{_minutes_to_hhmm(end_min)}'}). Choose a time after the maintenance window."
+    return {
+        "message": message,
+        "times": overlapping,
+        "maintenance_start": _minutes_to_hhmm(start_min),
+        "maintenance_end": _minutes_to_hhmm(end_min),
+        "maintenance_window": window_str,
+        "uses_default_schedule_time": uses_default,
+    }
+
+
 @app.route("/start-kometa", methods=["POST"])
 def start_kometa():
     data = request.get_json() or {}
@@ -3969,9 +4121,30 @@ def start_kometa():
     start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=maintenance_config_name)
     if start_min is None or end_min is None:
         start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=maintenance_config_name)
+    schedule_conflict = _get_kometa_schedule_maintenance_conflict(command, start_min, end_min, window_str)
+    if schedule_conflict:
+        return (
+            jsonify(
+                {
+                    "error": schedule_conflict["message"],
+                    "status": "blocked",
+                    "blocked_by": "maintenance_schedule",
+                    "maintenance_window": window_str,
+                    "schedule_conflict": schedule_conflict,
+                }
+            ),
+            400,
+        )
     if _is_within_maintenance_window(datetime.now(), start_min, end_min):
         _set_pending_kometa_start(command, session.get("config_name"), start_mode=start_mode)
-        return jsonify({"status": "queued", "maintenance_window": window_str, "start_mode": start_mode}), 202
+        payload = {
+            "status": "queued",
+            "maintenance_window": window_str,
+            "start_mode": start_mode,
+            "queued_reason": "plex_maintenance",
+        }
+        payload.update(_build_kometa_queue_timing_payload(command, start_min, end_min, now=datetime.now()))
+        return jsonify(payload), 202
 
     ok, result = _launch_kometa_command(command, session.get("config_name"), start_mode=start_mode)
     if ok:
@@ -4060,6 +4233,7 @@ def kometa_status():
     pending_requested_at = pending.get("requested_at") if pending else None
     pending_start_mode = _normalize_kometa_start_mode(pending.get("start_mode")) if pending else "current"
     pending_command = pending.get("command") if pending else None
+    pending_timing = _get_pending_kometa_timing_payload(pending, include_window=False) if pending else {}
     ctx = _get_run_context()
     pid = helpers.get_kometa_pid()
     if not pid:
@@ -4072,11 +4246,12 @@ def kometa_status():
             except Exception:
                 pid = None
     if not pid:
-        try:
-            _ingest_completed_live_logs("kometa")
-        except Exception:
-            pass
-        _clear_run_context()
+        if not pending_start:
+            try:
+                _ingest_completed_live_logs("kometa")
+            except Exception:
+                pass
+            _clear_run_context()
         with MAINTENANCE_STATE_LOCK:
             maintenance_active = MAINTENANCE_STATE["active"]
             maintenance_paused = MAINTENANCE_STATE["paused"]
@@ -4086,7 +4261,7 @@ def kometa_status():
             window_unavailable = MAINTENANCE_STATE["window_unavailable"]
             window_unavailable_since = MAINTENANCE_STATE["window_unavailable_since"]
         return jsonify(
-            status="not started",
+            status="queued" if pending_start else "not started",
             maintenance_active=maintenance_active,
             maintenance_paused=maintenance_paused,
             maintenance_window=maintenance_window,
@@ -4098,6 +4273,7 @@ def kometa_status():
             pending_requested_at=pending_requested_at,
             pending_start_mode=pending_start_mode,
             pending_command=pending_command,
+            **pending_timing,
         )
 
     try:
@@ -4210,7 +4386,8 @@ def kometa_status():
             os.remove(helpers.get_kometa_pid_file())
         except Exception:
             pass
-        _clear_run_context()
+        if not pending_start:
+            _clear_run_context()
         with MAINTENANCE_STATE_LOCK:
             maintenance_active = MAINTENANCE_STATE["active"]
             maintenance_paused = MAINTENANCE_STATE["paused"]
@@ -4220,7 +4397,7 @@ def kometa_status():
             window_unavailable = MAINTENANCE_STATE["window_unavailable"]
             window_unavailable_since = MAINTENANCE_STATE["window_unavailable_since"]
         return jsonify(
-            status="not started",
+            status="queued" if pending_start else "not started",
             maintenance_active=maintenance_active,
             maintenance_paused=maintenance_paused,
             maintenance_window=maintenance_window,
@@ -4232,12 +4409,90 @@ def kometa_status():
             pending_requested_at=pending_requested_at,
             pending_start_mode=pending_start_mode,
             pending_command=pending_command,
+            **pending_timing,
         )
+
+
+def _get_active_kometa_started_at_ts():
+    pid = helpers.get_kometa_pid()
+    candidates = []
+    if pid:
+        try:
+            candidates.append(psutil.Process(pid))
+        except Exception:
+            pass
+    try:
+        proc = _find_running_kometa_process()
+        if proc:
+            candidates.append(proc)
+    except Exception:
+        pass
+    for proc in candidates:
+        try:
+            if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                cmdline = " ".join(proc.cmdline() or [])
+                if "kometa.py" in cmdline:
+                    return proc.create_time()
+        except Exception:
+            continue
+    return None
+
+
+def _build_waiting_for_kometa_log_payload(log_path, status="waiting_for_log", started_at_ts=None):
+    payload = {
+        "status": status,
+        "log": "",
+        "log_mtime": None,
+        "log_age_seconds": None,
+        "log_is_stale": True,
+        "log_path": str(log_path),
+    }
+    if status == "queued":
+        pending = _peek_pending_kometa_start()
+        payload.update(_get_pending_kometa_timing_payload(pending))
+        payload.update(
+            {
+                "pending_start": True,
+                "pending_requested_at": pending.get("requested_at") if pending else None,
+                "pending_start_mode": _normalize_kometa_start_mode(pending.get("start_mode")) if pending else "current",
+                "pending_command": pending.get("command") if pending else None,
+                "message": "Kometa is queued and has not started writing a log yet.",
+            }
+        )
+    else:
+        ctx = _get_run_context()
+        payload.update(_build_kometa_schedule_timing_payload(ctx.get("command"), now=datetime.now()))
+        payload["pending_start"] = False
+        payload["started_at_ts"] = started_at_ts
+        payload["message"] = "Kometa is running but has not written a fresh meta.log for this run yet."
+    return payload
+
+
+def _get_kometa_log_wait_payload(log_path):
+    pending = _peek_pending_kometa_start()
+    active_started_at = _get_active_kometa_started_at_ts()
+    if pending and active_started_at is None:
+        return _build_waiting_for_kometa_log_payload(log_path, status="queued")
+    if active_started_at is None:
+        return None
+    try:
+        log_stats = log_path.stat()
+    except FileNotFoundError:
+        return _build_waiting_for_kometa_log_payload(log_path, started_at_ts=active_started_at)
+    except Exception:
+        return None
+    if log_stats.st_mtime < (active_started_at - 30):
+        return _build_waiting_for_kometa_log_payload(log_path, started_at_ts=active_started_at)
+    return None
 
 
 @app.route("/tail-log")
 def tail_log():
     log_path = helpers.get_kometa_log_dir() / "meta.log"
+
+    wait_payload = _get_kometa_log_wait_payload(log_path)
+    if wait_payload:
+        return jsonify(wait_payload)
 
     if not log_path.exists():
         return jsonify({"error": f"Log file not found at: {log_path}"}), 404
@@ -4518,6 +4773,11 @@ def logscan_analyze():
     normalized_name = (config_name or "").strip().lower().replace(" ", "_") or "default"
     config_path = helpers.get_kometa_config_dir() / f"{normalized_name}_config.yml"
 
+    wait_payload = _get_kometa_log_wait_payload(log_path)
+    if wait_payload:
+        wait_payload.update({"cached": False, "ingest_skipped": True, "summary": None, "recommendations": []})
+        return jsonify(wait_payload)
+
     if not log_path.exists():
         return jsonify({"error": f"Log file not found at: {log_path}"}), 404
 
@@ -4594,6 +4854,11 @@ def logscan_progress():
     log_path = helpers.get_kometa_log_dir() / "meta.log"
     sidecar_path = _get_kometa_maintenance_sidecar_path(kometa_root)
     pending_path = _get_kometa_pending_marker_path(kometa_root)
+
+    wait_payload = _get_kometa_log_wait_payload(log_path)
+    if wait_payload:
+        wait_payload.update({"libraries": [], "total_count": 0, "completed_count": 0})
+        return jsonify(wait_payload)
 
     if not log_path.exists():
         return jsonify({"error": f"Log file not found at: {log_path}"}), 404

--- a/quickstart.py
+++ b/quickstart.py
@@ -4238,10 +4238,11 @@ def _kometa_log_looks_waiting_after_finished(log_path, started_at_ts=None):
         content = _read_text_tail(log_path, 4000)
     except Exception:
         return False
-    finished_idx = content.rfind("Finished Run")
-    if finished_idx < 0:
+    finished_matches = list(re.finditer(r"\bFinished(?:\s+(?:Libraries|\d{1,2}:\d{2}))?\s+Run\b", content, flags=re.IGNORECASE))
+    if not finished_matches:
         return False
-    after_finished = content[finished_idx + len("Finished Run") :]
+    finished_match = finished_matches[-1]
+    after_finished = content[finished_match.end() :]
     if re.search(r"Mapping\s+.+?\s+Library|Starting\s+(Run|Library)|Processing\s+", after_finished, flags=re.IGNORECASE):
         return False
     return True

--- a/quickstart.py
+++ b/quickstart.py
@@ -4222,6 +4222,41 @@ def stop_kometa():
         return jsonify({"error": f"Failed to stop Kometa: {str(e)}"}), 500
 
 
+def _kometa_command_has_schedule(command):
+    times, _uses_default = _extract_kometa_scheduled_times(command)
+    return bool(times)
+
+
+def _kometa_log_looks_waiting_after_finished(log_path, started_at_ts=None):
+    try:
+        stats = log_path.stat()
+    except Exception:
+        return False
+    if started_at_ts is not None and stats.st_mtime < (started_at_ts - 30):
+        return False
+    try:
+        content = _read_text_tail(log_path, 4000)
+    except Exception:
+        return False
+    finished_idx = content.rfind("Finished Run")
+    if finished_idx < 0:
+        return False
+    after_finished = content[finished_idx + len("Finished Run") :]
+    if re.search(r"Mapping\s+.+?\s+Library|Starting\s+(Run|Library)|Processing\s+", after_finished, flags=re.IGNORECASE):
+        return False
+    return True
+
+
+def _build_scheduled_waiting_payload(command, log_path, started_at_ts=None):
+    if not _kometa_command_has_schedule(command):
+        return None
+    if not _kometa_log_looks_waiting_after_finished(log_path, started_at_ts=started_at_ts):
+        return None
+    payload = _build_kometa_schedule_timing_payload(command, now=datetime.now())
+    payload["message"] = "Kometa finished the current scheduled run and is waiting for the next scheduled time."
+    return payload
+
+
 @app.route("/kometa-status", methods=["GET"])
 def kometa_status():
     try:
@@ -4311,8 +4346,10 @@ def kometa_status():
                     queued_started_at = MAINTENANCE_STATE["queued_started_at"]
                     window_unavailable = MAINTENANCE_STATE["window_unavailable"]
                     window_unavailable_since = MAINTENANCE_STATE["window_unavailable_since"]
+                active_command = ctx.get("command")
+                scheduled_waiting = _build_scheduled_waiting_payload(active_command, helpers.get_kometa_log_dir() / "meta.log", started_at_ts=started_at_ts)
                 return jsonify(
-                    status="running",
+                    status="scheduled_waiting" if scheduled_waiting else "running",
                     pid=pid,
                     started_at=started_at,
                     started_at_ts=started_at_ts,
@@ -4338,7 +4375,9 @@ def kometa_status():
                     pending_start=pending_start,
                     pending_requested_at=pending_requested_at,
                     start_mode=_normalize_kometa_start_mode(ctx.get("start_mode")),
-                    active_command=ctx.get("command"),
+                    active_command=active_command,
+                    scheduled_waiting=bool(scheduled_waiting),
+                    **(scheduled_waiting or {}),
                 )
         # If we're here, it likely ended; try to get a return code
         try:
@@ -4593,12 +4632,14 @@ def tail_log():
         log_is_stale = False
         if log_mtime is not None and kometa_started_at is not None:
             log_is_stale = log_mtime < (kometa_started_at - 30)
+        log_is_previous_run = kometa_started_at is None
 
         response = {
             "log": log_content,
             "log_mtime": log_mtime,
             "log_age_seconds": log_age_seconds,
             "log_is_stale": log_is_stale,
+            "log_is_previous_run": log_is_previous_run,
             "log_path": str(log_path),
         }
         if include_stats:
@@ -4999,6 +5040,27 @@ def logscan_progress():
                             entry["status"] = "Stopped"
             return data
 
+        def normalize_progress_for_finished(data):
+            if not isinstance(data, dict) or not data.get("run_finished"):
+                return data
+            data = deepcopy(data)
+            data["current_library"] = None
+            data["phase_current"] = None
+            data["playlist_running"] = False
+            libraries = data.get("libraries")
+            if isinstance(libraries, list):
+                completed = 0
+                for entry in libraries:
+                    if not isinstance(entry, dict):
+                        continue
+                    if entry.get("status") == "Skipped":
+                        continue
+                    entry["status"] = "Done"
+                    completed += 1
+                data["completed_count"] = completed
+                data["total_count"] = data.get("total_count") or len(libraries)
+            return data
+
         ctx = _get_run_context()
         selected = ctx.get("selected_libraries")
         started_at = ctx.get("started_at")
@@ -5024,6 +5086,7 @@ def logscan_progress():
         if not force_full_read and _cache_matches_progress_signature():
             data = cached.get("data") or {}
             data = refresh_live_progress_elapsed(data, running, started_at)
+            data = normalize_progress_for_finished(data)
             data = normalize_progress_for_stopped(data, running, stopped_requested)
             return jsonify(data)
 
@@ -5049,7 +5112,7 @@ def logscan_progress():
         phase_order = _get_progress_run_order(config_data=config_data)
         allowed_phases = phase_order or ["operations", "metadata", "collections", "overlays"]
         playlists_configured = bool(config_data.get("playlists")) if isinstance(config_data, dict) else False
-        if run_mode in ("collections", "overlays", "operations", "metadata", "playlists"):
+        if run_mode in ("collections", "overlays", "operations", "metadata", "playlists") and not progress.get("run_finished"):
             allowed_phases = [run_mode]
             progress["phase_current"] = run_mode
             progress["phases_completed"] = []
@@ -5061,6 +5124,7 @@ def logscan_progress():
         maintenance_summary = analyzer.extract_maintenance_summary(log_content)
         progress["maintenance_summary"] = maintenance_summary if isinstance(maintenance_summary, dict) else {}
         progress["maintenance_had_pause"] = bool((progress.get("maintenance_summary") or {}).get("had_pause"))
+        progress = normalize_progress_for_finished(progress)
         progress = normalize_progress_for_stopped(progress, running, stopped_requested)
         if log_stats:
             progress["last_log_at"] = datetime.fromtimestamp(log_stats.st_mtime, tz=timezone.utc).isoformat()

--- a/quickstart.py
+++ b/quickstart.py
@@ -3964,13 +3964,14 @@ def _extract_kometa_scheduled_times(command):
     return ["05:00"], True
 
 
-def _next_local_datetime_for_hhmm(value, now=None):
+def _next_local_datetime_for_hhmm(value, now=None, after=None):
     minutes = _hhmm_to_minutes(value)
     if minutes is None:
         return None
     now = now or datetime.now()
-    candidate = now.replace(hour=minutes // 60, minute=minutes % 60, second=0, microsecond=0)
-    if candidate < now:
+    reference = after or now
+    candidate = reference.replace(hour=minutes // 60, minute=minutes % 60, second=0, microsecond=0)
+    if candidate <= reference:
         candidate += timedelta(days=1)
     return candidate
 
@@ -3981,9 +3982,9 @@ def _format_local_datetime_payload(value):
     return value.isoformat(), value.strftime("%Y-%m-%d %I:%M %p").lstrip("0")
 
 
-def _build_kometa_schedule_timing_payload(command, now=None):
+def _build_kometa_schedule_timing_payload(command, now=None, after=None):
     times, uses_default = _extract_kometa_scheduled_times(command)
-    candidates = [_next_local_datetime_for_hhmm(value, now=now) for value in times]
+    candidates = [_next_local_datetime_for_hhmm(value, now=now, after=after) for value in times]
     candidates = [value for value in candidates if value is not None]
     if not candidates:
         return {"schedule_times": times, "scheduled_run_at": None, "scheduled_run_local": None, "uses_default_schedule_time": uses_default}
@@ -4245,15 +4246,29 @@ def _kometa_log_looks_waiting_after_finished(log_path, started_at_ts=None):
     after_finished = content[finished_match.end() :]
     if re.search(r"Mapping\s+.+?\s+Library|Starting\s+(Run|Library)|Processing\s+", after_finished, flags=re.IGNORECASE):
         return False
-    return True
+    finished_at = None
+    line_start = content.rfind("\n", 0, finished_match.start()) + 1
+    line_end = content.find("\n", finished_match.end())
+    if line_end == -1:
+        line_end = len(content)
+    finished_line = content[line_start:line_end]
+    ts_match = re.search(r"\[(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})", finished_line)
+    if ts_match:
+        try:
+            finished_at = datetime.strptime(f"{ts_match.group(1)} {ts_match.group(2)}", "%Y-%m-%d %H:%M:%S")
+        except Exception:
+            finished_at = None
+    return {"finished_at": finished_at}
 
 
 def _build_scheduled_waiting_payload(command, log_path, started_at_ts=None):
     if not _kometa_command_has_schedule(command):
         return None
-    if not _kometa_log_looks_waiting_after_finished(log_path, started_at_ts=started_at_ts):
+    finished_info = _kometa_log_looks_waiting_after_finished(log_path, started_at_ts=started_at_ts)
+    if not finished_info:
         return None
-    payload = _build_kometa_schedule_timing_payload(command, now=datetime.now())
+    now = datetime.now()
+    payload = _build_kometa_schedule_timing_payload(command, now=now, after=finished_info.get("finished_at") or now)
     payload["message"] = "Kometa finished the current scheduled run and is waiting for the next scheduled time."
     return payload
 

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -784,9 +784,10 @@ function qsBuildKometaActiveWorkEntry () {
   const href = '/step/900-kometa'
   const status = String(data.status || '').trim().toLowerCase()
   const running = status === 'running'
+  const scheduledWaiting = status === 'scheduled_waiting'
   const runtimeDetails = qsBuildRuntimeActiveDetails(data, 'Kometa')
   const progressDetails = qsBuildKometaProgressDetails()
-  const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || running)
+  const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || running || scheduledWaiting)
 
   if (unavailableBlocksWork) {
     const since = data.window_unavailable_since ? `Since ${qsFormatTimestamp(data.window_unavailable_since)}` : 'Maintenance window data unavailable'
@@ -833,6 +834,21 @@ function qsBuildKometaActiveWorkEntry () {
       details,
       href,
       titleAttr: qsBuildActiveTitleAttr('Kometa is paused for Plex maintenance.', pausedSince, details)
+    }
+  }
+
+  if (scheduledWaiting) {
+    const details = [...progressDetails, ...runtimeDetails]
+    if (data.scheduled_run_local) qsPushActiveDetail(details, 'Next run', data.scheduled_run_local)
+    return {
+      key: 'kometa-scheduled-waiting',
+      title: 'Kometa scheduler',
+      chip: 'Waiting',
+      state: 'warn',
+      meta: data.scheduled_run_local ? `Next run ${data.scheduled_run_local}` : 'Current run finished; waiting for the next scheduled time.',
+      details,
+      href,
+      titleAttr: qsBuildActiveTitleAttr('Kometa scheduler', data.scheduled_run_local ? `Next run ${data.scheduled_run_local}` : 'Current run finished; waiting for the next scheduled time.', details)
     }
   }
 
@@ -1180,7 +1196,8 @@ function qsRenderBackgroundJobPills () {
 function qsHandleMaintenanceStatus (data) {
   if (!data) return
   qsLatestKometaStatus = data
-  const active = String(data.status || '').trim().toLowerCase() === 'running' || Boolean(data.maintenance_paused)
+  const activeStatus = String(data.status || '').trim().toLowerCase()
+  const active = activeStatus === 'running' || activeStatus === 'scheduled_waiting' || Boolean(data.maintenance_paused)
   if (!active) qsLatestKometaRunProgress = null
   const paused = Boolean(data.maintenance_paused)
   const windowLabel = data.maintenance_window ? ` (${data.maintenance_window})` : ''
@@ -1195,7 +1212,7 @@ function qsHandleMaintenanceStatus (data) {
   const queuedBadge = document.getElementById('qs-queued-badge')
 
   if (runningBadge) {
-    if (data.status === 'running') {
+    if (data.status === 'running' || data.status === 'scheduled_waiting') {
       const elapsed = typeof data.elapsed_seconds === 'number' ? data.elapsed_seconds : null
       let elapsedLabel = ''
       if (elapsed !== null) {
@@ -1211,7 +1228,11 @@ function qsHandleMaintenanceStatus (data) {
       runningBadge.classList.remove('d-none')
       const label = runningBadge.querySelector('span')
       if (label) {
-        label.innerHTML = `<i class="bi bi-play-circle me-1"></i> Kometa running${elapsedLabel}`
+        if (data.status === 'scheduled_waiting') {
+          label.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Kometa scheduler waiting'
+        } else {
+          label.innerHTML = `<i class="bi bi-play-circle me-1"></i> Kometa running${elapsedLabel}`
+        }
       }
     } else {
       runningBadge.classList.add('d-none')

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -541,6 +541,69 @@ function qsShowQueuedFlashToast () {
 }
 
 // Function to show toast messages
+function qsConfirmAction (options = {}) {
+  const title = String(options.title || 'Confirm action')
+  const message = String(options.message || 'Continue?')
+  const details = String(options.details || '').trim()
+  const confirmText = String(options.confirmText || 'Continue')
+  const cancelText = String(options.cancelText || 'Cancel')
+  const confirmClass = String(options.confirmClass || 'btn-primary')
+  const iconClass = String(options.iconClass || 'bi bi-exclamation-triangle text-warning')
+  const modalEl = document.getElementById('qs-confirm-modal')
+
+  const fallback = () => {
+    const fallbackMessage = [title, '', message, details ? `\n${details}` : ''].filter((part) => part !== '').join('\n')
+    return Promise.resolve(typeof window.confirm === 'function' ? window.confirm(fallbackMessage) : true)
+  }
+  if (!modalEl || typeof bootstrap === 'undefined' || !bootstrap.Modal) return fallback()
+
+  const titleEl = document.getElementById('qs-confirm-title')
+  const titleText = titleEl ? titleEl.querySelector('span') : null
+  const iconEl = document.getElementById('qs-confirm-icon')
+  const messageEl = document.getElementById('qs-confirm-message')
+  const detailsEl = document.getElementById('qs-confirm-details')
+  const confirmBtn = document.getElementById('qs-confirm-confirm')
+  const cancelBtn = document.getElementById('qs-confirm-cancel')
+  if (!titleEl || !messageEl || !confirmBtn || !cancelBtn) return fallback()
+
+  if (titleText) titleText.textContent = title
+  else titleEl.textContent = title
+  if (iconEl) iconEl.className = iconClass
+  messageEl.textContent = message
+  if (detailsEl) {
+    detailsEl.textContent = details
+    detailsEl.classList.toggle('d-none', !details)
+  }
+  confirmBtn.textContent = confirmText
+  cancelBtn.textContent = cancelText
+  confirmBtn.className = `btn ${confirmClass}`
+
+  return new Promise((resolve) => {
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl)
+    let settled = false
+    const cleanup = () => {
+      confirmBtn.removeEventListener('click', onConfirm)
+      modalEl.removeEventListener('hidden.bs.modal', onHidden)
+    }
+    const settle = (value) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const onConfirm = () => {
+      settle(true)
+      modal.hide()
+    }
+    const onHidden = () => settle(false)
+    confirmBtn.addEventListener('click', onConfirm)
+    modalEl.addEventListener('hidden.bs.modal', onHidden)
+    modal.show()
+  })
+}
+
+window.QS_confirmAction = qsConfirmAction
+
 function showToast (type, message) {
   const toastId = `toast-${Date.now()}` // Unique ID for each toast
   const toastContainer = document.querySelector('.toast-container')
@@ -2589,26 +2652,25 @@ function qsShouldPromptForBulkValidationDuringScheduledKometa (options = {}) {
 }
 
 function qsConfirmBulkValidationDuringScheduledKometa (options = {}) {
-  if (!qsShouldPromptForBulkValidationDuringScheduledKometa(options)) return true
+  if (!qsShouldPromptForBulkValidationDuringScheduledKometa(options)) return Promise.resolve(true)
   const nextRun = String((qsLatestKometaStatus && qsLatestKometaStatus.scheduled_run_local) || '').trim()
-  const suffix = nextRun ? `
-
-Next scheduled run: ${nextRun}` : ''
-  const message = `Kometa is waiting for a scheduled run. Validate All can continue, but it will not stop the waiting scheduler. If validation finds critical issues, stop Kometa before the next scheduled run.${suffix}
-
-Continue Validate All?`
-  if (typeof window.confirm !== 'function') return true
-  const confirmed = window.confirm(message)
-  if (!confirmed && typeof showToast === 'function') {
-    showToast('info', 'Validate All cancelled. Kometa scheduler is still waiting for its next run.')
-  }
-  return confirmed
+  return qsConfirmAction({
+    title: 'Kometa scheduler is waiting',
+    message: 'Validate All can continue, but it will not stop the waiting scheduler. If validation finds critical issues, stop Kometa before the next scheduled run.',
+    details: nextRun ? `Next scheduled run: ${nextRun}` : '',
+    confirmText: 'Continue Validate All',
+    cancelText: 'Cancel',
+    confirmClass: 'btn-warning',
+    iconClass: 'bi bi-exclamation-triangle text-warning'
+  }).then((confirmed) => {
+    if (!confirmed && typeof showToast === 'function') {
+      showToast('info', 'Validate All cancelled. Kometa scheduler is still waiting for its next run.')
+    }
+    return confirmed
+  })
 }
 
-function qsRunBulkValidation (options = {}) {
-  if (qsBulkValidationRequest) return qsBulkValidationRequest
-  if (!qsConfirmBulkValidationDuringScheduledKometa(options)) return Promise.resolve(null)
-
+function qsStartBulkValidation (options = {}) {
   const runId = options.runId || `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`
   qsLatestBulkValidationProgress = {
     run_id: runId,
@@ -2689,6 +2751,12 @@ function qsRunBulkValidation (options = {}) {
     })
 
   return qsBulkValidationRequest
+}
+
+function qsRunBulkValidation (options = {}) {
+  if (qsBulkValidationRequest) return qsBulkValidationRequest
+  return qsConfirmBulkValidationDuringScheduledKometa(options)
+    .then((confirmed) => confirmed ? qsStartBulkValidation(options) : null)
 }
 
 function updateValidationCallouts (inputId) {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -840,6 +840,7 @@ function qsBuildKometaActiveWorkEntry () {
   if (scheduledWaiting) {
     const details = [...progressDetails, ...runtimeDetails]
     if (data.scheduled_run_local) qsPushActiveDetail(details, 'Next run', data.scheduled_run_local)
+    if (Array.isArray(data.schedule_times) && data.schedule_times.length) qsPushActiveDetail(details, 'Schedule', data.schedule_times.join(' | '))
     return {
       key: 'kometa-scheduled-waiting',
       title: 'Kometa scheduler',

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -2581,8 +2581,33 @@ function qsSetBulkValidationLoading (isLoading) {
   })
 }
 
+function qsShouldPromptForBulkValidationDuringScheduledKometa (options = {}) {
+  if (options.skipScheduledKometaPrompt) return false
+  if (options.silentToast || options.source === 'final-freshness') return false
+  const status = String((qsLatestKometaStatus && qsLatestKometaStatus.status) || '').trim().toLowerCase()
+  return status === 'scheduled_waiting'
+}
+
+function qsConfirmBulkValidationDuringScheduledKometa (options = {}) {
+  if (!qsShouldPromptForBulkValidationDuringScheduledKometa(options)) return true
+  const nextRun = String((qsLatestKometaStatus && qsLatestKometaStatus.scheduled_run_local) || '').trim()
+  const suffix = nextRun ? `
+
+Next scheduled run: ${nextRun}` : ''
+  const message = `Kometa is waiting for a scheduled run. Validate All can continue, but it will not stop the waiting scheduler. If validation finds critical issues, stop Kometa before the next scheduled run.${suffix}
+
+Continue Validate All?`
+  if (typeof window.confirm !== 'function') return true
+  const confirmed = window.confirm(message)
+  if (!confirmed && typeof showToast === 'function') {
+    showToast('info', 'Validate All cancelled. Kometa scheduler is still waiting for its next run.')
+  }
+  return confirmed
+}
+
 function qsRunBulkValidation (options = {}) {
   if (qsBulkValidationRequest) return qsBulkValidationRequest
+  if (!qsConfirmBulkValidationDuringScheduledKometa(options)) return Promise.resolve(null)
 
   const runId = options.runId || `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`
   qsLatestBulkValidationProgress = {

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -115,6 +115,48 @@ let lastRenderedLogStartLine = null
 let lastFilteredLogResult = null
 let finalLogscanAnalyzeTriggered = false
 
+const RUN_BUTTON_IDLE_HTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run</span>'
+
+function setRunButtonIdleLabel () {
+  const runNow = document.getElementById('run-now')
+  if (runNow) {
+    runNow.innerHTML = RUN_BUTTON_IDLE_HTML
+    return
+  }
+  const label = document.getElementById('run-now-label')
+  if (label) label.textContent = 'Run'
+}
+
+function buildQueuedKometaMessage (data = {}) {
+  const windowLabel = data.maintenance_window ? ` (${data.maintenance_window})` : ''
+  const launchLabel = data.queued_start_local ? ` at ${data.queued_start_local}` : ' when it ends'
+  let message = `Plex maintenance active${windowLabel}. Quickstart will launch Kometa${launchLabel}.`
+  if (data.scheduled_run_local) {
+    const scheduleLabel = data.uses_default_schedule_time ? 'Kometa default scheduled run' : 'Kometa scheduled run'
+    message += ` ${scheduleLabel}: ${data.scheduled_run_local}.`
+  } else if (Array.isArray(data.schedule_times) && data.schedule_times.length === 0) {
+    message += ' The selected command will run immediately after launch.'
+  }
+  return message
+}
+
+function buildWaitingForKometaLogMessage (data = {}) {
+  if (data.status === 'queued' || data.pending_start) return buildQueuedKometaMessage(data)
+  let message = data.message || 'Kometa is running but has not written a fresh meta.log for this run yet.'
+  if (data.scheduled_run_local) {
+    const scheduleLabel = data.uses_default_schedule_time ? 'Default scheduled run' : 'Scheduled run'
+    message += ` ${scheduleLabel}: ${data.scheduled_run_local}.`
+  }
+  return message
+}
+
+function rebuildRunCommandAfterControlChange () {
+  if (kometaState.kometaStatus !== 'running' && !kometaState.kometaPendingStart && !kometaState.kometaUpdating) {
+    clearActiveRunCommandState()
+  }
+  buildCommand()
+}
+
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
 const tailSelect = document.getElementById('run-log-tail')
@@ -377,14 +419,14 @@ document.querySelectorAll('input[name="run-option"]').forEach(el => el.addEventL
   const value = this.value
   updateLibraryVisibility(value)
   checkMaintenanceWarning(value)
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 }))
 
-document.getElementById('times-input')?.addEventListener('input', buildCommand)
+document.getElementById('times-input')?.addEventListener('input', rebuildRunCommandAfterControlChange)
 
-document.getElementById('library-multiselect')?.addEventListener('change', buildCommand)
-document.querySelectorAll('input[name="mode-flag"]').forEach(el => el.addEventListener('change', buildCommand))
-document.querySelectorAll('input[name="log-flag"]').forEach(el => el.addEventListener('change', buildCommand))
+document.getElementById('library-multiselect')?.addEventListener('change', rebuildRunCommandAfterControlChange)
+document.querySelectorAll('input[name="mode-flag"]').forEach(el => el.addEventListener('change', rebuildRunCommandAfterControlChange))
+document.querySelectorAll('input[name="log-flag"]').forEach(el => el.addEventListener('change', rebuildRunCommandAfterControlChange))
 
 function syncValidationCommandOptions () {
   const validateMode = (document.querySelector('input[name="validate-mode"]:checked') || {}).value || ''
@@ -410,17 +452,17 @@ function syncValidationCommandOptions () {
 document.querySelectorAll('input[name="validate-mode"]').forEach(el => {
   el.addEventListener('change', function () {
     syncValidationCommandOptions()
-    buildCommand()
+    rebuildRunCommandAfterControlChange()
   })
 })
-document.getElementById('opt-validate-level')?.addEventListener('change', buildCommand)
+document.getElementById('opt-validate-level')?.addEventListener('change', rebuildRunCommandAfterControlChange)
 document.getElementById('opt-validate-schema')?.addEventListener('change', function () {
   syncValidationCommandOptions()
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
-document.getElementById('opt-validate-file-val')?.addEventListener('input', buildCommand)
-document.getElementById('opt-validate-dir-val')?.addEventListener('input', buildCommand)
-document.getElementById('opt-schema-path')?.addEventListener('input', buildCommand)
+document.getElementById('opt-validate-file-val')?.addEventListener('input', rebuildRunCommandAfterControlChange)
+document.getElementById('opt-validate-dir-val')?.addEventListener('input', rebuildRunCommandAfterControlChange)
+document.getElementById('opt-schema-path')?.addEventListener('input', rebuildRunCommandAfterControlChange)
 
 const checkboxFlags = [
   'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
@@ -430,7 +472,7 @@ const checkboxFlags = [
 
 checkboxFlags.forEach(opt => {
   const checkbox = document.getElementById(`opt-${opt}`)
-  if (checkbox) checkbox.addEventListener('change', buildCommand)
+  if (checkbox) checkbox.addEventListener('change', rebuildRunCommandAfterControlChange)
 })
 
 
@@ -515,7 +557,7 @@ function startKometaCommand (command, opts = {}) {
         lastLogStartLine = 1
         renderFilteredRunLog()
         document.getElementById('run-now').disabled = false
-        document.getElementById('run-now-label').textContent = 'Run Now'
+        setRunButtonIdleLabel()
         document.getElementById('stop-now').classList.add('d-none')
         syncIncompleteRunActions()
         return
@@ -524,9 +566,7 @@ function startKometaCommand (command, opts = {}) {
       if (data.status === 'queued') {
         applyActiveRunCommandState(command, startMode)
         kometaState.kometaPendingStart = true
-        const windowLabel = data.maintenance_window ? ` (${data.maintenance_window})` : ''
-        const nowLabel = (typeof window.QS_formatTimestamp === 'function') ? window.QS_formatTimestamp() : new Date().toLocaleString()
-        const message = `Plex maintenance active${windowLabel} at ${nowLabel}. Kometa will start automatically when it ends.`
+        const message = buildQueuedKometaMessage(data)
         showToast('warning', message)
         lastLogText = `${message}\n`
         lastLogStartLine = 1
@@ -557,7 +597,7 @@ function startKometaCommand (command, opts = {}) {
       try { buildCommand() } catch {}
       appendRunLogText('\n⚠️ Failed to start Kometa.')
       document.getElementById('run-now').disabled = false
-      document.getElementById('run-now-label').textContent = 'Run Now'
+      setRunButtonIdleLabel()
       document.getElementById('stop-now').classList.add('d-none')
       syncIncompleteRunActions()
     })
@@ -569,11 +609,13 @@ function startPollingIfNeeded () {
   if (kometaState.kometaInterval) clearInterval(kometaState.kometaInterval)
   if (kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
   if (kometaState.kometaProgressInterval) clearInterval(kometaState.kometaProgressInterval)
-  fetchKometaLog()
-  fetchRunProgress()
-  kometaState.kometaInterval = setInterval(fetchKometaLog, 3000)
+  if (!kometaState.kometaPendingStart) {
+    fetchKometaLog()
+    fetchRunProgress()
+    kometaState.kometaInterval = setInterval(fetchKometaLog, 3000)
+    kometaState.kometaProgressInterval = setInterval(fetchRunProgress, 5000)
+  }
   kometaState.kometaStatusInterval = setInterval(checkKometaStatus, 5000)
-  kometaState.kometaProgressInterval = setInterval(fetchRunProgress, 5000)
 }
 
 function resumeKometaLiveView () {
@@ -584,8 +626,10 @@ function resumeKometaLiveView () {
       if (kometaState.kometaStatus === 'running' || kometaState.kometaPendingStart) {
         kometaState.kometaPollingStarted = false
         startPollingIfNeeded()
-        fetchRunProgress(true)
-        fetchKometaLog()
+        if (!kometaState.kometaPendingStart) {
+          fetchRunProgress(true)
+          fetchKometaLog()
+        }
       }
     })
 }
@@ -630,7 +674,7 @@ document.getElementById('opt-timeout')?.addEventListener('change', function() {
     document.getElementById('opt-timeout-val').value = ''
     document.getElementById('timeout-error').classList.add('d-none')
   }
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
 
 document.getElementById('opt-width')?.addEventListener('change', function() {
@@ -639,13 +683,13 @@ document.getElementById('opt-width')?.addEventListener('change', function() {
     document.getElementById('opt-width-val').value = ''
     document.getElementById('width-error').classList.add('d-none')
   }
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
 
 // Restrict divider input
 document.getElementById('opt-divider-val')?.addEventListener('input', function() {
   this.value = this.value.replace(/\s/g, '').slice(0, 1)
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
 
 // Prevent non-numeric input for Timeout
@@ -654,7 +698,7 @@ document.getElementById('opt-timeout-val')?.addEventListener('input', function()
   if (this.value !== sanitized) {
     this.value = sanitized
   }
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
 
 // Prevent non-numeric input for Width
@@ -663,7 +707,7 @@ document.getElementById('opt-width-val')?.addEventListener('input', function() {
   if (this.value !== sanitized) {
     this.value = sanitized
   }
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
 
 document.getElementById('opt-divider')?.addEventListener('change', function() {
@@ -672,7 +716,7 @@ document.getElementById('opt-divider')?.addEventListener('change', function() {
     document.getElementById('opt-divider-val').value = ''
     document.getElementById('divider-error').classList.add('d-none')
   }
-  buildCommand()
+  rebuildRunCommandAfterControlChange()
 })
 
 pauseLogBtn?.addEventListener('click', function() {
@@ -1296,7 +1340,7 @@ function performStopKometa () {
       }
       kometaState.kometaStatus = 'not started'
       document.getElementById('run-now').disabled = false
-      document.getElementById('run-now-label').textContent = 'Run Now'
+      setRunButtonIdleLabel()
       document.getElementById('stop-now').classList.add('d-none') // hide stop again
       updateRunNowState()
     })
@@ -1328,6 +1372,13 @@ function fetchKometaLog () {
       if (!runLog) return
       if (data.error) {
         lastLogText = `❌ ${data.error}`
+        lastLogStartLine = 1
+        renderFilteredRunLog()
+        updateLogRecency(null)
+        return
+      }
+      if (data.status === 'queued' || data.status === 'waiting_for_log' || data.pending_start) {
+        lastLogText = `${buildWaitingForKometaLogMessage(data)}\n`
         lastLogStartLine = 1
         renderFilteredRunLog()
         updateLogRecency(null)
@@ -1412,9 +1463,7 @@ function checkKometaStatus () {
           data.pending_command || kometaState.activeRunCommandOverride || getRecoveryRunCommand(),
           data.pending_start_mode || kometaState.activeRunCommandMode || 'recovery'
         )
-        const windowLabel = data.maintenance_window ? ` (${data.maintenance_window})` : ''
-        const nowLabel = (typeof window.QS_formatTimestamp === 'function') ? window.QS_formatTimestamp() : new Date().toLocaleString()
-        const message = `Plex maintenance active${windowLabel} at ${nowLabel}. Kometa will start automatically when it ends.`
+        const message = buildQueuedKometaMessage(data)
         runNow.disabled = true
         runNow.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Waiting...'
         stopNow.classList.add('d-none')
@@ -1450,7 +1499,7 @@ function checkKometaStatus () {
         // Kometa is actively running → keep Run disabled, allow Stop
         revealRunCommandSection()
         runNow.disabled = true
-        runNow.innerHTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>'
+        setRunButtonIdleLabel()
         stopNow.classList.remove('d-none')
         stopNow.disabled = false
         document.getElementById('run-output').classList.remove('d-none')
@@ -1467,7 +1516,7 @@ function checkKometaStatus () {
       clearActiveRunCommandState()
       try { buildCommand() } catch {}
 
-      if (runNow) runNow.innerHTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>'
+      setRunButtonIdleLabel()
       if (stopNow) {
         stopNow.classList.add('d-none')
         stopNow.disabled = false

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1450,13 +1450,14 @@ function checkKometaStatus () {
       const stopNow = document.getElementById('stop-now')
       setKometaPrepareRunningState(data.status === 'running')
 
-      // Disable update if a Kometa process is active or an update is in progress
-      const kometaProcessActive = data.status === 'running' || data.status === 'scheduled_waiting'
+      // Disable update only while Kometa is actively running or an update is in progress.
+      // A waiting scheduler can be stopped safely by the update action after confirmation.
+      const kometaProcessActive = data.status === 'running'
       const shouldDisableUpdate = kometaProcessActive || kometaState.kometaUpdating
       if (shouldDisableUpdate) {
         const why = kometaState.kometaUpdating
           ? 'Kometa is updating; wait for it to finish.'
-          : (data.status === 'scheduled_waiting' ? 'Kometa scheduler is waiting; stop it before updating.' : 'Kometa is running; stop it before updating.')
+          : 'Kometa is running; stop it before updating.'
         if (updateBtn) {
           updateBtn.disabled = true
           updateBtn.setAttribute('title', why)

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -151,7 +151,7 @@ function buildWaitingForKometaLogMessage (data = {}) {
 }
 
 function rebuildRunCommandAfterControlChange () {
-  if (kometaState.kometaStatus !== 'running' && !kometaState.kometaPendingStart && !kometaState.kometaUpdating) {
+  if (kometaState.kometaStatus !== 'running' && kometaState.kometaStatus !== 'scheduled_waiting' && !kometaState.kometaPendingStart && !kometaState.kometaUpdating) {
     clearActiveRunCommandState()
   }
   buildCommand()
@@ -623,12 +623,16 @@ function resumeKometaLiveView () {
   checkKometaStatus()
     .catch(() => null)
     .finally(() => {
-      if (kometaState.kometaStatus === 'running' || kometaState.kometaPendingStart) {
+      if (kometaState.kometaStatus === 'running' || kometaState.kometaStatus === 'scheduled_waiting' || kometaState.kometaPendingStart) {
         kometaState.kometaPollingStarted = false
-        startPollingIfNeeded()
-        if (!kometaState.kometaPendingStart) {
+        if (kometaState.kometaStatus === 'scheduled_waiting') {
           fetchRunProgress(true)
-          fetchKometaLog()
+        } else {
+          startPollingIfNeeded()
+          if (!kometaState.kometaPendingStart) {
+            fetchRunProgress(true)
+            fetchKometaLog()
+          }
         }
       }
     })
@@ -751,10 +755,18 @@ function renderLogStats (filteredResult = lastFilteredLogResult) {
   updateStatRow(logStatsFiltered, filteredStats)
 }
 
-function updateTailNotice () {
+function updateTailNotice (data = null) {
   if (!tailNotice) return
   const sizeLabel = tailSize === 'all' ? 'all lines' : `last ${tailSize} lines`
+  if (data && data.log_is_previous_run) {
+    tailNotice.textContent = `Showing previous meta.log (${sizeLabel}). Kometa is not currently writing to this file.`
+    tailNotice.classList.add('text-warning')
+    tailNotice.classList.remove('text-muted')
+    return
+  }
   tailNotice.textContent = `Showing ${sizeLabel} from meta.log`
+  tailNotice.classList.remove('text-warning')
+  tailNotice.classList.add('text-muted')
 }
 
 function syncRunStatusVisibility () {
@@ -783,12 +795,16 @@ function updateLogRecency (data) {
     return
   }
   const ageText = formatRunSeconds(data.log_age_seconds) || 'n/a'
-  let logText = `meta.log updated ${ageText} ago`
+  let logText = data.log_is_previous_run ? `Previous meta.log updated ${ageText} ago` : `meta.log updated ${ageText} ago`
   const totalLines = data?.stats?.total_lines ?? lastLogStatsTotal?.total_lines
   if (typeof totalLines === 'number' && Number.isFinite(totalLines)) {
     logText += ` • ${totalLines.toLocaleString()} lines`
   }
-  if (data.log_is_stale && kometaState.kometaStatus === 'running') {
+  if (data.log_is_previous_run) {
+    logText += ' • Kometa is not running'
+    runStatusLog.classList.add('text-warning')
+    runStatusLog.classList.remove('text-muted')
+  } else if (data.log_is_stale && kometaState.kometaStatus === 'running') {
     logText += ' • waiting for new meta.log entries from this run'
     runStatusLog.classList.add('text-warning')
     runStatusLog.classList.remove('text-muted')
@@ -835,8 +851,7 @@ if (levelButtons && levelButtons.length) {
 
 tailSelect?.addEventListener('change', function() {
   tailSize = this.value || '2000'
-  const label = tailSize === 'all' ? 'entire log' : `last ${tailSize} lines of the log`
-  if (tailNotice) tailNotice.innerHTML = `<i class="bi bi-info-circle"></i> Showing ${label}`
+  updateTailNotice()
   lastRenderedLogRawText = null
   fetchKometaLog()
 })
@@ -1375,6 +1390,7 @@ function fetchKometaLog () {
         lastLogStartLine = 1
         renderFilteredRunLog()
         updateLogRecency(null)
+        updateTailNotice()
         return
       }
       if (data.status === 'queued' || data.status === 'waiting_for_log' || data.pending_start) {
@@ -1382,6 +1398,7 @@ function fetchKometaLog () {
         lastLogStartLine = 1
         renderFilteredRunLog()
         updateLogRecency(null)
+        updateTailNotice()
         return
       }
       const nextLogText = data.log || ''
@@ -1390,6 +1407,7 @@ function fetchKometaLog () {
       lastLogText = nextLogText
       lastLogStartLine = nextLogStartLine
       updateLogRecency(data)
+      updateTailNotice(data)
       if (data.stats) {
         lastLogStatsTotal = data.stats
       }
@@ -1422,19 +1440,23 @@ function checkKometaStatus () {
   return fetch('/kometa-status')
     .then(res => res.json())
     .then(data => {
+      const previousKometaStatus = kometaState.kometaStatus
       kometaState.latestKometaStatusPayload = data || null
       kometaState.kometaStatus = data.status || null
-      kometaState.kometaPendingStart = Boolean(data.pending_start && data.status !== 'running')
+      kometaState.kometaPendingStart = Boolean(data.pending_start && data.status !== 'running' && data.status !== 'scheduled_waiting')
       const updateBtn = updateKometaBtn
       const forceUpdate = forceUpdateToggle
       const runNow = document.getElementById('run-now')
       const stopNow = document.getElementById('stop-now')
       setKometaPrepareRunningState(data.status === 'running')
 
-      // Disable update if Kometa is running or an update is in progress
-      const shouldDisableUpdate = (data.status === 'running') || kometaState.kometaUpdating
+      // Disable update if a Kometa process is active or an update is in progress
+      const kometaProcessActive = data.status === 'running' || data.status === 'scheduled_waiting'
+      const shouldDisableUpdate = kometaProcessActive || kometaState.kometaUpdating
       if (shouldDisableUpdate) {
-        const why = kometaState.kometaUpdating ? 'Kometa is updating; wait for it to finish.' : 'Kometa is running; stop it before updating.'
+        const why = kometaState.kometaUpdating
+          ? 'Kometa is updating; wait for it to finish.'
+          : (data.status === 'scheduled_waiting' ? 'Kometa scheduler is waiting; stop it before updating.' : 'Kometa is running; stop it before updating.')
         if (updateBtn) {
           updateBtn.disabled = true
           updateBtn.setAttribute('title', why)
@@ -1454,7 +1476,7 @@ function checkKometaStatus () {
       if (typeof window.QS_handleMaintenanceStatus === 'function') {
         window.QS_handleMaintenanceStatus(data)
       }
-      if (kometaState.lastRunProgressPayload && data.status === 'running') {
+      if (kometaState.lastRunProgressPayload && (data.status === 'running' || data.status === 'scheduled_waiting')) {
         renderRunProgress(kometaState.lastRunProgressPayload)
       }
 
@@ -1484,6 +1506,37 @@ function checkKometaStatus () {
         stopNow.disabled = true
         syncIncompleteRunActions()
         return // don't do the rest while we're mid-update
+      }
+
+      if (data.status === 'scheduled_waiting') {
+        applyActiveRunCommandState(
+          data.active_command || kometaState.activeRunCommandOverride || getCurrentRunCommand(),
+          data.start_mode || kometaState.activeRunCommandMode || 'current'
+        )
+        kometaState.kometaPendingStart = false
+        revealRunCommandSection()
+        runNow.disabled = true
+        runNow.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Waiting...'
+        stopNow.classList.remove('d-none')
+        stopNow.disabled = false
+        document.getElementById('run-output').classList.remove('d-none')
+        syncIncompleteRunActions()
+        if (previousKometaStatus !== 'scheduled_waiting' || !kometaState.lastRunProgressPayload) {
+          fetchRunProgress(true)
+        }
+        if (!finalLogscanAnalyzeTriggered) {
+          finalLogscanAnalyzeTriggered = true
+          fetchLogscanAnalysis(true, { updateHeaderBadge: updateLogscanHeaderBadge, kometaState })
+        }
+        if (typeof kometaState.kometaInterval !== 'undefined' && kometaState.kometaInterval) {
+          clearInterval(kometaState.kometaInterval)
+          kometaState.kometaInterval = null
+        }
+        stopProgressPolling()
+        kometaState.kometaPollingStarted = false
+        if (kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
+        kometaState.kometaStatusInterval = setInterval(checkKometaStatus, 5000)
+        return
       }
 
       // Handle Kometa process states

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -3926,10 +3926,10 @@ tableNext.addEventListener('click', function () {
 })
 if (tableCollapseEl) {
   tableCollapseEl.addEventListener('shown.bs.collapse', function () {
-    tableToggle.textContent = 'Hide table'
+    tableToggle.textContent = 'Hide runs'
   })
   tableCollapseEl.addEventListener('hidden.bs.collapse', function () {
-    tableToggle.textContent = 'Show table'
+    tableToggle.textContent = 'Show runs'
   })
 }
 configFilter.on('change', function () {

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -50,6 +50,7 @@
 import { formatHeaderStyleLabel, isValidTimesFormat, computeYamlLineCount, isRunCommandValid } from './_util.js'
 import { kometaState } from './_state.js'
 import { syncKometaBranchRollupBadge } from './_kometaBranch.js'
+import { getMaintenanceScheduleConflict } from './_maintenanceWindow.js'
 
 // ---------------------------------------------------------------------
 // Core primitives
@@ -134,6 +135,10 @@ export function updateRunOptionHeaderBadge () {
   const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value || ''
   const libSelect = document.getElementById('library-multiselect')
   const selectedLibs = libSelect ? Array.from(libSelect.selectedOptions || []).map(o => o.value) : []
+  if (getMaintenanceScheduleConflict(mainOption)) {
+    setHeaderRollupBadge('heading-runopt-rollup-badge', 'error', 'Maintenance overlap')
+    return
+  }
   if (mainOption === '--run-libraries') {
     if (!selectedLibs.length) {
       setHeaderRollupBadge('heading-runopt-rollup-badge', 'warn', 'Libraries needed')

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -275,6 +275,7 @@ export function updateConfigOutputHeaderBadges () {
  *   kometaUpdating                    -- 'Updating Kometa' (unknown)
  *   !kometaValidated                  -- 'Validate Kometa' (warn)
  *   kometaStatus === 'running'        -- 'Run in progress' (warn)
+ *   kometaStatus === 'scheduled_waiting' -- 'Scheduler waiting' (warn)
  *   otherwise                         -- isRunCommandValid() ?
  *                                          'Ready' (ok) :
  *                                          'Incomplete' (warn)
@@ -298,6 +299,10 @@ export function updateRunCommandHeaderBadge () {
   }
   if (kometaState.kometaStatus === 'running') {
     setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Run in progress')
+    return
+  }
+  if (kometaState.kometaStatus === 'scheduled_waiting') {
+    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Scheduler waiting')
     return
   }
   const valid = isRunCommandValid()

--- a/static/local-js/modules/kometa/_kometaUpdate.js
+++ b/static/local-js/modules/kometa/_kometaUpdate.js
@@ -13,9 +13,9 @@
 //        job manually). Runs runKometaStatusPass, shows toast based
 //        on result, updates a note element if update is available.
 //
-//   3. Running short-circuit
-//        Kometa is currently running (mid-run). Show a toast and
-//        bail -- we can't update a live install.
+//   3. Running / scheduler safety
+//        Kometa is currently running (mid-run): show a toast and bail.
+//        Kometa scheduler is waiting: ask to stop it, then continue update.
 //
 //   4. Already-installed-no-force branch
 //        Kometa is installed and user didn't tick 'force update'
@@ -192,6 +192,43 @@ function handleAlreadyInstalledNoForceCheck () {
     })
 }
 
+function stopScheduledKometaForUpdate () {
+  const confirmed = typeof window.confirm === 'function'
+    ? window.confirm('Kometa is waiting for a scheduled run. Updating safely requires stopping that scheduler first. Stop the scheduler and continue with the update?')
+    : false
+  if (!confirmed) {
+    showToast('info', 'Kometa update cancelled. The scheduler is still waiting for its next run.')
+    return
+  }
+
+  const btn = getUpdateButton()
+  if (btn) {
+    btn.disabled = true
+    btn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Stopping scheduler...'
+  }
+  showToast('info', 'Stopping Kometa scheduler before updating...')
+
+  fetch('/stop-kometa', { method: 'POST' })
+    .then(async res => {
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || data.error) {
+        throw new Error(data.error || data.warning || `Stop request failed (${res.status}).`)
+      }
+      kometaState.kometaStatus = 'not started'
+      kometaState.kometaPendingStart = false
+      showToast(data.warning ? 'warning' : 'success', data.message || data.warning || 'Kometa scheduler stopped.')
+      callUpdateKometa()
+    })
+    .catch(err => {
+      const message = err && err.message ? err.message : 'Failed to stop Kometa scheduler before update.'
+      showToast('error', message)
+      if (btn) {
+        btn.disabled = false
+        syncUpdateButtonLabel()
+      }
+    })
+}
+
 /**
  * Main entry. See module docstring for the five execution paths.
  */
@@ -211,11 +248,13 @@ export function callUpdateKometa () {
   }
 
   // ---- Path 3: Kometa running or scheduler waiting ---------------
-  if (kometaState.kometaStatus === 'running' || kometaState.kometaStatus === 'scheduled_waiting') {
-    const message = kometaState.kometaStatus === 'scheduled_waiting'
-      ? 'Kometa scheduler is waiting; stop it before updating.'
-      : 'Kometa is currently running; update skipped.'
-    showToast('info', message)
+  if (kometaState.kometaStatus === 'running') {
+    showToast('info', 'Kometa is currently running; update skipped.')
+    return
+  }
+
+  if (kometaState.kometaStatus === 'scheduled_waiting') {
+    stopScheduledKometaForUpdate()
     return
   }
 

--- a/static/local-js/modules/kometa/_kometaUpdate.js
+++ b/static/local-js/modules/kometa/_kometaUpdate.js
@@ -210,9 +210,12 @@ export function callUpdateKometa () {
     return
   }
 
-  // ---- Path 3: Kometa running -----------------------------------
-  if (kometaState.kometaStatus === 'running') {
-    showToast('info', 'Kometa is currently running; update skipped.')
+  // ---- Path 3: Kometa running or scheduler waiting ---------------
+  if (kometaState.kometaStatus === 'running' || kometaState.kometaStatus === 'scheduled_waiting') {
+    const message = kometaState.kometaStatus === 'scheduled_waiting'
+      ? 'Kometa scheduler is waiting; stop it before updating.'
+      : 'Kometa is currently running; update skipped.'
+    showToast('info', message)
     return
   }
 

--- a/static/local-js/modules/kometa/_kometaUpdate.js
+++ b/static/local-js/modules/kometa/_kometaUpdate.js
@@ -192,41 +192,54 @@ function handleAlreadyInstalledNoForceCheck () {
     })
 }
 
+function confirmStopScheduledKometaForUpdate () {
+  const options = {
+    title: 'Kometa scheduler is waiting',
+    message: 'Updating safely requires stopping the waiting scheduler first. Stop the scheduler and continue with the update?',
+    confirmText: 'Stop and Update',
+    cancelText: 'Cancel',
+    confirmClass: 'btn-warning',
+    iconClass: 'bi bi-exclamation-triangle text-warning'
+  }
+  if (typeof window.QS_confirmAction === 'function') return window.QS_confirmAction(options)
+  const fallbackMessage = [options.title, '', options.message].join('\n')
+  return Promise.resolve(typeof window.confirm === 'function' ? window.confirm(fallbackMessage) : false)
+}
+
 function stopScheduledKometaForUpdate () {
-  const confirmed = typeof window.confirm === 'function'
-    ? window.confirm('Kometa is waiting for a scheduled run. Updating safely requires stopping that scheduler first. Stop the scheduler and continue with the update?')
-    : false
-  if (!confirmed) {
-    showToast('info', 'Kometa update cancelled. The scheduler is still waiting for its next run.')
-    return
-  }
+  confirmStopScheduledKometaForUpdate().then((confirmed) => {
+    if (!confirmed) {
+      showToast('info', 'Kometa update cancelled. The scheduler is still waiting for its next run.')
+      return
+    }
 
-  const btn = getUpdateButton()
-  if (btn) {
-    btn.disabled = true
-    btn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Stopping scheduler...'
-  }
-  showToast('info', 'Stopping Kometa scheduler before updating...')
+    const btn = getUpdateButton()
+    if (btn) {
+      btn.disabled = true
+      btn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Stopping scheduler...'
+    }
+    showToast('info', 'Stopping Kometa scheduler before updating...')
 
-  fetch('/stop-kometa', { method: 'POST' })
-    .then(async res => {
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok || data.error) {
-        throw new Error(data.error || data.warning || `Stop request failed (${res.status}).`)
-      }
-      kometaState.kometaStatus = 'not started'
-      kometaState.kometaPendingStart = false
-      showToast(data.warning ? 'warning' : 'success', data.message || data.warning || 'Kometa scheduler stopped.')
-      callUpdateKometa()
-    })
-    .catch(err => {
-      const message = err && err.message ? err.message : 'Failed to stop Kometa scheduler before update.'
-      showToast('error', message)
-      if (btn) {
-        btn.disabled = false
-        syncUpdateButtonLabel()
-      }
-    })
+    fetch('/stop-kometa', { method: 'POST' })
+      .then(async res => {
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok || data.error) {
+          throw new Error(data.error || data.warning || `Stop request failed (${res.status}).`)
+        }
+        kometaState.kometaStatus = 'not started'
+        kometaState.kometaPendingStart = false
+        showToast(data.warning ? 'warning' : 'success', data.message || data.warning || 'Kometa scheduler stopped.')
+        callUpdateKometa()
+      })
+      .catch(err => {
+        const message = err && err.message ? err.message : 'Failed to stop Kometa scheduler before update.'
+        showToast('error', message)
+        if (btn) {
+          btn.disabled = false
+          syncUpdateButtonLabel()
+        }
+      })
+  })
 }
 
 /**

--- a/static/local-js/modules/kometa/_maintenanceWindow.js
+++ b/static/local-js/modules/kometa/_maintenanceWindow.js
@@ -39,17 +39,43 @@ export function toggleTimesInputVisibility (mainOption) {
  * Return the currently-configured Plex maintenance window, as
  * `{ start, end }` HH:MM strings. Reads from the
  * `#plex-maintenance-window` element's `data-window` attribute,
- * which the backend populates with a string like "03:00–05:00"
- * (note the EN-DASH separator, not a hyphen).
+ * which the backend populates with a string like "03:00–05:00".
+ * Plain hyphen payloads are accepted too, because older support
+ * payloads and tests may use "03:00-05:00".
  *
  * Returns null when the element is present but has no configured
  * window, or when the payload is malformed.
  */
 export function getMaintenanceWindow () {
-  const windowStr = document.getElementById('plex-maintenance-window').dataset.window
-  if (!windowStr || !windowStr.includes('–')) return null
-  const [start, end] = windowStr.split('–').map(t => t.trim())
-  return { start, end }
+  const windowStr = document.getElementById('plex-maintenance-window')?.dataset.window || ''
+  const matches = String(windowStr).match(/([01]\d|2[0-3]):[0-5]\d/g)
+  if (!matches || matches.length < 2) return null
+  return { start: matches[0], end: matches[1] }
+}
+
+export function getMaintenanceScheduleConflict (mainOption) {
+  const maintenance = getMaintenanceWindow()
+  if (!maintenance) return null
+
+  if (mainOption === '') {
+    const defaultTime = '05:00'
+    if (isTimeWithinRange(defaultTime, maintenance.start, maintenance.end)) {
+      return { maintenance, times: [defaultTime], source: 'default' }
+    }
+    return null
+  }
+
+  if (mainOption === '--times') {
+    const timesInput = document.getElementById('times-input')?.value.trim() || ''
+    if (!isValidTimesFormat(timesInput)) return null
+    const times = timesInput.split('|').map(t => t.trim())
+    const overlappingTimes = times.filter(t => isTimeWithinRange(t, maintenance.start, maintenance.end))
+    if (overlappingTimes.length) {
+      return { maintenance, times: overlappingTimes, source: 'times' }
+    }
+  }
+
+  return null
 }
 
 /**
@@ -64,28 +90,14 @@ export function getMaintenanceWindow () {
  */
 export function checkMaintenanceWarning (mainOption) {
   const warningBox = document.getElementById('times-warning')
-  const maintenance = getMaintenanceWindow()
+  if (!warningBox) return null
   warningBox.classList.add('d-none')
 
-  if (!maintenance) return
-
-  if (mainOption === '') {
-    // Kometa's implicit default schedule fires at 05:00.
-    const defaultTime = '05:00'
-    if (isTimeWithinRange(defaultTime, maintenance.start, maintenance.end)) {
-      warningBox.classList.remove('d-none')
-    }
-    return
+  const conflict = getMaintenanceScheduleConflict(mainOption)
+  if (conflict) {
+    const label = conflict.source === 'default' ? 'Kometa default time 05:00' : `Selected time${conflict.times.length > 1 ? 's' : ''} ${conflict.times.join(', ')}`
+    warningBox.textContent = `${label} starts during Plex scheduled maintenance (${conflict.maintenance.start} - ${conflict.maintenance.end}). Choose a time after the window.`
+    warningBox.classList.remove('d-none')
   }
-
-  if (mainOption === '--times') {
-    const timesInput = document.getElementById('times-input').value.trim()
-    if (isValidTimesFormat(timesInput)) {
-      const times = timesInput.split('|').map(t => t.trim())
-      const overlaps = times.some(t => isTimeWithinRange(t, maintenance.start, maintenance.end))
-      if (overlaps) {
-        warningBox.classList.remove('d-none')
-      }
-    }
-  }
+  return conflict
 }

--- a/static/local-js/modules/kometa/_runCommand.js
+++ b/static/local-js/modules/kometa/_runCommand.js
@@ -2,7 +2,7 @@
 //
 // The "run command" is the exact CLI Quickstart shows in the UI --
 // the one users can copy-paste to launch Kometa manually, or that
-// Quickstart itself invokes on "Run Now". It's assembled from:
+// Quickstart itself invokes on "Run". It's assembled from:
 //
 //   - the venv python + kometa.py paths (from #run-command-output dataset)
 //   - the currently-selected run option (radio: default, --times,
@@ -212,7 +212,7 @@ const CHECKBOX_FLAGS = [
  *   undefined    -- no run-command-output in the DOM (short-circuit)
  *
  * Side effects at every non-short-circuit exit:
- *   - updateRunNowState() -- refresh the Run Now button
+ *   - updateRunNowState() -- refresh the Run button
  *   - syncFinalAccordionRollups() -- refresh header badges
  *
  * @returns {boolean | undefined}
@@ -302,6 +302,17 @@ export function buildCommand () {
 
   if (mainOption) cli += ` ${mainOption}`
 
+  if (mainOption === '') {
+    const conflict = checkMaintenanceWarning(mainOption)
+    if (conflict) {
+      runCmdOutput.textContent = '⚠️ Kometa default scheduled time 05:00 starts during Plex maintenance. Choose --run to start immediately, or set --times after the maintenance window.'
+      notify()
+      return false
+    }
+  } else if (mainOption !== '--times') {
+    checkMaintenanceWarning(mainOption)
+  }
+
   // ---- --times: validate + append quoted value --------------------
   if (mainOption === '--times') {
     const timesInput = document.getElementById('times-input').value.trim()
@@ -314,7 +325,12 @@ export function buildCommand () {
       return false
     }
     document.getElementById('times-error').classList.add('d-none')
-    checkMaintenanceWarning(mainOption)
+    const conflict = checkMaintenanceWarning(mainOption)
+    if (conflict) {
+      runCmdOutput.textContent = `⚠️ Kometa scheduled time${conflict.times.length > 1 ? 's' : ''} ${conflict.times.join(', ')} start${conflict.times.length > 1 ? '' : 's'} during Plex maintenance. Choose a time after the maintenance window.`
+      notify()
+      return false
+    }
     cli += ` "${timesInput}"`
   } else {
     toggleTimesInputVisibility(mainOption)

--- a/static/local-js/modules/kometa/_runCommandSection.js
+++ b/static/local-js/modules/kometa/_runCommandSection.js
@@ -85,7 +85,7 @@ import { updateRunNowState } from './_runControls.js'
  *
  * Priority order (first match wins):
  *   1. !showYAML             -> "Fix validation before..."
- *   2. running               -> "Kometa is currently running"
+ *   2. running/waiting       -> "Kometa is currently running" or scheduler waiting
  *   3. kometaUpdating        -> "Kometa update in progress"
  *   4. validationInProgress  -> "Preparing Kometa"
  *   5. !localCheckCompleted  -> "Checking Kometa state"
@@ -120,6 +120,10 @@ export function setRunCommandPlaceholderState () {
   } else if (kometaState.kometaStatus === 'running') {
     title = 'Kometa is currently running'
     message = 'Run output and stop controls are active below. Prepare Kometa is locked until the current run finishes.'
+    showButton = false
+  } else if (kometaState.kometaStatus === 'scheduled_waiting') {
+    title = 'Kometa scheduler is waiting'
+    message = 'The scheduled run cycle has finished and the Kometa process is waiting for the next scheduled time. Stop it before changing the run command.'
     showButton = false
   } else if (kometaState.kometaUpdating) {
     title = 'Kometa update in progress'

--- a/static/local-js/modules/kometa/_runCommandSection.js
+++ b/static/local-js/modules/kometa/_runCommandSection.js
@@ -23,7 +23,7 @@
 //
 //   hideRunCommandSectionUntilValidated()
 //     -- collapse the run-command accordion and swap in the
-//        placeholder. Also disables the "Run Now" button and puts it
+//        placeholder. Also disables the "Run" button and puts it
 //        into a "Waiting..." state. Called from many places (probe
 //        errors, install-needed states, update in progress, etc.).
 //
@@ -35,7 +35,7 @@
 //
 //   showRunCommandSectionAfterValidated()
 //     -- convenience wrapper that unhides the section, resets the
-//        "Run Now" button label to its default, rebuilds the run
+//        "Run" button label to its default, rebuilds the run
 //        command string, and refreshes the button's disabled state.
 //
 // STATE TOUCHED:
@@ -63,7 +63,7 @@
 //   #run-command-output-collapse -- the accordion collapsable body
 //   #run-command-output-heading .accordion-button
 //                                -- accordion toggle button
-//   #run-now                     -- the "Run Now" button
+//   #run-now                     -- the "Run" button
 //   #copy-command                -- the copy-to-clipboard button
 //   #run-command-box .form-label -- the label above the command
 //   #run-command-box pre         -- the <pre> that holds the command
@@ -170,7 +170,7 @@ export function clearRunCommandPlaceholderState () {
 
 /**
  * Collapse the run-command accordion and swap in the placeholder.
- * Also disables the "Run Now" button and puts it into a "Waiting..."
+ * Also disables the "Run" button and puts it into a "Waiting..."
  * state (so a distracted user can't click it while validation is
  * pending).
  *
@@ -226,7 +226,7 @@ export function revealRunCommandSection () {
 }
 
 /**
- * Convenience wrapper that unhides the section, resets the "Run Now"
+ * Convenience wrapper that unhides the section, resets the "Run"
  * button label to its default, rebuilds the run command string, and
  * refreshes the button's disabled state.
  *
@@ -238,7 +238,7 @@ export function showRunCommandSectionAfterValidated () {
   revealRunCommandSection()
   const runNowEl = document.getElementById('run-now')
   if (runNowEl) {
-    runNowEl.innerHTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>'
+    runNowEl.innerHTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run</span>'
   }
   try { buildCommand() } catch { /* swallow -- caller may not need a rebuild */ }
   updateRunNowState()

--- a/static/local-js/modules/kometa/_runControls.js
+++ b/static/local-js/modules/kometa/_runControls.js
@@ -106,7 +106,7 @@ export function updateRunNowState () {
     !kometaState.showYAML ||
     kometaState.kometaValidationInProgress ||
     kometaState.kometaUpdating ||
-    kometaState.kometaStatus === 'running' ||
+    (kometaState.kometaStatus === 'running' || kometaState.kometaStatus === 'scheduled_waiting') ||
     !kometaState.kometaValidated
   )
 
@@ -153,7 +153,8 @@ export function syncIncompleteRunActions () {
     !kometaState.kometaValidationInProgress &&
     !kometaState.kometaUpdating &&
     !kometaState.kometaPendingStart &&
-    kometaState.kometaStatus !== 'running'
+    kometaState.kometaStatus !== 'running' &&
+    kometaState.kometaStatus !== 'scheduled_waiting'
 
   runRecovery.classList.toggle('d-none', !alertVisible)
   runRecovery.disabled = !recoveryRunnable
@@ -173,6 +174,8 @@ export function syncIncompleteRunActions () {
     runRecovery.setAttribute('title', 'A Kometa start is already queued for the next Plex maintenance window.')
   } else if (kometaState.kometaStatus === 'running') {
     runRecovery.setAttribute('title', 'Kometa is already running.')
+  } else if (kometaState.kometaStatus === 'scheduled_waiting') {
+    runRecovery.setAttribute('title', 'Kometa scheduler is waiting. Stop it before starting a recovery run.')
   } else {
     // Alert is visible, no blockers, but no recovery command in the
     // panel. Unusual state (server said recovery is possible but the

--- a/static/local-js/modules/kometa/_runControls.js
+++ b/static/local-js/modules/kometa/_runControls.js
@@ -1,10 +1,10 @@
-// Run controls: the "Run Now" button and the "Recovery Command" button.
+// Run controls: the "Run" button and the "Recovery Command" button.
 //
 // This module owns the two functions that decide whether these
 // buttons should be enabled / clickable, based on the current
 // kometaState:
 //
-//   updateRunNowState        -- enables/disables the primary Run Now
+//   updateRunNowState        -- enables/disables the primary Run
 //                               button based on the six-flag state
 //                               machine (validation + install +
 //                               running-status + run-command validity)
@@ -61,11 +61,11 @@ export function getRecoveryRunCommand () {
 }
 
 // ---------------------------------------------------------------------
-// Run Now button
+// Run button
 // ---------------------------------------------------------------------
 
 /**
- * Update the Run Now button's disabled state based on current
+ * Update the Run button's disabled state based on current
  * validation + install + running-status flags.
  *
  * Disable rules (any one triggers disable):

--- a/static/local-js/modules/kometa/_runProgress.js
+++ b/static/local-js/modules/kometa/_runProgress.js
@@ -464,6 +464,10 @@ export function fetchRunProgress (forceFull = false) {
         }
         return
       }
+      if (data.status === 'queued' || data.status === 'waiting_for_log' || data.pending_start) {
+        clearRunProgress(false)
+        return
+      }
       renderRunProgress(data)
     })
     .catch(() => {

--- a/static/local-js/modules/kometa/_runStatusFormat.js
+++ b/static/local-js/modules/kometa/_runStatusFormat.js
@@ -70,6 +70,9 @@ export function formatPercent (value) {
  *     Renders the live snapshot: started-at, elapsed, CPU/mem/disk
  *     for both Kometa and the host system.
  *
+ *   data.status === 'scheduled_waiting'
+ *     Renders scheduler-waiting text after a scheduled run finishes.
+ *
  *   data.status === 'done'
  *     Renders "Kometa run complete." with empty metrics.
  *
@@ -85,10 +88,19 @@ export function formatPercent (value) {
  *   Format the elapsed-seconds count. Typically `formatRunSeconds`
  *   from _util.js. Falsy return value is replaced with 'n/a'.
  * @returns {{ timerText:string, metricsText:string, stage:string }}
- *   stage is 'running' | 'done' | 'idle'.
+ *   stage is 'running' | 'scheduled_waiting' | 'done' | 'idle'.
  */
 export function buildRunStatusText (data, opts) {
   const { formatStartedAt, formatElapsed } = opts
+
+  if (data && data.status === 'scheduled_waiting') {
+    const nextRun = data.scheduled_run_local ? ` Next scheduled run: ${data.scheduled_run_local}.` : ''
+    return {
+      timerText: `Kometa scheduler is waiting.${nextRun}`,
+      metricsText: data.message || '',
+      stage: 'scheduled_waiting'
+    }
+  }
 
   if (data && data.status === 'running') {
     const startedAt = formatStartedAt(data.started_at)

--- a/static/local-js/modules/kometa/_runtime.js
+++ b/static/local-js/modules/kometa/_runtime.js
@@ -122,7 +122,7 @@ export function getConfiguredKometaRootDisplay () {
 
 /**
  * True iff Quickstart can invoke Kometa to run (as opposed to only
- * being able to write config files). Gates the "Run Now" button.
+ * being able to write config files). Gates the "Run" button.
  *
  * @returns {boolean}
  */

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -195,7 +195,11 @@ export function isTimeWithinRange (time, rangeStart, rangeEnd) {
     return h * 60 + m
   }
   const timeMin = toMinutes(time)
-  return timeMin >= toMinutes(rangeStart) && timeMin < toMinutes(rangeEnd)
+  const startMin = toMinutes(rangeStart)
+  const endMin = toMinutes(rangeEnd)
+  if (startMin === endMin) return false
+  if (startMin < endMin) return timeMin >= startMin && timeMin < endMin
+  return timeMin >= startMin || timeMin < endMin
 }
 
 // ---------------------------------------------------------------------

--- a/static/local-js/modules/kometa/_validationGate.js
+++ b/static/local-js/modules/kometa/_validationGate.js
@@ -114,7 +114,7 @@ function rowFor (label, href) {
  * kometaState.showYAML as read-only after this returns.
  *
  * Side effects at the end of every path:
- *   - updateRunNowState() -- refresh the Run Now button state
+ *   - updateRunNowState() -- refresh the Run button state
  *   - syncFinalAccordionRollups() -- refresh every section-header
  *                                    rollup badge
  */
@@ -136,7 +136,7 @@ export function updateValidationGate () {
     toggleGroup(downloadIds, 'd-none', true)
     if (runControls) runControls.classList.add('d-none')
     if (runNowEl) runNowEl.disabled = true
-    if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
+    if (runNowLabelEl) runNowLabelEl.textContent = 'Run'
     updateRunNowState()
     syncFinalAccordionRollups()
     return
@@ -162,7 +162,7 @@ export function updateValidationGate () {
   if (!settValid) validationMessages.push(rowFor('Settings page values have likely been skipped.', '/step/150-settings'))
 
   if (runNowEl) runNowEl.disabled = true
-  if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
+  if (runNowLabelEl) runNowLabelEl.textContent = 'Run'
 
   if (!kometaState.showYAML) {
     // Show validation messages if any, else just hide the panel
@@ -181,7 +181,7 @@ export function updateValidationGate () {
     toggleGroup(yamlIds, 'd-none', false)
     if (runControls) runControls.classList.remove('d-none')
     // NOTE: runNowEl.disabled stays true here -- the actual "enable
-    // Run Now" call happens later in updateRunNowState after checking
+    // Run" call happens later in updateRunNowState after checking
     // the runtime-state (Kometa installed?, not currently running?, etc.)
   }
 

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -196,6 +196,28 @@
 
   <!-- Global Toast Container -->
   <div class="toast-container position-fixed top-0 start-50 translate-middle-x p-3" id="toastContainer"></div>
+
+  <div class="modal fade" id="qs-confirm-modal" tabindex="-1" aria-labelledby="qs-confirm-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title d-flex align-items-center gap-2" id="qs-confirm-title">
+            <i class="bi bi-exclamation-triangle text-warning" id="qs-confirm-icon" aria-hidden="true"></i>
+            <span>Confirm action</span>
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p class="mb-0" id="qs-confirm-message"></p>
+          <p class="text-muted small mt-3 mb-0 d-none" id="qs-confirm-details"></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" id="qs-confirm-cancel" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="qs-confirm-confirm">Continue</button>
+        </div>
+      </div>
+    </div>
+  </div>
   {% if page_info and page_info.save_error %}
   <div id="qs-save-error" data-message="{{ page_info.save_error|e }}"></div>
   {% endif %}

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -1090,7 +1090,7 @@
               </div>
               {% endif %}
               <button id="run-now" class="btn btn-primary mt-3" disabled>
-                <i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>
+                <i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run</span>
               </button>
               {% if incomplete_resume_hint.suggested_command %}
               <button type="button" id="run-recovery-command" class="btn btn-warning mt-3 ms-2"

--- a/templates/modals/900-final.html
+++ b/templates/modals/900-final.html
@@ -15,7 +15,7 @@
         <p>Now that you have your Kometa Configuration File, you should check if any errors have been flagged. If they
           have been, go back to the relevant page and make any necessary adjustments.</p>
 
-        <p>A version of Kometa is being installed/updated to facilitate running Kometa directly from here. Skip down to the <code>Build Your Kometa Run Command</code> and feel free to hit the <code>Run Now</code> button to launch Kometa immediately.</p>
+        <p>A version of Kometa is being installed/updated to facilitate running Kometa directly from here. Skip down to the <code>Build Your Kometa Run Command</code> and feel free to hit the <code>Run</code> button to launch Kometa.</p>
 
         <p>We have added some ASCII headers to categorize the configuration, you can choose your <b>Header Style</b> to
           change how your config looks!</p>

--- a/templates/partials/_movie_overlays.html
+++ b/templates/partials/_movie_overlays.html
@@ -261,7 +261,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
       <div>
         <h6 class="fw-bold mb-1">Custom Fonts</h6>
-        <p class="small text-muted mb-0">Upload .ttf or .otf files. Quickstart stores them in the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder, adopts matching legacy shared fonts automatically, and syncs referenced fonts to Kometa during Validate Kometa and Run Now.</p>
+        <p class="small text-muted mb-0">Upload .ttf or .otf files. Quickstart stores them in the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder, adopts matching legacy shared fonts automatically, and syncs referenced fonts to Kometa during Validate Kometa and Run.</p>
       </div>
       <div class="d-flex flex-wrap gap-2 align-items-center">
         <input type="file" class="form-control form-control-sm" data-font-upload-input accept=".ttf,.otf" multiple>

--- a/templates/partials/_show_overlays.html
+++ b/templates/partials/_show_overlays.html
@@ -265,7 +265,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
       <div>
         <h6 class="fw-bold mb-1">Custom Fonts</h6>
-        <p class="small text-muted mb-0">Upload .ttf or .otf files. Quickstart stores them in the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder, adopts matching legacy shared fonts automatically, and syncs referenced fonts to Kometa during Validate Kometa and Run Now.</p>
+        <p class="small text-muted mb-0">Upload .ttf or .otf files. Quickstart stores them in the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder, adopts matching legacy shared fonts automatically, and syncs referenced fonts to Kometa during Validate Kometa and Run.</p>
       </div>
       <div class="d-flex flex-wrap gap-2 align-items-center">
         <input type="file" class="form-control form-control-sm" data-font-upload-input accept=".ttf,.otf" multiple>

--- a/tests/js/kometa/headerBadges.test.js
+++ b/tests/js/kometa/headerBadges.test.js
@@ -248,6 +248,7 @@ describe('updateRunOptionHeaderBadge', () => {
         <option value="Anime">Anime</option>
       </select>
       <input type="text" id="times-input" value="${timesValue}" />
+      <div id="plex-maintenance-window" data-window=""></div>
     `
     const select = document.getElementById('library-multiselect')
     libraryValues.forEach(v => {
@@ -297,6 +298,15 @@ describe('updateRunOptionHeaderBadge', () => {
     expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
   })
 
+  it('--times inside maintenance: shows "Maintenance overlap" (error)', () => {
+    installRunOptionDom('--times', [], '05:00|17:00')
+    document.getElementById('plex-maintenance-window').dataset.window = '04:00–06:00'
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Maintenance overlap')
+    expect(badge.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
   it('--times with garbage input: shows "Invalid times" (error)', () => {
     installRunOptionDom('--times', [], 'not-a-time')
     updateRunOptionHeaderBadge()
@@ -311,6 +321,15 @@ describe('updateRunOptionHeaderBadge', () => {
     const badge = document.getElementById('heading-runopt-rollup-badge')
     expect(badge.textContent).toBe('Scheduled')
     expect(badge.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('scheduled default inside maintenance: shows "Maintenance overlap" (error)', () => {
+    installRunOptionDom('')
+    document.getElementById('plex-maintenance-window').dataset.window = '04:00–06:00'
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Maintenance overlap')
+    expect(badge.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
   })
 })
 

--- a/tests/js/kometa/kometaUpdate.test.js
+++ b/tests/js/kometa/kometaUpdate.test.js
@@ -287,6 +287,52 @@ describe('callUpdateKometa -- path 3: Kometa running', () => {
 })
 
 // ---------------------------------------------------------------------
+// Path 3b: Kometa scheduler waiting
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- path 3b: Kometa scheduler waiting', () => {
+  it("asks before stopping a waiting scheduler and cancels cleanly", async () => {
+    const originalConfirm = window.confirm
+    window.confirm = vi.fn(() => false)
+    try {
+      kometaState.kometaStatus = 'scheduled_waiting'
+      installFixture()
+      global.fetch = vi.fn()
+      callUpdateKometa()
+      expect(window.confirm).toHaveBeenCalled()
+      expect(global.fetch).not.toHaveBeenCalled()
+      expect(toastCalls.some(c => c[0] === 'info' && c[1].includes('cancelled'))).toBe(true)
+    } finally {
+      window.confirm = originalConfirm
+    }
+  })
+
+  it("stops a waiting scheduler before continuing with update", async () => {
+    const originalConfirm = window.confirm
+    window.confirm = vi.fn(() => true)
+    try {
+      kometaState.kometaStatus = 'scheduled_waiting'
+      kometaState.kometaUpdateAvailable = true
+      installFixture()
+      global.fetch = vi.fn((url) => {
+        if (url === '/stop-kometa') return Promise.resolve(okJson({ success: true, message: 'Kometa stopped and cleaned up.' }))
+        if (url === '/update-kometa') return Promise.resolve(okJson({ success: true }))
+        return Promise.reject(new Error(`unexpected fetch ${url}`))
+      })
+      callUpdateKometa()
+      await flush()
+      await flush()
+      expect(global.fetch).toHaveBeenNthCalledWith(1, '/stop-kometa', { method: 'POST' })
+      expect(global.fetch).toHaveBeenNthCalledWith(2, '/update-kometa', expect.objectContaining({ method: 'POST' }))
+      expect(kometaState.kometaStatus).toBe('not started')
+      expect(kometaState.kometaUpdating).toBe(true)
+    } finally {
+      window.confirm = originalConfirm
+    }
+  })
+})
+
+// ---------------------------------------------------------------------
 // Path 4: Already-installed-no-force
 // ---------------------------------------------------------------------
 

--- a/tests/js/kometa/kometaUpdate.test.js
+++ b/tests/js/kometa/kometaUpdate.test.js
@@ -300,6 +300,7 @@ describe('callUpdateKometa -- path 3b: Kometa scheduler waiting', () => {
       global.fetch = vi.fn()
       callUpdateKometa()
       expect(window.confirm).toHaveBeenCalled()
+      await flush()
       expect(global.fetch).not.toHaveBeenCalled()
       expect(toastCalls.some(c => c[0] === 'info' && c[1].includes('cancelled'))).toBe(true)
     } finally {

--- a/tests/js/kometa/maintenanceWindow.test.js
+++ b/tests/js/kometa/maintenanceWindow.test.js
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   toggleTimesInputVisibility,
   getMaintenanceWindow,
+  getMaintenanceScheduleConflict,
   checkMaintenanceWarning
 } from '../../../static/local-js/modules/kometa/_maintenanceWindow.js'
 
@@ -125,12 +126,9 @@ describe('getMaintenanceWindow', () => {
     expect(getMaintenanceWindow()).toBeNull()
   })
 
-  it('returns null when the payload lacks the en-dash separator', () => {
-    // A hyphen (`-`) is NOT the same as the en-dash (`–`). The backend
-    // deliberately uses the en-dash to make the separator visually
-    // distinct in the maintenance summary UI.
+  it('returns { start, end } when the payload uses a plain hyphen separator', () => {
     installFixtureDom({ maintenanceWindow: '03:00-05:00' })
-    expect(getMaintenanceWindow()).toBeNull()
+    expect(getMaintenanceWindow()).toEqual({ start: '03:00', end: '05:00' })
   })
 
   it('returns null when the payload has garbage', () => {
@@ -140,10 +138,49 @@ describe('getMaintenanceWindow', () => {
 
   it('handles a payload that is just the en-dash (empty start/end)', () => {
     installFixtureDom({ maintenanceWindow: '–' })
-    // Splitting '–' by '–' produces ['', ''] which are trimmed to '' each.
-    // The contract is "the string included a separator", so this is a
-    // known-degenerate but non-null case. Both fields are empty strings.
-    expect(getMaintenanceWindow()).toEqual({ start: '', end: '' })
+    expect(getMaintenanceWindow()).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------
+// getMaintenanceScheduleConflict
+// ---------------------------------------------------------------------
+
+describe('getMaintenanceScheduleConflict', () => {
+  it('reports the implicit 05:00 default when it overlaps maintenance', () => {
+    installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+    expect(getMaintenanceScheduleConflict('')).toEqual({
+      maintenance: { start: '04:00', end: '06:00' },
+      times: ['05:00'],
+      source: 'default'
+    })
+  })
+
+  it('reports only user-supplied --times values that overlap maintenance', () => {
+    installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+    document.getElementById('times-input').value = '05:00|17:00'
+    expect(getMaintenanceScheduleConflict('--times')).toEqual({
+      maintenance: { start: '04:00', end: '06:00' },
+      times: ['05:00'],
+      source: 'times'
+    })
+  })
+
+  it('supports overnight maintenance windows', () => {
+    installFixtureDom({ maintenanceWindow: '22:00–02:00' })
+    document.getElementById('times-input').value = '01:00|12:00|23:00'
+    expect(getMaintenanceScheduleConflict('--times')).toEqual({
+      maintenance: { start: '22:00', end: '02:00' },
+      times: ['01:00', '23:00'],
+      source: 'times'
+    })
+  })
+
+  it('returns null when there is no overlap', () => {
+    installFixtureDom({ maintenanceWindow: '01:00–02:00' })
+    document.getElementById('times-input').value = '05:00|17:00'
+    expect(getMaintenanceScheduleConflict('')).toBeNull()
+    expect(getMaintenanceScheduleConflict('--times')).toBeNull()
   })
 })
 

--- a/tests/js/kometa/runCommand.test.js
+++ b/tests/js/kometa/runCommand.test.js
@@ -78,6 +78,7 @@ function installRunCommandDom (opts = {}) {
     <div id="run-command-active-badge" class="d-none"></div>
 
     <input type="radio" name="run-option" value="" ${runOption === '' ? 'checked' : ''}>
+    <input type="radio" name="run-option" value="--run" ${runOption === '--run' ? 'checked' : ''}>
     <input type="radio" name="run-option" value="--collections-only" ${runOption === '--collections-only' ? 'checked' : ''}>
     <input type="radio" name="run-option" value="--times" ${runOption === '--times' ? 'checked' : ''}>
     <input type="radio" name="run-option" value="--run-libraries" ${runOption === '--run-libraries' ? 'checked' : ''}>
@@ -370,6 +371,28 @@ describe('buildCommand basic path (no flags)', () => {
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out.startsWith('python3 ')).toBe(true)
   })
+
+  it('blocks the implicit 05:00 default when it overlaps Plex maintenance', () => {
+    installRunCommandDom({ runOption: '' })
+    document.getElementById('plex-maintenance-window').dataset.window = '04:00–06:00'
+
+    const result = buildCommand()
+
+    expect(result).toBe(false)
+    expect(document.getElementById('run-command-output').textContent).toContain('default scheduled time 05:00')
+    expect(document.getElementById('times-warning').classList.contains('d-none')).toBe(false)
+  })
+
+  it('allows immediate --run even when the default scheduled time would overlap maintenance', () => {
+    installRunCommandDom({ runOption: '--run' })
+    document.getElementById('plex-maintenance-window').dataset.window = '04:00–06:00'
+
+    const result = buildCommand()
+
+    expect(result).toBe(true)
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--run')
+    expect(document.getElementById('times-warning').classList.contains('d-none')).toBe(true)
+  })
 })
 
 describe('buildCommand mainOption --times', () => {
@@ -401,6 +424,30 @@ describe('buildCommand mainOption --times', () => {
     document.getElementById('times-error').classList.remove('d-none') // stale
     buildCommand()
     expect(document.getElementById('times-error').classList.contains('d-none')).toBe(true)
+  })
+
+  it('blocks scheduled --times values that overlap Plex maintenance', () => {
+    installRunCommandDom({ runOption: '--times' })
+    document.getElementById('plex-maintenance-window').dataset.window = '04:00–06:00'
+    document.getElementById('times-input').value = '05:00|17:00'
+
+    const result = buildCommand()
+
+    expect(result).toBe(false)
+    expect(document.getElementById('run-command-output').textContent).toContain('05:00')
+    expect(document.getElementById('times-warning').classList.contains('d-none')).toBe(false)
+  })
+
+  it('allows scheduled --times values outside Plex maintenance', () => {
+    installRunCommandDom({ runOption: '--times' })
+    document.getElementById('plex-maintenance-window').dataset.window = '04:00–06:00'
+    document.getElementById('times-input').value = '07:00'
+
+    const result = buildCommand()
+
+    expect(result).toBe(true)
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--times "07:00"')
+    expect(document.getElementById('times-warning').classList.contains('d-none')).toBe(true)
   })
 })
 

--- a/tests/js/kometa/runCommandSection.test.js
+++ b/tests/js/kometa/runCommandSection.test.js
@@ -361,11 +361,11 @@ describe('revealRunCommandSection', () => {
 // ---------------------------------------------------------------------
 
 describe('showRunCommandSectionAfterValidated', () => {
-  it("resets the run-now button to the default Run Now state", () => {
+  it("resets the run-now button to the default Run state", () => {
     installFullSectionFixture()
     showRunCommandSectionAfterValidated()
     const btn = document.getElementById('run-now')
-    expect(btn.innerHTML).toContain('Run Now')
+    expect(btn.innerHTML).toContain('Run')
     expect(btn.innerHTML).toContain('bi-play-fill')
   })
 

--- a/tests/js/kometa/runControls.test.js
+++ b/tests/js/kometa/runControls.test.js
@@ -4,7 +4,7 @@
 //
 //   getCurrentRunCommand    -- reads #run-command-output text
 //   getRecoveryRunCommand   -- reads #recovery-command-output text
-//   updateRunNowState       -- big state machine for the Run Now button
+//   updateRunNowState       -- big state machine for the Run button
 //   syncIncompleteRunActions -- recovery button visibility + tooltip
 //
 // COVERAGE STRATEGY:

--- a/tests/js/kometa/runProgress.test.js
+++ b/tests/js/kometa/runProgress.test.js
@@ -585,6 +585,22 @@ describe('fetchRunProgress', () => {
     expect(kometaState.lastRunProgressPayload).toBe(payload)
   })
 
+  it("clears the panel when the server is waiting for a fresh live log", async () => {
+    installFixture()
+    const cached = makePayload({ total_count: 5 })
+    kometaState.lastRunProgressPayload = cached
+    document.getElementById('run-progress').classList.remove('d-none')
+    global.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ status: 'waiting_for_log', libraries: [], total_count: 0 })
+    }))
+
+    await fetchRunProgress()
+
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(true)
+    expect(kometaState.lastRunProgressPayload).toBe(cached)
+  })
+
   it("!ok response: falls to null branch (running+cached -> re-render)", async () => {
     installFixture()
     const cached = makePayload({ total_count: 5 })

--- a/tests/js/kometa/runStatusFormat.test.js
+++ b/tests/js/kometa/runStatusFormat.test.js
@@ -182,6 +182,18 @@ describe('buildRunStatusText', () => {
     expect(result.metricsText).toBe('')
   })
 
+  it('returns stage=scheduled_waiting with next scheduled run text', () => {
+    const result = buildRunStatusText({
+      status: 'scheduled_waiting',
+      scheduled_run_local: '2026-09-12 05:00 AM',
+      message: 'Kometa finished the current scheduled run and is waiting for the next scheduled time.'
+    }, opts)
+    expect(result.stage).toBe('scheduled_waiting')
+    expect(result.timerText).toContain('Kometa scheduler is waiting.')
+    expect(result.timerText).toContain('Next scheduled run: 2026-09-12 05:00 AM.')
+    expect(result.metricsText).toContain('waiting for the next scheduled time')
+  })
+
   it('returns stage=running for status=running', () => {
     const data = { status: 'running', started_at: 'T', elapsed_seconds: 30 }
     expect(buildRunStatusText(data, opts).stage).toBe('running')

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -323,6 +323,14 @@ describe('isTimeWithinRange', () => {
   it('returns false when time is after the range', () => {
     expect(isTimeWithinRange('04:01', '02:00', '04:00')).toBe(false)
   })
+  it('handles overnight ranges that cross midnight', () => {
+    expect(isTimeWithinRange('23:30', '22:00', '02:00')).toBe(true)
+    expect(isTimeWithinRange('01:30', '22:00', '02:00')).toBe(true)
+    expect(isTimeWithinRange('12:00', '22:00', '02:00')).toBe(false)
+  })
+  it('treats equal start/end as an empty range', () => {
+    expect(isTimeWithinRange('05:00', '05:00', '05:00')).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------

--- a/tests/js/kometa/validationGate.test.js
+++ b/tests/js/kometa/validationGate.test.js
@@ -28,7 +28,7 @@
 //                                syncFinalAccordionRollups)
 //             fire exactly once at every exit point
 //     Path H: kometaState.showYAML is correctly toggled per branch
-//     Path I: run-now button label defaults to 'Run Now' in all branches
+//     Path I: run-now button label defaults to 'Run' in all branches
 //
 // updateRunNowState + syncFinalAccordionRollups are mocked via
 // vi.mock() so we can spy on invocation counts without needing to
@@ -207,7 +207,7 @@ describe('updateValidationGate stage=todo', () => {
     expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('download-btn').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('run-now').disabled).toBe(true)
-    expect(document.getElementById('run-now-label').textContent).toBe('Run Now')
+    expect(document.getElementById('run-now-label').textContent).toBe('Run')
   })
 
   it('invokes both callbacks exactly once', () => {
@@ -269,7 +269,7 @@ describe('updateValidationGate stage=config, all flags valid', () => {
     updateValidationGate()
     // The gate itself doesn't enable the button -- that's updateRunNowState's job
     expect(document.getElementById('run-now').disabled).toBe(true)
-    expect(document.getElementById('run-now-label').textContent).toBe('Run Now')
+    expect(document.getElementById('run-now-label').textContent).toBe('Run')
   })
 })
 

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -26,6 +26,13 @@ def _write_log(kometa_root: Path, content: bytes):
     return log_path
 
 
+def _isolate_empty_imagemaid_root(base_dir: Path, monkeypatch, qs_module):
+    imagemaid_root = base_dir / "imagemaid-empty"
+    (imagemaid_root / "config" / "logs").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: imagemaid_root)
+    return imagemaid_root
+
+
 def test_logscan_analyze_missing_log(client, isolated_config_dir):
     resp = client.get("/logscan/analyze")
     assert resp.status_code == 404
@@ -1090,6 +1097,58 @@ def test_prune_logscan_archive_uses_imagemaid_keep_limit(isolated_config_dir, mo
     assert newer.exists()
 
 
+def test_logscan_progress_returns_queued_without_parsing_old_meta_log(client, tmp_path, monkeypatch, qs_module):
+    kometa_root = tmp_path / "kometa"
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "meta.log").write_text(
+        "[2026-04-01 01:13:24,670] [kometa.py:730] [INFO]     |================================== Mapping Old Library ===================================|\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+
+    qs_module._set_pending_kometa_start("python kometa.py --times 07:00", "demo", start_mode="current")
+    try:
+        resp = client.get("/logscan/progress")
+    finally:
+        qs_module._clear_pending_kometa_start()
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "queued"
+    assert payload["pending_start"] is True
+    assert payload["libraries"] == []
+    assert payload["total_count"] == 0
+
+
+def test_logscan_progress_waits_for_fresh_log_when_running_log_is_stale(client, tmp_path, monkeypatch, qs_module):
+    log_dir = tmp_path / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text(
+        "[2026-04-01 01:13:24,670] [kometa.py:730] [INFO]     |================================== Mapping Old Library ===================================|\n",
+        encoding="utf-8",
+    )
+    started_at = time.time()
+    os.utime(log_path, (started_at - 120, started_at - 120))
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module, "_peek_pending_kometa_start", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_active_kometa_started_at_ts", lambda: started_at)
+
+    resp = client.get("/logscan/progress")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "waiting_for_log"
+    assert payload["libraries"] == []
+    assert payload["total_count"] == 0
+
+
 def test_logscan_progress_tracks_libraries(client, isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     log_dir = kometa_root / "config" / "logs"
@@ -1409,6 +1468,7 @@ def test_logscan_reingest_ingests_day_runtime_log(client, isolated_config_dir, m
     )
 
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    _isolate_empty_imagemaid_root(isolated_config_dir, monkeypatch, qs_module)
     monkeypatch.setattr(qs_module.logscan.LogscanAnalyzer, "preload_people_index", lambda self, *_args, **_kwargs: None)
 
     resp = client.post("/logscan/trends/reingest", json={"reset": True})
@@ -1651,6 +1711,7 @@ def test_logscan_reingest_archives_incomplete_rotated_live_log(client, isolated_
     saved = {}
 
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    _isolate_empty_imagemaid_root(isolated_config_dir, monkeypatch, qs_module)
     monkeypatch.setattr(qs_module.logscan.LogscanAnalyzer, "preload_people_index", lambda self, *_args, **_kwargs: None)
     monkeypatch.setattr(
         qs_module.logscan.LogscanAnalyzer,
@@ -1705,6 +1766,7 @@ def test_logscan_reingest_ingests_gzip_archived_log(client, isolated_config_dir,
         )
 
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    _isolate_empty_imagemaid_root(isolated_config_dir, monkeypatch, qs_module)
     monkeypatch.setattr(qs_module.logscan.LogscanAnalyzer, "preload_people_index", lambda self, *_args, **_kwargs: None)
 
     resp = client.post("/logscan/trends/reingest", json={"reset": True})

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1197,7 +1197,7 @@ def test_logscan_progress_marks_finished_scheduled_run_complete(client, isolated
             [
                 "[2026-09-11 15:23:37,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
                 "[2026-09-11 15:23:40,000] [kometa.py:730] [INFO]     |================================== Mapping TV Shows Library ===================================|",
-                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished Run                                            |",
+                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished 15:23 Run                                            |",
                 "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |   Start Time: 15:23:37 2026-09-11     Finished: 15:23:43 2026-09-11     Run Time: 0:00:06   |",
             ]
         ),

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1187,6 +1187,62 @@ def test_logscan_progress_tracks_libraries(client, isolated_config_dir, monkeypa
     assert statuses["TV Shows"] == "In progress"
 
 
+def test_logscan_progress_marks_finished_scheduled_run_complete(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-09-11 15:23:37,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
+                "[2026-09-11 15:23:40,000] [kometa.py:730] [INFO]     |================================== Mapping TV Shows Library ===================================|",
+                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished Run                                            |",
+                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |   Start Time: 15:23:37 2026-09-11     Finished: 15:23:43 2026-09-11     Run Time: 0:00:06   |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    qs_module.LOGSCAN_PROGRESS_CACHE.update({"mtime": None, "size": None, "aux_signature": None, "data": None})
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: True)
+    monkeypatch.setattr(qs_module, "_load_progress_config", lambda *_args, **_kwargs: {})
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return {
+                "libraries": {
+                    "mov-library_movies-library": "Movies",
+                    "sho-library_tv_shows-library": "TV Shows",
+                }
+            }
+        return {}
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    with qs_module.RUN_CONTEXT_LOCK:
+        qs_module.RUN_CONTEXT["started_at"] = datetime.fromisoformat("2026-09-11T15:23:37")
+        qs_module.RUN_CONTEXT["selected_libraries"] = ["Movies", "TV Shows"]
+        qs_module.RUN_CONTEXT["config_path"] = None
+        qs_module.RUN_CONTEXT["run_mode"] = "operations"
+        qs_module.RUN_CONTEXT["stop_requested_at"] = None
+
+    try:
+        resp = client.get("/logscan/progress?size=all")
+    finally:
+        qs_module._clear_run_context()
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["run_finished"] is True
+    assert payload["current_library"] is None
+    assert payload["phase_current"] is None
+    assert payload["completed_count"] == 2
+    statuses = {entry["name"]: entry["status"] for entry in payload["libraries"]}
+    assert statuses == {"Movies": "Done", "TV Shows": "Done"}
+
+
 def test_logscan_progress_cached_running_payload_keeps_live_elapsed(client, isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     log_dir = kometa_root / "config" / "logs"

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 
@@ -53,6 +54,51 @@ def test_tail_log_size_reads_only_requested_tail(client, tmp_path, monkeypatch, 
     assert resp.get_json()["log"].splitlines() == ["line 46", "line 47", "line 48", "line 49", "line 50"]
 
 
+def test_tail_log_returns_queued_without_reading_old_meta_log(client, tmp_path, monkeypatch, qs_module):
+    kometa_root = tmp_path / "kometa"
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "meta.log").write_text("old completed run\n", encoding="utf-8")
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+
+    qs_module._set_pending_kometa_start("python kometa.py --times 07:00", "demo", start_mode="current")
+    try:
+        resp = client.get("/tail-log?size=all")
+    finally:
+        qs_module._clear_pending_kometa_start()
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "queued"
+    assert payload["pending_start"] is True
+    assert payload["log"] == ""
+
+
+def test_tail_log_waits_for_fresh_log_when_running_log_is_stale(client, tmp_path, monkeypatch, qs_module):
+    log_dir = tmp_path / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text("previous run content\n", encoding="utf-8")
+    started_at = time.time()
+    os.utime(log_path, (started_at - 120, started_at - 120))
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module, "_peek_pending_kometa_start", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_active_kometa_started_at_ts", lambda: started_at)
+
+    resp = client.get("/tail-log?size=all")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "waiting_for_log"
+    assert payload["log"] == ""
+    assert payload["log_is_stale"] is True
+
+
 def test_start_kometa_queues_during_maintenance(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
@@ -68,6 +114,9 @@ def test_start_kometa_queues_during_maintenance(client, monkeypatch, qs_module):
     data = resp.get_json()
     assert data["status"] == "queued"
     assert data["maintenance_window"] == "01:00-02:00"
+    assert data["queued_start_local"]
+    assert data["scheduled_run_local"]
+    assert data["uses_default_schedule_time"] is True
     assert qs_module._peek_pending_kometa_start() is not None
 
     qs_module._clear_pending_kometa_start()
@@ -88,11 +137,108 @@ def test_start_kometa_queues_during_maintenance_preserves_start_mode(client, mon
     data = resp.get_json()
     assert data["status"] == "queued"
     assert data["start_mode"] == "recovery"
+    assert data["queued_start_local"]
     pending = qs_module._peek_pending_kometa_start()
     assert pending is not None
     assert pending["start_mode"] == "recovery"
 
     qs_module._clear_pending_kometa_start()
+
+
+def test_kometa_status_keeps_pending_start_queued_without_ingesting(client, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (60, 120, "01:00-02:00"))
+    ingest_calls = []
+    monkeypatch.setattr(qs_module, "_ingest_completed_live_logs", lambda tool: ingest_calls.append(tool))
+
+    with qs_module.RUN_CONTEXT_LOCK:
+        qs_module.RUN_CONTEXT["command"] = "python kometa.py --times 07:00"
+        qs_module.RUN_CONTEXT["start_mode"] = "current"
+
+    qs_module._set_pending_kometa_start("python kometa.py --times 07:00", "demo", start_mode="current")
+    try:
+        resp = client.get("/kometa-status")
+        with qs_module.RUN_CONTEXT_LOCK:
+            command_after_status = qs_module.RUN_CONTEXT["command"]
+    finally:
+        qs_module._clear_pending_kometa_start()
+        qs_module._clear_run_context()
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "queued"
+    assert data["pending_start"] is True
+    assert data["pending_command"] == "python kometa.py --times 07:00"
+    assert data["queued_start_local"]
+    assert data["scheduled_run_local"]
+    assert data["schedule_times"] == ["07:00"]
+    assert ingest_calls == []
+    assert command_after_status == "python kometa.py --times 07:00"
+
+
+def test_start_kometa_blocks_times_inside_maintenance(client, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (240, 360, "04:00-06:00"))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: False)
+
+    resp = client.post("/start-kometa", json={"command": 'python kometa.py --times "05:00|17:00"'})
+
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["status"] == "blocked"
+    assert data["blocked_by"] == "maintenance_schedule"
+    assert data["schedule_conflict"]["times"] == ["05:00"]
+    assert "05:00" in data["error"]
+
+
+def test_start_kometa_blocks_default_schedule_inside_maintenance(client, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (240, 360, "04:00-06:00"))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: False)
+
+    resp = client.post("/start-kometa", json={"command": "python kometa.py --config config.yml"})
+
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["status"] == "blocked"
+    assert data["blocked_by"] == "maintenance_schedule"
+    assert data["schedule_conflict"]["uses_default_schedule_time"] is True
+    assert data["schedule_conflict"]["times"] == ["05:00"]
+    assert "default scheduled time 05:00" in data["error"]
+
+
+def test_start_kometa_queues_run_inside_active_maintenance(client, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_kometa_process", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (60, 120, "01:00-02:00"))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: True)
+
+    resp = client.post("/start-kometa", json={"command": "python kometa.py --run"})
+
+    try:
+        assert resp.status_code == 202
+        data = resp.get_json()
+        assert data["status"] == "queued"
+        assert data["schedule_times"] == []
+        assert data["scheduled_run_local"] is None
+        assert data["queued_start_local"]
+    finally:
+        qs_module._clear_pending_kometa_start()
 
 
 def test_start_kometa_starts_outside_maintenance(client, monkeypatch, qs_module):

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -51,7 +51,9 @@ def test_tail_log_size_reads_only_requested_tail(client, tmp_path, monkeypatch, 
     resp = client.get("/tail-log?size=5")
 
     assert resp.status_code == 200
-    assert resp.get_json()["log"].splitlines() == ["line 46", "line 47", "line 48", "line 49", "line 50"]
+    payload = resp.get_json()
+    assert payload["log"].splitlines() == ["line 46", "line 47", "line 48", "line 49", "line 50"]
+    assert payload["log_is_previous_run"] is True
 
 
 def test_tail_log_returns_queued_without_reading_old_meta_log(client, tmp_path, monkeypatch, qs_module):
@@ -349,6 +351,81 @@ def test_kometa_status_includes_active_command_and_start_mode(client, monkeypatc
     assert data["disk_write_mb"] == 128.2
     assert data["disk_read_rate_mb_s"] == 12.5
     assert data["disk_write_rate_mb_s"] == 3.75
+
+
+def test_kometa_status_reports_scheduled_waiting_after_finished_times_run(client, tmp_path, monkeypatch, qs_module):
+    log_dir = tmp_path / "kometa" / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-09-11 15:23:37,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
+                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished Run                                            |",
+                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |   Start Time: 15:23:37 2026-09-11     Finished: 15:23:43 2026-09-11     Run Time: 0:00:06   |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    started_at_ts = time.time() - 120
+    os.utime(log_path, (time.time(), time.time()))
+
+    monkeypatch.setattr(qs_module, "_peek_pending_kometa_start", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_log_dir", lambda: log_dir)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: 4321)
+    monkeypatch.setattr(qs_module, "_calculate_process_cpu_percent", lambda proc: 0.0)
+    monkeypatch.setattr(qs_module, "_calculate_system_cpu_percent", lambda: 0.0)
+    monkeypatch.setattr(qs_module, "_calculate_process_io_stats", lambda proc, cache_name: {})
+
+    class _FakeMemInfo:
+        rss = 64 * 1024 * 1024
+
+    class _FakeVM:
+        total = 8 * 1024 * 1024 * 1024
+        available = 6 * 1024 * 1024 * 1024
+        percent = 25.0
+
+    class _FakeProc:
+        pid = 4321
+
+        def is_running(self):
+            return True
+
+        def status(self):
+            return qs_module.psutil.STATUS_SLEEPING
+
+        def cmdline(self):
+            return ["python", "kometa.py", "--times", "05:00"]
+
+        def create_time(self):
+            return started_at_ts
+
+        def memory_info(self):
+            return _FakeMemInfo()
+
+        def children(self, recursive=True):
+            return []
+
+    monkeypatch.setattr(qs_module.psutil, "Process", lambda pid: _FakeProc())
+    monkeypatch.setattr(qs_module.psutil, "virtual_memory", lambda: _FakeVM())
+
+    with qs_module.RUN_CONTEXT_LOCK:
+        qs_module.RUN_CONTEXT["command"] = 'python kometa.py --times "05:00" --config config.yml'
+        qs_module.RUN_CONTEXT["start_mode"] = "current"
+
+    try:
+        resp = client.get("/kometa-status")
+    finally:
+        qs_module._clear_run_context()
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "scheduled_waiting"
+    assert data["scheduled_waiting"] is True
+    assert data["active_command"] == 'python kometa.py --times "05:00" --config config.yml'
+    assert data["schedule_times"] == ["05:00"]
+    assert data["scheduled_run_local"]
+    assert "waiting for the next scheduled time" in data["message"]
 
 
 def test_imagemaid_status_clears_stale_run_context_when_not_running(client, monkeypatch, qs_module):

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -360,9 +360,9 @@ def test_kometa_status_reports_scheduled_waiting_after_finished_times_run(client
     log_path.write_text(
         "\n".join(
             [
-                "[2026-09-11 15:23:37,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
-                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished 15:23 Run                                            |",
-                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |   Start Time: 15:23:37 2026-09-11     Finished: 15:23:43 2026-09-11     Run Time: 0:00:06   |",
+                "[2026-09-12 07:42:41,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
+                "[2026-09-12 07:42:47,627] [kometa.py:874] [INFO]     |                                            Finished 07:42 Run                                            |",
+                "[2026-09-12 07:42:47,627] [kometa.py:874] [INFO]     |   Start Time: 07:42:41 2026-09-12     Finished: 07:42:47 2026-09-12     Run Time: 0:00:06   |",
             ]
         ),
         encoding="utf-8",
@@ -410,7 +410,7 @@ def test_kometa_status_reports_scheduled_waiting_after_finished_times_run(client
     monkeypatch.setattr(qs_module.psutil, "virtual_memory", lambda: _FakeVM())
 
     with qs_module.RUN_CONTEXT_LOCK:
-        qs_module.RUN_CONTEXT["command"] = 'python kometa.py --times "05:00" --config config.yml'
+        qs_module.RUN_CONTEXT["command"] = 'python kometa.py --times "07:42|07:44" --config config.yml'
         qs_module.RUN_CONTEXT["start_mode"] = "current"
 
     try:
@@ -422,9 +422,9 @@ def test_kometa_status_reports_scheduled_waiting_after_finished_times_run(client
     data = resp.get_json()
     assert data["status"] == "scheduled_waiting"
     assert data["scheduled_waiting"] is True
-    assert data["active_command"] == 'python kometa.py --times "05:00" --config config.yml'
-    assert data["schedule_times"] == ["05:00"]
-    assert data["scheduled_run_local"]
+    assert data["active_command"] == 'python kometa.py --times "07:42|07:44" --config config.yml'
+    assert data["schedule_times"] == ["07:42", "07:44"]
+    assert data["scheduled_run_local"] == "2026-09-12 07:44 AM"
     assert "waiting for the next scheduled time" in data["message"]
 
 

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -361,7 +361,7 @@ def test_kometa_status_reports_scheduled_waiting_after_finished_times_run(client
         "\n".join(
             [
                 "[2026-09-11 15:23:37,000] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
-                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished Run                                            |",
+                "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |                                            Finished 15:23 Run                                            |",
                 "[2026-09-11 15:23:43,627] [kometa.py:874] [INFO]     |   Start Time: 15:23:37 2026-09-11     Finished: 15:23:43 2026-09-11     Run Time: 0:00:06   |",
             ]
         ),


### PR DESCRIPTION
## Related Issues

<!--
  This section matters -- please fill it in even if the PR is just
  a small cleanup. Because this repo squash-merges, individual commit
  trailers get discarded on merge, and GitHub only auto-closes issues
  when the keyword appears in the PR *body* (i.e. right here).

  Auto-close keywords: Closes #, Fixes #, Resolves #
  Link-only keywords:  Refs #, Related: #

  Delete the placeholder or fill it in. "N/A" is also a fine answer
  for PRs that don't relate to any issue.
-->

Closes #

## What type of PR is this?

<!-- Place an X in any relevant option(s). -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
- Fixed scheduled Kometa runs so the UI reports `scheduled_waiting` before the first fresh `meta.log` is written.
- Kept the Active Work card, run status header, and log panel in sync when Kometa is alive but waiting for the next scheduled time.
- Added backend coverage for the pre-first-run stale-log case, alongside the existing between-runs scheduler state.

**Validation**
- `python -m py_compile quickstart.py tests\test_start_stop.py`
- `python -m pytest tests/test_start_stop.py::test_kometa_status_reports_scheduled_waiting_after_finished_times_run tests/test_start_stop.py::test_kometa_status_reports_scheduled_waiting_before_fresh_log tests/test_start_stop.py::test_tail_log_waits_for_fresh_log_when_running_log_is_stale -q`
- `npx.cmd vitest run tests/js/kometa/runStatusFormat.test.js tests/js/kometa/runControls.test.js tests/js/kometa/runCommandSection.test.js`

## Which Environment Did You Test On?

<!-- Place an X in any/all relevant option(s). -->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Quickstart/pr/1825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791861073&installation_model_id=431096&pr_number=1825&repository=Kometa-Team%2FQuickstart&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FQuickstart%2Fpull%2F1825&signature=791b8b59dec88f3665402a2d149006aeb6a4e275187034e8cbac77244284509e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->